### PR TITLE
Document Todo model and test encoding

### DIFF
--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -5,20 +5,20 @@
 Running `swift test --enable-code-coverage` and analysing with `llvm-cov` produced the following totals:
 
 ```
-TOTAL                                          31309   28166    10.04%   13938 12280    11.90%   98464   87817    10.81%
+TOTAL                                          31315   28166    10.06%   13942 12280    11.92%   98473   87817    10.82%
 ```
 
-The repository contains **98,464** executable lines, with **10,647** lines covered (approx. **10.8%** line coverage).
+The repository contains **98,473** executable lines, with **10,656** lines covered (approx. **10.82%** line coverage).
 
 ### Repository source coverage
 
 Ignoring third-party packages under `.build/checkouts`, the totals are:
 
 ```
-TOTAL                                            931     411    55.85%     406   119    70.69%    2117     808    61.83%
+TOTAL                                            937     411    56.14%     410   119    70.98%    2126     808    61.99%
 ```
 
-Within repository sources there are **2,117** lines, with **1,309** covered, giving **61.83%** line coverage.
+Within repository sources there are **2,126** lines, with **1,318** covered, giving **61.99%** line coverage.
 
 Coverage results are recalculated after each test run to monitor progress. The project strives for ever more comprehensive test suites across all modules. Recent additions include unit tests for ``APIClient``. New tests now verify ``URLSessionHTTPClient`` behavior and the ``Supervisor`` process termination logic.
 Additional tests now cover ``OpenAPISpec.swiftType`` and the ``camelCased`` string helper. A new ``GatewayServerTests`` suite raises total tests to **27**.
@@ -28,6 +28,7 @@ New ``DeleteZoneRequestTests`` ensures zone deletion paths are correct, bringing
 The added metrics check raises the suite to **33** tests.
 The new ``GetRecordRequestTests`` brings the total test count to **34**.
 The added ``PublishingConfigDefaultValues`` test raises the suite to **35** tests.
+The new ``TodoEncodingRoundTrip`` test brings the total test count to **36**.
 
 ---
 © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainCore/Models.swift
+++ b/Sources/FountainCore/Models.swift
@@ -1,8 +1,11 @@
 // Models for Sample API
 
 /// Simple task model used in unit tests.
-public struct Todo: Codable {
+/// Represents an item with identifier and title.
+public struct Todo: Codable, Equatable {
+    /// Unique identifier for the task.
     public let id: Int
+    /// Human-readable title for the task.
     public let name: String
 }
 

--- a/Tests/FountainCoreTests/FountainCoreTests.swift
+++ b/Tests/FountainCoreTests/FountainCoreTests.swift
@@ -8,6 +8,13 @@ final class FountainCoreTests: XCTestCase {
         XCTAssertEqual(todo.id, 1)
         XCTAssertEqual(todo.name, "Task")
     }
+
+    func testTodoEncodingRoundTrip() throws {
+        let original = Todo(id: 42, name: "Answer")
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(Todo.self, from: data)
+        XCTAssertEqual(decoded, original)
+    }
 }
 
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,6 +34,7 @@ As modules gain documentation, brief summaries are added here.
 - **bulkUpdateRecords**, **deleteZone**, **updateZone**, **exportZoneFile** – additional DNS client requests documented.
 - **getRecord** and **updateRecord** – request types now include usage documentation.
 - **PublishingConfig.port** and **rootPath** – documented properties clarifying server binding and static directory.
+- **Todo.id** and **Todo.name** – documented properties clarifying task identifiers and titles.
 
 Documentation coverage will expand alongside test coverage.
 


### PR DESCRIPTION
## Summary
- document `Todo` model properties
- add encoding round-trip test for `Todo`
- track documentation and coverage progress

## Testing
- `swift build -c release -Xswiftc -O -Xswiftc -warnings-as-errors`
- `swift test -c release --enable-code-coverage`


------
https://chatgpt.com/codex/tasks/task_e_688d85dad1908325b37e96259bb93650