### PR TITLE
Document PublishingConfig defaults

### DIFF
--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -5,20 +5,20 @@
 Running `swift test --enable-code-coverage` and analysing with `llvm-cov` produced the following totals:
 
 ```
-TOTAL                                          31308   27961    10.69%   13935 12101    13.16%   98480   87483    11.17%
+TOTAL                                          31309   28166    10.04%   13938 12280    11.90%   98464   87817    10.81%
 ```
 
-The repository contains **81,265** executable lines, with **8,690** lines covered (approx. **10.7%** line coverage).
+The repository contains **98,464** executable lines, with **10,647** lines covered (approx. **10.8%** line coverage).
 
 ### Repository source coverage
 
 Ignoring third-party packages under `.build/checkouts`, the totals are:
 
 ```
-TOTAL                                            811     355    56.23%     322    89    72.36%    1840     671    63.53%
+TOTAL                                            931     411    55.85%     406   119    70.69%    2117     808    61.83%
 ```
 
-Within repository sources there are **1,840** lines, with **1,169** covered, giving **63.53%** line coverage.
+Within repository sources there are **2,117** lines, with **1,309** covered, giving **61.83%** line coverage.
 
 Coverage results are recalculated after each test run to monitor progress. The project strives for ever more comprehensive test suites across all modules. Recent additions include unit tests for ``APIClient``. New tests now verify ``URLSessionHTTPClient`` behavior and the ``Supervisor`` process termination logic.
 Additional tests now cover ``OpenAPISpec.swiftType`` and the ``camelCased`` string helper. A new ``GatewayServerTests`` suite raises total tests to **27**.
@@ -27,6 +27,7 @@ New ``SpecValidatorTests`` and ``ListRecordsRequestTests`` bring the total test 
 New ``DeleteZoneRequestTests`` ensures zone deletion paths are correct, bringing the total to **32** tests.
 The added metrics check raises the suite to **33** tests.
 The new ``GetRecordRequestTests`` brings the total test count to **34**.
+The added ``PublishingConfigDefaultValues`` test raises the suite to **35** tests.
 
 ---
 © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/PublishingFrontend/PublishingFrontend.swift
+++ b/Sources/PublishingFrontend/PublishingFrontend.swift
@@ -6,7 +6,9 @@ import Yams
 
 /// Configuration for the ``PublishingFrontend`` server.
 public struct PublishingConfig: Codable {
+    /// TCP port the server listens on.
     public var port: Int
+    /// Directory containing static files served by the frontend.
     public var rootPath: String
 
     /// Creates a new configuration with optional port and root path.

--- a/Tests/PublishingFrontendTests/PublishingFrontendTests.swift
+++ b/Tests/PublishingFrontendTests/PublishingFrontendTests.swift
@@ -38,6 +38,12 @@ final class PublishingFrontendTests: XCTestCase {
         XCTAssertEqual(config.port, 1234)
         XCTAssertEqual(config.rootPath, "/tmp/Public")
     }
+
+    func testPublishingConfigDefaultValues() throws {
+        let config = PublishingConfig()
+        XCTAssertEqual(config.port, 8085)
+        XCTAssertEqual(config.rootPath, "./Public")
+    }
 }
 
 // © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,6 +33,7 @@ As modules gain documentation, brief summaries are added here.
 - **listRecords** and **listPrimaryServers** – request types now include documentation.
 - **bulkUpdateRecords**, **deleteZone**, **updateZone**, **exportZoneFile** – additional DNS client requests documented.
 - **getRecord** and **updateRecord** – request types now include usage documentation.
+- **PublishingConfig.port** and **rootPath** – documented properties clarifying server binding and static directory.
 
 Documentation coverage will expand alongside test coverage.
 


### PR DESCRIPTION
## Summary
- document PublishingConfig port and rootPath properties
- test default PublishingConfig values
- update coverage metrics after new tests

## Testing
- `swift build -c release -Xswiftc -O -Xswiftc -warnings-as-errors`
- `swift test -c release --enable-code-coverage`


------
https://chatgpt.com/codex/tasks/task_e_688d8159aae08325918fc90a8b799b55