### PR TITLE
Improve docs and add certificate manager tests

### DIFF
--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -22,6 +22,7 @@ Within repository sources there are **1,634** lines, with **747** covered, givin
 
 Coverage results are recalculated after each test run to monitor progress. The project strives for ever more comprehensive test suites across all modules. Recent additions include unit tests for ``APIClient``. New tests now verify ``URLSessionHTTPClient`` behavior and the ``Supervisor`` process termination logic.
 Additional tests now cover ``OpenAPISpec.swiftType`` and the ``camelCased`` string helper. A new ``GatewayServerTests`` suite raises total tests to **27**.
+The new ``CertificateManagerTests`` ensure renewal scripts run correctly.
 
 ---
 © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/GatewayApp/CertificateManager.swift
+++ b/Sources/GatewayApp/CertificateManager.swift
@@ -2,8 +2,11 @@ import Foundation
 
 /// Manages periodic execution of a certificate renewal script.
 public final class CertificateManager {
+    /// Dispatch timer scheduling periodic renewals.
     private var timer: DispatchSourceTimer?
+    /// Absolute path to the renewal script executed.
     private let scriptPath: String
+    /// Delay between script executions.
     private let interval: TimeInterval
 
     /// Creates a new manager with optional script path and repeat interval.

--- a/Sources/clientgen-service/main.swift
+++ b/Sources/clientgen-service/main.swift
@@ -1,5 +1,8 @@
 import FountainCodex
 
+/// Command line wrapper executing ``GeneratorCLI``.
+/// Invoke this tool to generate API clients and servers.
+
 try GeneratorCLI.main()
 
 // © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/publishing-frontend/main.swift
+++ b/Sources/publishing-frontend/main.swift
@@ -2,6 +2,9 @@ import Foundation
 import Dispatch
 import PublishingFrontend
 
+/// CLI entry point launching ``PublishingFrontend``.
+/// Loads configuration and starts the server on the main run loop.
+
 let config = try loadPublishingConfig()
 let app = PublishingFrontend(config: config)
 Task { @MainActor in

--- a/Tests/IntegrationRuntimeTests/CertificateManagerTests.swift
+++ b/Tests/IntegrationRuntimeTests/CertificateManagerTests.swift
@@ -1,0 +1,23 @@
+import XCTest
+@testable import gateway_server
+
+final class CertificateManagerTests: XCTestCase {
+    func testTriggerNowRunsScript() throws {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent("cert_test")
+        try? FileManager.default.removeItem(at: dir)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let logURL = dir.appendingPathComponent("log.txt")
+        let scriptURL = dir.appendingPathComponent("renew.sh")
+        let script = "#!/bin/sh\necho ran >> \(logURL.path)\n"
+        try script.write(to: scriptURL, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: scriptURL.path)
+        let manager = CertificateManager(scriptPath: scriptURL.path, interval: 60)
+        manager.triggerNow()
+        // Wait briefly for the process to complete
+        sleep(1)
+        let exists = FileManager.default.fileExists(atPath: logURL.path)
+        XCTAssertTrue(exists)
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,8 @@ As modules gain documentation, brief summaries are added here.
 - **OpenAPISpec.swiftType** – documented helper converting schemas to Swift types.
 - **String.camelCased** – extension for transforming snake case identifiers.
 - **Agent.main** – entry point usage instructions are now documented.
+- **publishing-frontend CLI** – documented main entrypoint starting the static server.
+- **clientgen-service CLI** – wrapper around GeneratorCLI is now documented.
 - **GatewayServerTests** – verifies the gateway's health endpoint.
 
 Documentation coverage will expand alongside test coverage.


### PR DESCRIPTION
## Summary
- document CLI entrypoints and certificate manager
- add CertificateManagerTests to ensure renewal script runs
- extend developer docs with new bullet points
- note additional test suite in coverage report

## Testing
- `swift build -c release -Xswiftc -O -Xswiftc -warnings-as-errors`
- `swift test -c release --enable-code-coverage` *(fails: environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_688d15d8b08483258095d8e3d886f198