### PR TITLE
Document OpenAPI security components and expand tests

### DIFF
--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -5,20 +5,20 @@
 Running `swift test --enable-code-coverage` and analysing with `llvm-cov` produced the following totals:
 
 ```
-TOTAL                                          31315   28166    10.06%   13942 12280    11.92%   98473   87817    10.82%
+TOTAL                                          31329   28161    10.11%   13953 12278    12.00%   98499   87809    10.85%
 ```
 
-The repository contains **98,473** executable lines, with **10,656** lines covered (approx. **10.82%** line coverage).
+The repository contains **98,499** executable lines, with **10,690** lines covered (approx. **10.85%** line coverage).
 
 ### Repository source coverage
 
 Ignoring third-party packages under `.build/checkouts`, the totals are:
 
 ```
-TOTAL                                            937     411    56.14%     410   119    70.98%    2126     808    61.99%
+TOTAL                                            951     406    57.31%     421   117    72.21%    2152     800    62.83%
 ```
 
-Within repository sources there are **2,126** lines, with **1,318** covered, giving **61.99%** line coverage.
+Within repository sources there are **2,152** lines, with **1,352** covered, giving **62.83%** line coverage.
 
 Coverage results are recalculated after each test run to monitor progress. The project strives for ever more comprehensive test suites across all modules. Recent additions include unit tests for ``APIClient``. New tests now verify ``URLSessionHTTPClient`` behavior and the ``Supervisor`` process termination logic.
 Additional tests now cover ``OpenAPISpec.swiftType`` and the ``camelCased`` string helper. A new ``GatewayServerTests`` suite raises total tests to **27**.
@@ -29,6 +29,7 @@ The added metrics check raises the suite to **33** tests.
 The new ``GetRecordRequestTests`` brings the total test count to **34**.
 The added ``PublishingConfigDefaultValues`` test raises the suite to **35** tests.
 The new ``TodoEncodingRoundTrip`` test brings the total test count to **36**.
+The new ``SecurityRequirementTests`` bring the total test count to **38**.
 
 ---
 © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainCodex/Parser/OpenAPISpec.swift
+++ b/Sources/FountainCodex/Parser/OpenAPISpec.swift
@@ -1,23 +1,32 @@
 import Foundation
 
+/// Root OpenAPI description loaded from specification files.
 public struct OpenAPISpec: Codable {
-    /// Components container storing reusable objects.
+    /// Reusable schema and security definitions.
     public struct Components: Codable {
+        /// Map of schema names to definitions.
         public var schemas: [String: Schema]
+        /// Optional authentication schemes keyed by name.
         public var securitySchemes: [String: SecurityScheme]?
     }
 
-    /// Top-level server description.
+    /// Describes a server hosting the API.
     public struct Server: Codable {
+        /// Base URL of the server.
         public var url: String
+        /// Optional human readable description.
         public var description: String?
     }
 
-    /// Supported authentication scheme.
+    /// Authentication mechanism supported by the API.
     public struct SecurityScheme: Codable {
+        /// Type of the scheme such as `http` or `apiKey`.
         public var type: String
+        /// HTTP authentication scheme (e.g. `bearer`).
         public var scheme: String?
+        /// Name of the header or query parameter carrying credentials.
         public var name: String?
+        /// Location where the credential is transmitted.
         public var location: String?
 
         enum CodingKeys: String, CodingKey {
@@ -26,15 +35,23 @@ public struct OpenAPISpec: Codable {
         }
     }
 
-    /// Security requirements applied to an operation.
+    /// Lists required security schemes for an operation.
     public struct SecurityRequirement: Codable {
+        /// Mapping of scheme names to required scopes.
         public var schemes: [String: [String]]
 
+        /// Creates a requirement with the given scheme map.
+        public init(schemes: [String: [String]]) {
+            self.schemes = schemes
+        }
+
+        /// Creates a requirement by decoding a simple dictionary.
         public init(from decoder: Decoder) throws {
             let container = try decoder.singleValueContainer()
             schemes = try container.decode([String: [String]].self)
         }
 
+        /// Encodes the requirement as a dictionary.
         public func encode(to encoder: Encoder) throws {
             var container = encoder.singleValueContainer()
             try container.encode(schemes)

--- a/Tests/ClientGeneratorTests/SecurityRequirementTests.swift
+++ b/Tests/ClientGeneratorTests/SecurityRequirementTests.swift
@@ -1,0 +1,25 @@
+import XCTest
+@testable import FountainCodex
+
+/// Tests encoding and decoding of ``OpenAPISpec.SecurityRequirement``.
+final class SecurityRequirementTests: XCTestCase {
+    /// Decoding a security requirement from JSON yields the expected mapping.
+    func testDecodesSchemesFromJSON() throws {
+        let json = """
+        {"api_key":[],"oauth":["read","write"]}
+        """.data(using: .utf8)!
+        let requirement = try JSONDecoder().decode(OpenAPISpec.SecurityRequirement.self, from: json)
+        XCTAssertEqual(requirement.schemes["api_key"], [])
+        XCTAssertEqual(requirement.schemes["oauth"], ["read", "write"])
+    }
+
+    /// Encoding a requirement produces the correct JSON structure.
+    func testEncodesSchemesToJSON() throws {
+        let requirement = OpenAPISpec.SecurityRequirement(schemes: ["oauth": ["read"]])
+        let data = try JSONEncoder().encode(requirement)
+        let object = try JSONSerialization.jsonObject(with: data) as? [String: [String]]
+        XCTAssertEqual(object?["oauth"], ["read"])
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,6 +35,7 @@ As modules gain documentation, brief summaries are added here.
 - **getRecord** and **updateRecord** – request types now include usage documentation.
 - **PublishingConfig.port** and **rootPath** – documented properties clarifying server binding and static directory.
 - **Todo.id** and **Todo.name** – documented properties clarifying task identifiers and titles.
+- **OpenAPISpec** – root model now documents components, servers, security schemes, and requirements.
 
 Documentation coverage will expand alongside test coverage.
 


### PR DESCRIPTION
## Summary
- document OpenAPISpec root, components, server, security scheme, and security requirement
- exercise SecurityRequirement encoding and decoding in new unit tests
- track improved coverage and doc progress in README and COVERAGE reports

## Testing
- `swift build -c release -Xswiftc -O -Xswiftc -warnings-as-errors`
- `swift test -c release --enable-code-coverage`

------
https://chatgpt.com/codex/tasks/task_e_688da34aaa808325af3a61227f372542