### PR TITLE
Improve documentation and add tests

### DIFF
--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -20,7 +20,7 @@ TOTAL                                            746     884    45.77%     0   0
 
 Within repository sources there are **1,630** lines, with **746** covered, giving **45.77%** line coverage.
 
-Coverage results are recalculated after each test run to monitor progress. The project strives for ever more comprehensive test suites across all modules. Recent additions include unit tests for ``APIClient``.
+Coverage results are recalculated after each test run to monitor progress. The project strives for ever more comprehensive test suites across all modules. Recent additions include unit tests for ``APIClient``. New tests now verify ``URLSessionHTTPClient`` behavior and the ``Supervisor`` process termination logic.
 
 ---
 © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/FountainAiLauncher/Tests/FountainAiLauncherTests/FountainAiLauncherTests.swift
+++ b/FountainAiLauncher/Tests/FountainAiLauncherTests/FountainAiLauncherTests.swift
@@ -9,6 +9,16 @@ final class FountainAiLauncherTests: XCTestCase {
         process.waitUntilExit()
         XCTAssertEqual(process.terminationStatus, 0)
     }
+
+    func testTerminateAllStopsProcesses() throws {
+        let supervisor = Supervisor()
+        let service = Service(name: "Sleep", binaryPath: "/bin/sleep", arguments: ["5"])
+        let process = try supervisor.start(service: service)
+        XCTAssertTrue(process.isRunning)
+        supervisor.terminateAll()
+        process.waitUntilExit()
+        XCTAssertFalse(process.isRunning)
+    }
 }
 
 // © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainCodex/IntegrationRuntime/HTTPRequest.swift
+++ b/Sources/FountainCodex/IntegrationRuntime/HTTPRequest.swift
@@ -2,12 +2,20 @@ import Foundation
 
 public struct NoBody: Codable {}
 
+/// Represents an HTTP request flowing through ``HTTPKernel`` powered servers.
+/// Stores the HTTP method, path, headers and optional body data.
 public struct HTTPRequest: Sendable {
     public let method: String
     public let path: String
     public var headers: [String: String]
     public var body: Data
 
+    /// Creates a new request instance.
+    /// - Parameters:
+    ///   - method: HTTP verb such as `GET` or `POST`.
+    ///   - path: Requested resource path.
+    ///   - headers: HTTP headers to include.
+    ///   - body: Optional payload data.
     public init(method: String, path: String, headers: [String: String] = [:], body: Data = Data()) {
         self.method = method
         self.path = path

--- a/Sources/FountainCodex/IntegrationRuntime/HTTPResponse.swift
+++ b/Sources/FountainCodex/IntegrationRuntime/HTTPResponse.swift
@@ -1,10 +1,17 @@
 import Foundation
 
+/// Standard HTTP response returned by ``HTTPKernel`` handlers.
+/// Provides mutable status, headers and response body.
 public struct HTTPResponse: Sendable {
     public var status: Int
     public var headers: [String: String]
     public var body: Data
 
+    /// Creates a new response value.
+    /// - Parameters:
+    ///   - status: HTTP status code to return.
+    ///   - headers: Headers for the response.
+    ///   - body: Response body bytes.
     public init(status: Int = 200, headers: [String: String] = [:], body: Data = Data()) {
         self.status = status
         self.headers = headers

--- a/Tests/IntegrationRuntimeTests/URLSessionHTTPClientTests.swift
+++ b/Tests/IntegrationRuntimeTests/URLSessionHTTPClientTests.swift
@@ -1,0 +1,42 @@
+import XCTest
+import NIOCore
+import NIOHTTP1
+@testable import FountainCodex
+
+final class URLSessionHTTPClientTests: XCTestCase {
+    private class MockURLProtocol: URLProtocol {
+        static var handler: ((URLRequest) -> (HTTPURLResponse, Data))?
+        override class func canInit(with request: URLRequest) -> Bool { true }
+        override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+        override func startLoading() {
+            guard let handler = MockURLProtocol.handler else { return }
+            let (resp, data) = handler(request)
+            client?.urlProtocol(self, didReceive: resp, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        }
+        override func stopLoading() {}
+    }
+
+    func testExecutePerformsRequest() async throws {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [MockURLProtocol.self]
+        let session = URLSession(configuration: config)
+        MockURLProtocol.handler = { request in
+            XCTAssertEqual(request.httpMethod, "POST")
+            XCTAssertEqual(request.value(forHTTPHeaderField: "X-Test"), "1")
+            let body = String(data: request.httpBody ?? Data(), encoding: .utf8)
+            XCTAssertEqual(body, "hi")
+            let resp = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: ["X-Reply": "ok"])! 
+            return (resp, Data("pong".utf8))
+        }
+        var buffer = ByteBufferAllocator().buffer(capacity: 0)
+        buffer.writeString("hi")
+        let client = URLSessionHTTPClient(session: session)
+        let (data, headers) = try await client.execute(method: .POST, url: "http://localhost", headers: HTTPHeaders([("X-Test", "1")]), body: buffer)
+        XCTAssertEqual(data.getString(at: 0, length: data.readableBytes), "pong")
+        XCTAssertEqual(headers.first(name: "X-Reply"), "ok")
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,7 @@ As modules gain documentation, brief summaries are added here.
 - **ClientGenerator** and **ServerGenerator** – emit Swift client and server code from specs.
 - **GeneratorCLI** – command line interface for the code generators.
 - **CreateRecord** – documented request wrapper for adding DNS records.
+- **HTTPRequest** and **HTTPResponse** – request/response models now fully documented.
 
 Documentation coverage will expand alongside test coverage.
 


### PR DESCRIPTION
## Summary
- document HTTP request/response models
- extend supervisor tests
- add URLSessionHTTPClient tests
- track new modules and tests in documentation and coverage report

## Testing
- `swift test --enable-code-coverage` *(fails: compilation did not finish in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_688cf8faefbc8325b6c907e415b574e0