### PR TITLE
Document helpers and extend tests

### DIFF
--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -21,6 +21,7 @@ TOTAL                                            747     885    45.85%     0   0
 Within repository sources there are **1,634** lines, with **747** covered, giving **45.85%** line coverage.
 
 Coverage results are recalculated after each test run to monitor progress. The project strives for ever more comprehensive test suites across all modules. Recent additions include unit tests for ``APIClient``. New tests now verify ``URLSessionHTTPClient`` behavior and the ``Supervisor`` process termination logic.
+Additional tests now cover ``OpenAPISpec.swiftType`` and the ``camelCased`` string helper, bringing total tests to **26**.
 
 ---
 © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainCodex/ClientGenerator/ClientGenerator.swift
+++ b/Sources/FountainCodex/ClientGenerator/ClientGenerator.swift
@@ -182,14 +182,6 @@ public enum ClientGenerator {
     }
 }
 
-private extension String {
-    var camelCased: String {
-        guard !isEmpty else { return self }
-        let parts = split(separator: "_")
-        guard let first = parts.first else { return self }
-        let rest = parts.dropFirst().map { $0.capitalized }
-        return ([first.lowercased()] + rest).joined()
-    }
-}
+
 
 // © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainCodex/IntegrationRuntime/NIOHTTPServer.swift
+++ b/Sources/FountainCodex/IntegrationRuntime/NIOHTTPServer.swift
@@ -45,6 +45,8 @@ public final class NIOHTTPServer: @unchecked Sendable {
         var head: HTTPRequestHead?
         var body: ByteBuffer?
 
+        /// Creates a new handler bound to the provided ``HTTPKernel``.
+        /// - Parameter kernel: Kernel responsible for routing requests.
         init(kernel: HTTPKernel) {
             self.kernel = kernel
         }

--- a/Sources/FountainCodex/Parser/OpenAPISpec.swift
+++ b/Sources/FountainCodex/Parser/OpenAPISpec.swift
@@ -174,6 +174,8 @@ public struct OpenAPISpec: Codable {
 }
 
 extension OpenAPISpec.Schema.Property {
+    /// Returns the Swift type that best represents the property schema.
+    /// Falls back to `String` when no explicit type information is available.
     public var swiftType: String {
         if let ref {
             return ref.components(separatedBy: "/").last ?? ref
@@ -203,6 +205,9 @@ extension OpenAPISpec.Schema.Property {
 }
 
 extension OpenAPISpec.Schema {
+    /// Provides the Swift type represented by the schema itself.
+    /// When referencing other schemas the last path component of the
+    /// reference is used as the type name.
     public var swiftType: String {
         if let ref {
             return ref.components(separatedBy: "/").last ?? ref

--- a/Sources/FountainCodex/ServerGenerator/ServerGenerator.swift
+++ b/Sources/FountainCodex/ServerGenerator/ServerGenerator.swift
@@ -179,7 +179,10 @@ public enum ServerGenerator {
     }
 }
 
-private extension String {
+extension String {
+    /// Returns the string converted from `snake_case` to `camelCase`.
+    /// Words are split on underscores with the first word lowercased and
+    /// remaining words capitalized before joining them together.
     var camelCased: String {
         guard !isEmpty else { return self }
         let parts = split(separator: "_")

--- a/Tests/ClientGeneratorTests/OpenAPISwiftTypeTests.swift
+++ b/Tests/ClientGeneratorTests/OpenAPISwiftTypeTests.swift
@@ -1,0 +1,23 @@
+import XCTest
+@testable import FountainCodex
+
+final class OpenAPISwiftTypeTests: XCTestCase {
+    /// Verifies the `swiftType` helper produces the correct Swift type name.
+    func testSchemaPropertySwiftType() {
+        let prop = OpenAPISpec.Schema.Property()
+        prop.type = "array"
+        let item = OpenAPISpec.Schema()
+        item.type = "string"
+        prop.items = item
+        XCTAssertEqual(prop.swiftType, "[String]")
+    }
+
+    /// Ensures schema references are converted to the last path component.
+    func testSchemaRefSwiftType() {
+        let schema = OpenAPISpec.Schema()
+        schema.ref = "#/components/schemas/Todo"
+        XCTAssertEqual(schema.swiftType, "Todo")
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Tests/ClientGeneratorTests/StringExtensionTests.swift
+++ b/Tests/ClientGeneratorTests/StringExtensionTests.swift
@@ -1,0 +1,12 @@
+import XCTest
+@testable import FountainCodex
+
+final class StringExtensionTests: XCTestCase {
+    /// Ensures the `camelCased` computed property transforms snake case names.
+    func testCamelCased() {
+        XCTAssertEqual("hello_world".camelCased, "helloWorld")
+        XCTAssertEqual("AlreadyCamel".camelCased, "alreadycamel")
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Tests/IntegrationRuntimeTests/HTTPKernelTests.swift
+++ b/Tests/IntegrationRuntimeTests/HTTPKernelTests.swift
@@ -2,6 +2,7 @@ import XCTest
 @testable import FountainCodex
 
 final class HTTPKernelTests: XCTestCase {
+    /// Ensures the ``HTTPKernel`` routes requests to the correct handler.
     func testKernelRoutesRequest() async throws {
         let kernel = HTTPKernel { req in
             if req.path == "/hello" {

--- a/Tests/IntegrationRuntimeTests/LoggingPluginTests.swift
+++ b/Tests/IntegrationRuntimeTests/LoggingPluginTests.swift
@@ -3,6 +3,7 @@ import XCTest
 @testable import FountainCodex
 
 final class LoggingPluginTests: XCTestCase {
+    /// Verifies requests and responses pass through the ``LoggingPlugin``.
     func testLoggingPluginPassThrough() async throws {
         let plugin = LoggingPlugin()
         let req = HTTPRequest(method: "GET", path: "/")

--- a/Tests/IntegrationRuntimeTests/NIOHTTPServerTests.swift
+++ b/Tests/IntegrationRuntimeTests/NIOHTTPServerTests.swift
@@ -6,6 +6,7 @@ import FoundationNetworking
 @testable import FountainCodex
 
 final class NIOHTTPServerTests: XCTestCase {
+    /// Starts the server and verifies a simple request receives a response.
     func testServerResponds() async throws {
         let kernel = HTTPKernel { _ in HTTPResponse(status: 200, body: Data("hi".utf8)) }
         let server = NIOHTTPServer(kernel: kernel)

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,8 @@ As modules gain documentation, brief summaries are added here.
 - **HTTPRequest** and **HTTPResponse** – request/response models now fully documented.
 - **APIClient** – initializer and URLSession extension now documented for clarity.
 - **URLSessionHTTPClientTests** – updated for Linux compatibility ensuring network client coverage.
+- **OpenAPISpec.swiftType** – documented helper converting schemas to Swift types.
+- **String.camelCased** – extension for transforming snake case identifiers.
 
 Documentation coverage will expand alongside test coverage.
 


### PR DESCRIPTION
## Summary
- improve inline documentation for schema helpers and server internals
- document new utilities in the docs
- test swiftType and camelCased helpers
- add comments to existing tests

## Testing
- `swift test --enable-code-coverage`

------
https://chatgpt.com/codex/tasks/task_e_688d084beeac8325ad598e27d4a84806