### PR TITLE
Improve docs and add gateway test

### DIFF
--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -5,10 +5,10 @@
 Running `swift test --enable-code-coverage` and analysing with `llvm-cov` produced the following totals:
 
 ```
-TOTAL                                          31320   30826    10.70%   13850 12304    12.55%   98260   87760    10.70%
+TOTAL                                          31264   28203     9.79%   13901 12291    11.58%   98355   87885    10.65%
 ```
 
-The repository contains **98,260** executable lines, with **10,500** lines covered (approx. **10.70%** line coverage).
+The repository contains **98,355** executable lines, with **10,470** lines covered (approx. **10.65%** line coverage).
 
 ### Repository source coverage
 
@@ -21,7 +21,7 @@ TOTAL                                            747     885    45.85%     0   0
 Within repository sources there are **1,634** lines, with **747** covered, giving **45.85%** line coverage.
 
 Coverage results are recalculated after each test run to monitor progress. The project strives for ever more comprehensive test suites across all modules. Recent additions include unit tests for ``APIClient``. New tests now verify ``URLSessionHTTPClient`` behavior and the ``Supervisor`` process termination logic.
-Additional tests now cover ``OpenAPISpec.swiftType`` and the ``camelCased`` string helper, bringing total tests to **26**.
+Additional tests now cover ``OpenAPISpec.swiftType`` and the ``camelCased`` string helper. A new ``GatewayServerTests`` suite raises total tests to **27**.
 
 ---
 © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainCodex/agent.swift
+++ b/Sources/FountainCodex/agent.swift
@@ -2,6 +2,8 @@ import Foundation
 
 /// Codex orchestration entry point describing how to build and test the project.
 struct Agent {
+    /// Entry point executed by the ``clientgen-service`` tool.
+    /// Prints usage instructions for running the generators and tests.
     static func main() throws {
         print("""
         Codex Orchestration Steps:

--- a/Tests/IntegrationRuntimeTests/GatewayServerTests.swift
+++ b/Tests/IntegrationRuntimeTests/GatewayServerTests.swift
@@ -1,0 +1,25 @@
+import XCTest
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+@testable import gateway_server
+
+final class GatewayServerTests: XCTestCase {
+
+    @MainActor
+    func testHealthEndpointResponds() async throws {
+        let manager = CertificateManager(scriptPath: "/usr/bin/true", interval: 3600)
+        let server = GatewayServer(manager: manager, plugins: [])
+        Task { try await server.start(port: 9100) }
+        try await Task.sleep(nanoseconds: 100_000_000)
+        let url = URL(string: "http://127.0.0.1:9100/health")!
+        let (data, response) = try await URLSession.shared.data(from: url)
+        XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 200)
+        let body = try JSONSerialization.jsonObject(with: data) as? [String: String]
+        XCTAssertEqual(body?["status"], "ok")
+        try await server.stop()
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,6 +23,8 @@ As modules gain documentation, brief summaries are added here.
 - **URLSessionHTTPClientTests** – updated for Linux compatibility ensuring network client coverage.
 - **OpenAPISpec.swiftType** – documented helper converting schemas to Swift types.
 - **String.camelCased** – extension for transforming snake case identifiers.
+- **Agent.main** – entry point usage instructions are now documented.
+- **GatewayServerTests** – verifies the gateway's health endpoint.
 
 Documentation coverage will expand alongside test coverage.
 


### PR DESCRIPTION
## Summary
- add documentation for `Agent.main`
- test `GatewayServer` health endpoint
- record new documentation highlights
- update coverage numbers

## Testing
- `swift test -c release --enable-code-coverage`

------
https://chatgpt.com/codex/tasks/task_e_688d1017d8cc832594ff4f77d6b18eb5