### PR TITLE
Document NoBody and test HTTPResponse defaults

### DIFF
--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -5,20 +5,20 @@
 Running `swift test --enable-code-coverage` and analysing with `llvm-cov` produced the following totals:
 
 ```
-TOTAL                                          31329   28161    10.11%   13953 12278    12.00%   98499   87809    10.85%
+TOTAL                                          31341   28161    10.15%   13963 12278    12.07%   98519   87809    10.87%
 ```
 
-The repository contains **98,499** executable lines, with **10,690** lines covered (approx. **10.85%** line coverage).
+The repository contains **98,519** executable lines, with **10,710** lines covered (approx. **10.87%** line coverage).
 
 ### Repository source coverage
 
 Ignoring third-party packages under `.build/checkouts`, the totals are:
 
 ```
-TOTAL                                            951     406    57.31%     421   117    72.21%    2152     800    62.83%
+TOTAL                                            963     406    57.84%     431   117    72.85%    2172     800    63.17%
 ```
 
-Within repository sources there are **2,152** lines, with **1,352** covered, giving **62.83%** line coverage.
+Within repository sources there are **2,172** lines, with **1,372** covered, giving **63.17%** line coverage.
 
 Coverage results are recalculated after each test run to monitor progress. The project strives for ever more comprehensive test suites across all modules. Recent additions include unit tests for ``APIClient``. New tests now verify ``URLSessionHTTPClient`` behavior and the ``Supervisor`` process termination logic.
 Additional tests now cover ``OpenAPISpec.swiftType`` and the ``camelCased`` string helper. A new ``GatewayServerTests`` suite raises total tests to **27**.
@@ -30,6 +30,7 @@ The new ``GetRecordRequestTests`` brings the total test count to **34**.
 The added ``PublishingConfigDefaultValues`` test raises the suite to **35** tests.
 The new ``TodoEncodingRoundTrip`` test brings the total test count to **36**.
 The new ``SecurityRequirementTests`` bring the total test count to **38**.
+The new ``HTTPResponseDefaultsTests`` increase the total test count to **40**.
 
 ---
 © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainCodex/IntegrationRuntime/HTTPRequest.swift
+++ b/Sources/FountainCodex/IntegrationRuntime/HTTPRequest.swift
@@ -1,5 +1,6 @@
 import Foundation
 
+/// Placeholder type representing an empty request body.
 public struct NoBody: Codable {}
 
 /// Represents an HTTP request flowing through ``HTTPKernel`` powered servers.

--- a/Tests/IntegrationRuntimeTests/HTTPResponseDefaultsTests.swift
+++ b/Tests/IntegrationRuntimeTests/HTTPResponseDefaultsTests.swift
@@ -1,0 +1,21 @@
+import XCTest
+@testable import FountainCodex
+
+final class HTTPResponseDefaultsTests: XCTestCase {
+    /// Verifies default initializer values for ``HTTPResponse``.
+    func testResponseDefaults() {
+        let response = HTTPResponse()
+        XCTAssertEqual(response.status, 200)
+        XCTAssertTrue(response.headers.isEmpty)
+        XCTAssertEqual(response.body.count, 0)
+    }
+
+    /// Confirms ``NoBody`` encodes and decodes without data loss.
+    func testNoBodyCodable() throws {
+        let data = try JSONEncoder().encode(NoBody())
+        let decoded = try JSONDecoder().decode(NoBody.self, from: data)
+        XCTAssertNotNil(decoded)
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,7 @@ As modules gain documentation, brief summaries are added here.
 - **GeneratorCLI** – command line interface for the code generators.
 - **CreateRecord** – documented request wrapper for adding DNS records.
 - **HTTPRequest** and **HTTPResponse** – request/response models now fully documented.
+- **NoBody** – placeholder type for empty request bodies is now documented.
 - **APIClient** – initializer and URLSession extension now documented for clarity.
 - **URLSessionHTTPClientTests** – updated for Linux compatibility ensuring network client coverage.
 - **OpenAPISpec.swiftType** – documented helper converting schemas to Swift types.

--- a/logs/build-20250802073101.log
+++ b/logs/build-20250802073101.log
@@ -1,0 +1,2174 @@
+Fetching https://github.com/apple/swift-nio.git
+Fetching https://github.com/swift-server/async-http-client.git
+Fetching https://github.com/jpsim/Yams.git
+[1/10997] Fetching yams
+[2/25056] Fetching yams, async-http-client
+[14568/102198] Fetching yams, async-http-client, swift-nio
+Fetched https://github.com/swift-server/async-http-client.git from cache (4.36s)
+Fetched https://github.com/jpsim/Yams.git from cache (4.40s)
+Fetched https://github.com/apple/swift-nio.git from cache (4.48s)
+Computing version for https://github.com/jpsim/Yams.git
+Computed https://github.com/jpsim/Yams.git at 5.4.0 (6.87s)
+Computing version for https://github.com/swift-server/async-http-client.git
+Computed https://github.com/swift-server/async-http-client.git at 1.26.1 (0.58s)
+Fetching https://github.com/apple/swift-algorithms.git
+Fetching https://github.com/apple/swift-atomics.git
+Fetching https://github.com/apple/swift-log.git
+[1/1808] Fetching swift-atomics
+[689/7767] Fetching swift-atomics, swift-algorithms
+[1914/11647] Fetching swift-atomics, swift-algorithms, swift-log
+Fetched https://github.com/apple/swift-atomics.git from cache (0.75s)
+Fetched https://github.com/apple/swift-log.git from cache (0.75s)
+Fetched https://github.com/apple/swift-algorithms.git from cache (0.75s)
+Fetching https://github.com/apple/swift-nio-http2.git
+Fetching https://github.com/apple/swift-nio-transport-services.git
+Fetching https://github.com/apple/swift-nio-extras.git
+[1/2701] Fetching swift-nio-transport-services
+[191/8824] Fetching swift-nio-transport-services, swift-nio-extras
+[3192/20485] Fetching swift-nio-transport-services, swift-nio-extras, swift-nio-http2
+Fetched https://github.com/apple/swift-nio-transport-services.git from cache (0.59s)
+Fetched https://github.com/apple/swift-nio-extras.git from cache (0.59s)
+Fetching https://github.com/apple/swift-nio-ssl.git
+[2683/11661] Fetching swift-nio-http2
+[11662/26646] Fetching swift-nio-http2, swift-nio-ssl
+Fetched https://github.com/apple/swift-nio-http2.git from cache (1.23s)
+[4196/14985] Fetching swift-nio-ssl
+Fetched https://github.com/apple/swift-nio-ssl.git from cache (1.46s)
+Computing version for https://github.com/apple/swift-nio-transport-services.git
+Computed https://github.com/apple/swift-nio-transport-services.git at 1.25.0 (3.39s)
+Computing version for https://github.com/apple/swift-nio.git
+Computed https://github.com/apple/swift-nio.git at 2.85.0 (0.77s)
+Fetching https://github.com/apple/swift-system.git
+Fetching https://github.com/apple/swift-collections.git
+[1/4824] Fetching swift-system
+[98/21751] Fetching swift-system, swift-collections
+Fetched https://github.com/apple/swift-system.git from cache (1.69s)
+Fetched https://github.com/apple/swift-collections.git from cache (1.70s)
+Computing version for https://github.com/apple/swift-atomics.git
+Computed https://github.com/apple/swift-atomics.git at 1.3.0 (2.29s)
+Computing version for https://github.com/apple/swift-nio-http2.git
+Computed https://github.com/apple/swift-nio-http2.git at 1.38.0 (0.56s)
+Computing version for https://github.com/apple/swift-algorithms.git
+Computed https://github.com/apple/swift-algorithms.git at 1.2.1 (0.64s)
+Fetching https://github.com/apple/swift-numerics.git
+[1/5769] Fetching swift-numerics
+Fetched https://github.com/apple/swift-numerics.git from cache (0.58s)
+Computing version for https://github.com/apple/swift-nio-ssl.git
+Computed https://github.com/apple/swift-nio-ssl.git at 2.33.0 (1.34s)
+Computing version for https://github.com/apple/swift-numerics.git
+Computed https://github.com/apple/swift-numerics.git at 1.0.3 (0.66s)
+Computing version for https://github.com/apple/swift-log.git
+Computed https://github.com/apple/swift-log.git at 1.6.4 (0.55s)
+Computing version for https://github.com/apple/swift-nio-extras.git
+Computed https://github.com/apple/swift-nio-extras.git at 1.29.0 (0.62s)
+Fetching https://github.com/apple/swift-async-algorithms.git
+Fetching https://github.com/apple/swift-asn1.git
+Fetching https://github.com/swift-server/swift-service-lifecycle.git
+[1/1629] Fetching swift-asn1
+[116/4062] Fetching swift-asn1, swift-service-lifecycle
+[133/9069] Fetching swift-asn1, swift-service-lifecycle, swift-async-algorithms
+Fetched https://github.com/apple/swift-asn1.git from cache (0.56s)
+Fetched https://github.com/apple/swift-async-algorithms.git from cache (0.56s)
+Fetched https://github.com/swift-server/swift-service-lifecycle.git from cache (0.56s)
+Fetching https://github.com/apple/swift-certificates.git
+Fetching https://github.com/apple/swift-http-structured-headers.git
+Fetching https://github.com/apple/swift-http-types.git
+[1/917] Fetching swift-http-types
+[2/2093] Fetching swift-http-types, swift-http-structured-headers
+[396/8553] Fetching swift-http-types, swift-http-structured-headers, swift-certificates
+Fetched https://github.com/apple/swift-http-types.git from cache (0.44s)
+[1370/7636] Fetching swift-http-structured-headers, swift-certificates
+Fetched https://github.com/apple/swift-http-structured-headers.git from cache (0.63s)
+Fetched https://github.com/apple/swift-certificates.git from cache (0.63s)
+Computing version for https://github.com/swift-server/swift-service-lifecycle.git
+Computed https://github.com/swift-server/swift-service-lifecycle.git at 2.8.0 (1.78s)
+Computing version for https://github.com/apple/swift-async-algorithms.git
+Computed https://github.com/apple/swift-async-algorithms.git at 1.0.4 (0.65s)
+Computing version for https://github.com/apple/swift-asn1.git
+Computed https://github.com/apple/swift-asn1.git at 1.4.0 (0.66s)
+Computing version for https://github.com/apple/swift-certificates.git
+Computed https://github.com/apple/swift-certificates.git at 1.11.0 (0.70s)
+Fetching https://github.com/apple/swift-crypto.git
+[1/15930] Fetching swift-crypto
+Fetched https://github.com/apple/swift-crypto.git from cache (1.56s)
+Computing version for https://github.com/apple/swift-http-types.git
+Computed https://github.com/apple/swift-http-types.git at 1.4.0 (2.17s)
+Computing version for https://github.com/apple/swift-http-structured-headers.git
+Computed https://github.com/apple/swift-http-structured-headers.git at 1.3.0 (0.55s)
+Computing version for https://github.com/apple/swift-system.git
+Computed https://github.com/apple/swift-system.git at 1.6.1 (0.54s)
+Computing version for https://github.com/apple/swift-crypto.git
+Computed https://github.com/apple/swift-crypto.git at 3.13.3 (1.32s)
+Computing version for https://github.com/apple/swift-collections.git
+Computed https://github.com/apple/swift-collections.git at 1.2.1 (0.67s)
+Creating working copy for https://github.com/apple/swift-nio-transport-services.git
+Working copy of https://github.com/apple/swift-nio-transport-services.git resolved at 1.25.0
+Creating working copy for https://github.com/swift-server/async-http-client.git
+Working copy of https://github.com/swift-server/async-http-client.git resolved at 1.26.1
+Creating working copy for https://github.com/apple/swift-http-structured-headers.git
+Working copy of https://github.com/apple/swift-http-structured-headers.git resolved at 1.3.0
+Creating working copy for https://github.com/apple/swift-collections.git
+Working copy of https://github.com/apple/swift-collections.git resolved at 1.2.1
+Creating working copy for https://github.com/apple/swift-http-types.git
+Working copy of https://github.com/apple/swift-http-types.git resolved at 1.4.0
+Creating working copy for https://github.com/apple/swift-nio-http2.git
+Working copy of https://github.com/apple/swift-nio-http2.git resolved at 1.38.0
+Creating working copy for https://github.com/apple/swift-log.git
+Working copy of https://github.com/apple/swift-log.git resolved at 1.6.4
+Creating working copy for https://github.com/apple/swift-numerics.git
+Working copy of https://github.com/apple/swift-numerics.git resolved at 1.0.3
+Creating working copy for https://github.com/apple/swift-system.git
+Working copy of https://github.com/apple/swift-system.git resolved at 1.6.1
+Creating working copy for https://github.com/apple/swift-algorithms.git
+Working copy of https://github.com/apple/swift-algorithms.git resolved at 1.2.1
+Creating working copy for https://github.com/apple/swift-nio-ssl.git
+Working copy of https://github.com/apple/swift-nio-ssl.git resolved at 2.33.0
+Creating working copy for https://github.com/swift-server/swift-service-lifecycle.git
+Working copy of https://github.com/swift-server/swift-service-lifecycle.git resolved at 2.8.0
+Creating working copy for https://github.com/jpsim/Yams.git
+Working copy of https://github.com/jpsim/Yams.git resolved at 5.4.0
+Creating working copy for https://github.com/apple/swift-asn1.git
+Working copy of https://github.com/apple/swift-asn1.git resolved at 1.4.0
+Creating working copy for https://github.com/apple/swift-certificates.git
+Working copy of https://github.com/apple/swift-certificates.git resolved at 1.11.0
+Creating working copy for https://github.com/apple/swift-atomics.git
+Working copy of https://github.com/apple/swift-atomics.git resolved at 1.3.0
+Creating working copy for https://github.com/apple/swift-nio-extras.git
+Working copy of https://github.com/apple/swift-nio-extras.git resolved at 1.29.0
+Creating working copy for https://github.com/apple/swift-crypto.git
+Working copy of https://github.com/apple/swift-crypto.git resolved at 3.13.3
+Creating working copy for https://github.com/apple/swift-async-algorithms.git
+Working copy of https://github.com/apple/swift-async-algorithms.git resolved at 1.0.4
+Creating working copy for https://github.com/apple/swift-nio.git
+Working copy of https://github.com/apple/swift-nio.git resolved at 2.85.0
+Building for production...
+[0/459] Write sources
+[27/459] Compiling _NumericsShims _NumericsShims.c
+[28/459] Compiling _AtomicsShims.c
+[29/459] Compiling writer.c
+[30/459] Compiling reader.c
+[31/459] Write swift-version--4EAD98957C2213E4.txt
+[32/459] Compiling CNIOWindows shim.c
+[33/459] Compiling parser.c
+[34/461] Compiling api.c
+[35/462] Compiling emitter.c
+[36/463] Compiling scanner.c
+[38/464] Compiling _NIOBase64 Base64.swift
+[39/465] Compiling RealModule AlgebraicField.swift
+[40/465] Compiling _NIODataStructures Heap.swift
+[40/466] Compiling CNIOWindows WSAStartup.c
+[41/466] Compiling CNIOWASI CNIOWASI.c
+[42/466] Compiling CNIOPosix event_loop_id.c
+[43/466] Compiling CNIOLinux shim.c
+[45/466] Compiling FountainCore Models.swift
+[45/466] Compiling CNIOLinux liburing_shims.c
+[46/466] Compiling CNIOLLHTTP c_nio_http.c
+[48/466] Compiling InternalCollectionsUtilities FixedWidthInteger+roundUpToPowerOfTwo.swift
+[48/466] Compiling CNIOExtrasZlib empty.c
+[49/466] Compiling CNIOLLHTTP c_nio_api.c
+[50/466] Compiling CNIODarwin shim.c
+[51/467] Compiling CNIOBoringSSLShims shims.c
+[52/467] Compiling fiat_p256_adx_sqr.S
+[53/467] Compiling fiat_p256_adx_mul.S
+[54/467] Compiling fiat_curve25519_adx_square.S
+[55/467] Compiling CNIOLLHTTP c_nio_llhttp.c
+[56/467] Compiling fiat_curve25519_adx_mul.S
+[58/467] Compiling Logging Locks.swift
+[59/467] Compiling DequeModule Deque+Codable.swift
+[59/467] Compiling tls_method.cc
+[60/467] Compiling tls_record.cc
+[61/467] Compiling tls13_server.cc
+[62/467] Compiling tls13_both.cc
+[63/467] Compiling tls13_enc.cc
+[64/467] Compiling tls13_client.cc
+[65/467] Compiling t1_enc.cc
+[66/467] Compiling ssl_versions.cc
+[67/467] Compiling ssl_transcript.cc
+[68/467] Compiling ssl_x509.cc
+[69/467] Compiling ssl_stat.cc
+[70/467] Compiling ssl_privkey.cc
+[71/467] Compiling ssl_session.cc
+[72/467] Compiling ssl_key_share.cc
+[73/467] Compiling ssl_file.cc
+[74/467] Compiling ssl_lib.cc
+[75/467] Compiling ssl_credential.cc
+[76/467] Compiling ssl_cipher.cc
+[77/467] Compiling ssl_buffer.cc
+[78/467] Compiling ssl_cert.cc
+[79/467] Compiling ssl_asn1.cc
+[80/467] Compiling ssl_aead_ctx.cc
+[81/467] Compiling s3_lib.cc
+[82/467] Compiling s3_pkt.cc
+[83/467] Compiling s3_both.cc
+[85/467] Compiling Yams AliasDereferencingStrategy.swift
+[85/467] Compiling handshake_client.cc
+[86/467] Compiling handshake_server.cc
+[87/467] Compiling handshake.cc
+[88/467] Compiling handoff.cc
+[89/467] Compiling encrypted_client_hello.cc
+[90/467] Compiling extensions.cc
+[91/467] Compiling dtls_method.cc
+[92/467] Compiling dtls_record.cc
+[93/467] Compiling d1_srtp.cc
+[94/467] Compiling md5-x86_64-linux.S
+[95/467] Compiling bio_ssl.cc
+[96/467] Compiling d1_pkt.cc
+[97/467] Compiling md5-x86_64-apple.S
+[98/467] Compiling md5-586-linux.S
+[99/467] Compiling md5-586-apple.S
+[100/467] Compiling chacha20_poly1305_x86_64-linux.S
+[101/467] Compiling chacha20_poly1305_x86_64-apple.S
+[102/467] Compiling err_data.cc
+[103/467] Compiling chacha20_poly1305_armv8-win.S
+[104/467] Compiling chacha20_poly1305_armv8-linux.S
+[105/467] Compiling chacha20_poly1305_armv8-apple.S
+[106/467] Compiling d1_lib.cc
+[107/467] Compiling chacha-x86_64-linux.S
+[108/467] Compiling chacha-x86_64-apple.S
+[109/467] Compiling chacha-x86-linux.S
+[110/467] Compiling chacha-x86-apple.S
+[111/467] Compiling chacha-armv8-win.S
+[112/467] Compiling chacha-armv8-linux.S
+[113/467] Compiling chacha-armv8-apple.S
+[114/467] Compiling chacha-armv4-linux.S
+[115/467] Compiling aes128gcmsiv-x86_64-apple.S
+[116/467] Compiling aes128gcmsiv-x86_64-linux.S
+[117/467] Compiling x86_64-mont5-linux.S
+[118/467] Compiling x86_64-mont5-apple.S
+[119/467] Compiling d1_both.cc
+[120/467] Compiling x86_64-mont-apple.S
+[121/467] Compiling x86_64-mont-linux.S
+[122/467] Compiling x86-mont-linux.S
+[123/467] Compiling x86-mont-apple.S
+[124/467] Compiling vpaes-x86_64-linux.S
+[125/467] Compiling vpaes-x86-linux.S
+[126/467] Compiling vpaes-x86_64-apple.S
+[127/467] Compiling vpaes-x86-apple.S
+[128/467] Compiling vpaes-armv8-linux.S
+[129/467] Compiling vpaes-armv8-win.S
+[130/467] Compiling vpaes-armv8-apple.S
+[131/467] Compiling vpaes-armv7-linux.S
+[132/467] Compiling sha512-x86_64-linux.S
+[133/467] Compiling sha512-armv8-win.S
+[134/467] Compiling sha512-x86_64-apple.S
+[135/467] Compiling sha512-armv8-linux.S
+[136/467] Compiling sha512-armv8-apple.S
+[137/467] Compiling sha512-armv4-linux.S
+[138/467] Compiling sha512-586-linux.S
+[139/467] Compiling sha512-586-apple.S
+[140/467] Compiling sha256-x86_64-linux.S
+[141/467] Compiling sha256-x86_64-apple.S
+[142/467] Compiling sha256-armv8-win.S
+[143/467] Compiling sha256-armv8-linux.S
+[144/467] Compiling sha256-armv8-apple.S
+[145/467] Compiling sha256-armv4-linux.S
+[146/467] Compiling sha256-586-apple.S
+[147/467] Compiling sha256-586-linux.S
+[148/467] Compiling sha1-x86_64-apple.S
+[149/467] Compiling sha1-x86_64-linux.S
+[150/467] Compiling sha1-armv8-win.S
+[151/467] Compiling sha1-armv8-linux.S
+[152/467] Compiling sha1-armv8-apple.S
+[153/467] Compiling sha1-586-linux.S
+[154/467] Compiling sha1-armv4-large-linux.S
+[155/467] Compiling sha1-586-apple.S
+[156/467] Compiling rsaz-avx2-linux.S
+[157/467] Compiling rsaz-avx2-apple.S
+[158/467] Compiling rdrand-x86_64-apple.S
+[159/467] Compiling rdrand-x86_64-linux.S
+[160/467] Compiling p256_beeu-x86_64-asm-linux.S
+[161/467] Compiling p256_beeu-x86_64-asm-apple.S
+[162/467] Compiling p256_beeu-armv8-asm-win.S
+[163/467] Compiling p256_beeu-armv8-asm-apple.S
+[164/467] Compiling p256_beeu-armv8-asm-linux.S
+[165/467] Compiling p256-x86_64-asm-linux.S
+[166/467] Compiling p256-x86_64-asm-apple.S
+[167/467] Compiling p256-armv8-asm-win.S
+[168/467] Compiling p256-armv8-asm-linux.S
+[169/467] Compiling p256-armv8-asm-apple.S
+[170/467] Compiling ghashv8-armv8-win.S
+[171/467] Compiling ghashv8-armv8-linux.S
+[172/467] Compiling ghashv8-armv8-apple.S
+[173/467] Compiling ghashv8-armv7-linux.S
+[174/467] Compiling ghash-x86_64-linux.S
+[175/467] Compiling ghash-x86-linux.S
+[176/467] Compiling ghash-x86_64-apple.S
+[177/467] Compiling ghash-x86-apple.S
+[178/467] Compiling ghash-ssse3-x86_64-linux.S
+[179/467] Compiling ghash-ssse3-x86_64-apple.S
+[180/467] Compiling ghash-ssse3-x86-apple.S
+[181/467] Compiling ghash-ssse3-x86-linux.S
+[182/467] Compiling ghash-neon-armv8-win.S
+[183/467] Compiling ghash-neon-armv8-linux.S
+[184/467] Compiling ghash-neon-armv8-apple.S
+[185/467] Compiling ghash-armv4-linux.S
+[186/467] Compiling co-586-linux.S
+[187/467] Compiling co-586-apple.S
+[188/467] Compiling bsaes-armv7-linux.S
+[189/467] Compiling bn-armv8-win.S
+[190/467] Compiling bn-armv8-apple.S
+[191/467] Compiling bn-586-linux.S
+[192/467] Compiling bn-armv8-linux.S
+[193/467] Compiling bn-586-apple.S
+[194/467] Compiling armv8-mont-win.S
+[195/467] Compiling armv8-mont-linux.S
+[196/467] Compiling armv8-mont-apple.S
+[197/467] Compiling armv4-mont-linux.S
+[198/467] Compiling aesv8-gcm-armv8-win.S
+[199/467] Compiling aesv8-gcm-armv8-linux.S
+[200/467] Compiling aesv8-armv8-win.S
+[201/467] Compiling aesv8-armv8-linux.S
+[202/467] Compiling aesv8-gcm-armv8-apple.S
+[203/467] Compiling aesv8-armv8-apple.S
+[204/467] Compiling aesv8-armv7-linux.S
+[205/467] Compiling aesni-x86-linux.S
+[205/467] Compiling aesni-x86_64-apple.S
+[207/467] Compiling aesni-x86_64-linux.S
+[208/467] Compiling aesni-x86-apple.S
+[209/467] Compiling aesni-gcm-x86_64-linux.S
+[210/467] Compiling aes-gcm-avx2-x86_64-apple.S
+[211/467] Compiling aesni-gcm-x86_64-apple.S
+[212/467] Compiling aes-gcm-avx2-x86_64-linux.S
+[213/467] Compiling aes-gcm-avx10-x86_64-linux.S
+[214/467] Compiling aes-gcm-avx10-x86_64-apple.S
+[215/467] Compiling x_val.cc
+[216/467] Compiling x_x509a.cc
+[217/467] Compiling x_sig.cc
+[218/467] Compiling x_x509.cc
+[219/467] Compiling x_spki.cc
+[220/467] Compiling x_pubkey.cc
+[221/467] Compiling x_req.cc
+[222/467] Compiling x_exten.cc
+[223/467] Compiling x_crl.cc
+[224/467] Compiling x_name.cc
+[225/467] Compiling x_attrib.cc
+[226/467] Compiling x509spki.cc
+[227/467] Compiling x_algor.cc
+[228/467] Compiling x509rset.cc
+[229/467] Compiling x_all.cc
+[230/467] Compiling x509name.cc
+[231/467] Compiling x509_vpm.cc
+[232/467] Compiling x509_v3.cc
+[233/467] Compiling x509cset.cc
+[234/467] Compiling x509_vfy.cc
+[235/467] Compiling x509_txt.cc
+[236/467] Compiling x509_trs.cc
+[237/467] Compiling x509_set.cc
+[238/467] Compiling x509_req.cc
+[239/467] Compiling x509_obj.cc
+[240/467] Compiling x509_lu.cc
+[241/467] Compiling x509_def.cc
+[242/467] Compiling x509_d2.cc
+[243/467] Compiling x509_ext.cc
+[244/467] Compiling x509_cmp.cc
+[245/467] Compiling x509_att.cc
+[246/467] Compiling x509.cc
+[247/467] Compiling v3_skey.cc
+[248/467] Compiling v3_utl.cc
+[249/467] Compiling v3_purp.cc
+[250/467] Compiling v3_prn.cc
+[251/467] Compiling v3_pmaps.cc
+[252/467] Compiling v3_pcons.cc
+[253/467] Compiling v3_ocsp.cc
+[254/467] Compiling v3_int.cc
+[255/467] Compiling v3_lib.cc
+[256/467] Compiling v3_ncons.cc
+[257/467] Compiling v3_info.cc
+[258/467] Compiling v3_ia5.cc
+[259/467] Compiling v3_enum.cc
+[260/467] Compiling v3_genn.cc
+[261/467] Compiling v3_extku.cc
+[262/467] Compiling v3_crld.cc
+[263/467] Compiling v3_cpols.cc
+[264/467] Compiling v3_bcons.cc
+[265/467] Compiling v3_bitst.cc
+[266/467] Compiling v3_conf.cc
+[267/467] Compiling v3_akeya.cc
+[268/467] Compiling v3_alt.cc
+[269/467] Compiling v3_akey.cc
+[270/467] Compiling t_x509a.cc
+[271/467] Compiling t_x509.cc
+[272/467] Compiling t_crl.cc
+[273/467] Compiling t_req.cc
+[274/467] Compiling rsa_pss.cc
+[275/467] Compiling name_print.cc
+[276/467] Compiling i2d_pr.cc
+[277/467] Compiling policy.cc
+[278/467] Compiling by_file.cc
+[279/467] Compiling by_dir.cc
+[280/467] Compiling asn1_gen.cc
+[281/467] Compiling a_verify.cc
+[282/467] Compiling algorithm.cc
+[283/467] Compiling a_sign.cc
+[284/467] Compiling trust_token.cc
+[285/467] Compiling a_digest.cc
+[286/467] Compiling voprf.cc
+[287/467] Compiling thread_win.cc
+[288/467] Compiling pmbtoken.cc
+[289/467] Compiling thread_none.cc
+[290/467] Compiling thread.cc
+[291/467] Compiling thread_pthread.cc
+[292/467] Compiling stack.cc
+[293/467] Compiling slhdsa.cc
+[294/467] Compiling sha512.cc
+[295/467] Compiling siphash.cc
+[296/467] Compiling spake2plus.cc
+[297/467] Compiling sha256.cc
+[298/467] Compiling sha1.cc
+[299/467] Compiling rsa_extra.cc
+[300/467] Compiling rsa_print.cc
+[301/467] Compiling rsa_crypt.cc
+[302/467] Compiling refcount.cc
+[303/467] Compiling rsa_asn1.cc
+[304/467] Compiling rc4.cc
+[305/467] Compiling windows.cc
+[306/467] Compiling trusty.cc
+[307/467] Compiling rand.cc
+[308/467] Compiling urandom.cc
+[309/467] Compiling ios.cc
+[310/467] Compiling passive.cc
+[311/467] Compiling getentropy.cc
+[312/467] Compiling deterministic.cc
+[313/467] Compiling forkunsafe.cc
+[314/467] Compiling fork_detect.cc
+[315/467] Compiling poly1305_arm_asm.S
+[316/467] Compiling pool.cc
+[317/467] Compiling poly1305_arm.cc
+[318/467] Compiling poly1305.cc
+[319/467] Compiling poly1305_vec.cc
+[320/467] Compiling pkcs7.cc
+[321/467] Compiling pkcs8.cc
+[322/467] Compiling pkcs8_x509.cc
+[323/467] Compiling pkcs7_x509.cc
+[324/467] Compiling p5_pbev2.cc
+[325/467] Compiling pem_xaux.cc
+[326/467] Compiling pem_x509.cc
+[327/467] Compiling pem_pkey.cc
+[328/467] Compiling pem_pk8.cc
+[329/467] Compiling pem_oth.cc
+[330/467] Compiling obj_xref.cc
+[331/467] Compiling pem_info.cc
+[332/467] Compiling pem_lib.cc
+[333/467] Compiling obj.cc
+[334/467] Compiling pem_all.cc
+[335/467] Compiling mlkem.cc
+[336/467] Compiling mldsa.cc
+[337/467] Compiling md5.cc
+[338/467] Compiling mem.cc
+[339/467] Compiling md4.cc
+[340/467] Compiling lhash.cc
+[341/467] Compiling fips_shared_support.cc
+[342/467] Compiling poly_rq_mul.S
+[343/467] Compiling kyber.cc
+[344/467] Compiling ex_data.cc
+[345/467] Compiling hpke.cc
+[346/467] Compiling sign.cc
+[347/467] Compiling hrss.cc
+[348/467] Compiling scrypt.cc
+[349/467] Compiling print.cc
+[350/467] Compiling pbkdf.cc
+[351/467] Compiling p_x25519.cc
+[352/467] Compiling p_x25519_asn1.cc
+[353/467] Compiling p_rsa_asn1.cc
+[354/467] Compiling p_rsa.cc
+[355/467] Compiling p_hkdf.cc
+[356/467] Compiling p_ed25519_asn1.cc
+[357/467] Compiling p_ed25519.cc
+[358/467] Compiling p_ec_asn1.cc
+[359/467] Compiling p_ec.cc
+[360/467] Compiling p_dh_asn1.cc
+[361/467] Compiling p_dh.cc
+[362/467] Compiling p_dsa_asn1.cc
+[363/467] Compiling evp_ctx.cc
+[364/467] Compiling evp.cc
+[365/467] Compiling evp_asn1.cc
+[366/467] Compiling err.cc
+[367/467] Compiling engine.cc
+[368/467] Compiling ecdh.cc
+[369/467] Compiling ecdsa_asn1.cc
+[370/467] Compiling ec_derive.cc
+[371/467] Compiling hash_to_curve.cc
+[372/467] Compiling ec_asn1.cc
+[373/467] Compiling dsa_asn1.cc
+[374/467] Compiling dsa.cc
+[375/467] Compiling digest_extra.cc
+[376/467] Compiling params.cc
+[377/467] Compiling dh_asn1.cc
+[378/467] Compiling spake25519.cc
+[379/467] Compiling x25519-asm-arm.S
+[380/467] Compiling des.cc
+[381/467] Compiling crypto.cc
+[382/467] Compiling cpu_intel.cc
+[383/467] Compiling curve25519_64_adx.cc
+[384/467] Compiling cpu_arm_linux.cc
+[385/467] Compiling curve25519.cc
+[386/467] Compiling cpu_arm_freebsd.cc
+[387/467] Compiling cpu_aarch64_win.cc
+[388/467] Compiling cpu_aarch64_openbsd.cc
+[389/467] Compiling cpu_aarch64_sysreg.cc
+[390/467] Compiling cpu_aarch64_linux.cc
+[391/467] Compiling cpu_aarch64_fuchsia.cc
+[392/467] Compiling cpu_aarch64_apple.cc
+[393/467] Compiling conf.cc
+[394/467] Compiling get_cipher.cc
+[395/467] Compiling tls_cbc.cc
+[396/467] Compiling e_tls.cc
+[397/467] Compiling e_rc4.cc
+[398/467] Compiling e_null.cc
+[399/467] Compiling e_rc2.cc
+[400/467] Compiling e_des.cc
+[401/467] Compiling e_chacha20poly1305.cc
+[402/467] Compiling e_aesctrhmac.cc
+[403/467] Compiling derive_key.cc
+[404/467] Compiling e_aesgcmsiv.cc
+[405/467] Compiling chacha.cc
+[406/467] Compiling unicode.cc
+[407/467] Compiling cbb.cc
+[408/467] Compiling ber.cc
+[409/467] Compiling cbs.cc
+[410/467] Compiling asn1_compat.cc
+[411/467] Compiling buf.cc
+[412/467] Compiling bn_asn1.cc
+[413/467] Compiling convert.cc
+[414/467] Compiling blake2.cc
+[415/467] Compiling socket_helper.cc
+[416/467] Compiling socket.cc
+[417/467] Compiling printf.cc
+[418/467] Compiling pair.cc
+[419/467] Compiling hexdump.cc
+[420/467] Compiling file.cc
+[421/467] Compiling fd.cc
+[422/467] Compiling errno.cc
+[423/467] Compiling connect.cc
+[424/467] Compiling bio_mem.cc
+[425/467] Compiling base64.cc
+[426/467] Compiling bio.cc
+[427/467] Compiling tasn_typ.cc
+[428/467] Compiling tasn_utl.cc
+[429/467] Compiling tasn_new.cc
+[430/467] Compiling tasn_fre.cc
+[431/467] Compiling tasn_enc.cc
+[432/467] Compiling f_string.cc
+[433/467] Compiling posix_time.cc
+[434/467] Compiling tasn_dec.cc
+[435/467] Compiling f_int.cc
+[436/467] Compiling asn_pack.cc
+[437/467] Compiling asn1_par.cc
+[438/467] Compiling asn1_lib.cc
+[439/467] Compiling a_utctm.cc
+[440/467] Compiling a_type.cc
+[441/467] Compiling a_time.cc
+[442/467] Compiling a_strnid.cc
+[443/467] Compiling a_octet.cc
+[444/467] Compiling a_strex.cc
+[445/467] Compiling a_object.cc
+[446/467] Compiling a_mbstr.cc
+[447/467] Compiling a_i2d_fp.cc
+[448/467] Compiling a_int.cc
+[449/467] Compiling a_gentm.cc
+[450/467] Compiling a_dup.cc
+[451/467] Compiling a_d2i_fp.cc
+[452/467] Compiling a_bool.cc
+[453/467] Compiling CAsyncHTTPClient CAsyncHTTPClient.c
+[454/467] Write sources
+[456/467] Compiling a_bitstr.cc
+[457/467] Write sources
+[458/469] Compiling c-nioatomics.c
+[459/469] Compiling c-atomics.c
+[460/470] Compiling bcm.cc
+[462/470] Compiling NIOConcurrencyHelpers NIOAtomic.swift
+[463/470] Compiling Atomics OptionalRawRepresentable.swift
+[464/471] Compiling Algorithms AdjacentPairs.swift
+[465/471] Compiling NIOCore AddressedEnvelope.swift
+[466/473] Compiling NIOEmbedded AsyncTestingChannel.swift
+[467/473] Compiling NIOPosix BSDSocketAPICommon.swift
+[468/474] Compiling NIO Exports.swift
+[469/478] Compiling NIOTLS ApplicationProtocolNegotiationHandler.swift
+[470/479] Compiling NIOSOCKS SOCKSClientHandler.swift
+[471/479] Compiling NIOFoundationCompat ByteBuffer-foundation.swift
+[472/480] Compiling NIOTransportServices AcceptHandler.swift
+[473/480] Compiling NIOHTTP1 ByteCollectionUtils.swift
+[474/482] Compiling NIOSSL AndroidCABundle.swift
+[475/482] Compiling NIOHTTPCompression HTTPCompression.swift
+[476/482] Compiling NIOHPACK DynamicHeaderTable.swift
+[477/483] Compiling NIOHTTP2 ConnectionStateMachine.swift
+[478/484] Compiling AsyncHTTPClient AnyAsyncSequence.swift
+[0/1] Planning build
+Building for production...
+[0/470] Write sources
+[32/470] Compiling _AtomicsShims.c
+[33/470] Compiling writer.c
+[34/470] Compiling reader.c
+[35/470] Compiling _NumericsShims _NumericsShims.c
+[36/470] Write swift-version--4EAD98957C2213E4.txt
+[37/470] Compiling CNIOWindows shim.c
+[38/470] Compiling parser.c
+[39/472] Compiling api.c
+[40/473] Compiling emitter.c
+[41/473] Compiling scanner.c
+[43/475] Compiling _NIOBase64 Base64.swift
+[44/476] Compiling _NIODataStructures Heap.swift
+[45/476] Compiling RealModule AlgebraicField.swift
+[45/476] Compiling CNIOWindows WSAStartup.c
+[46/476] Compiling CNIOWASI CNIOWASI.c
+[47/477] Compiling CNIOPosix event_loop_id.c
+[48/477] Compiling CNIOLinux shim.c
+[49/477] Compiling CNIOLinux liburing_shims.c
+[51/477] Compiling FountainCore Models.swift
+[51/477] Compiling CNIOLLHTTP c_nio_http.c
+[53/478] Compiling InternalCollectionsUtilities FixedWidthInteger+roundUpToPowerOfTwo.swift
+[53/478] Compiling CNIOLLHTTP c_nio_api.c
+[54/478] Compiling CNIOLLHTTP c_nio_llhttp.c
+[55/478] Compiling CNIOExtrasZlib empty.c
+[56/479] Compiling CNIODarwin shim.c
+[57/479] Compiling CNIOBoringSSLShims shims.c
+[58/479] Compiling fiat_p256_adx_sqr.S
+[59/479] Compiling fiat_p256_adx_mul.S
+[60/479] Compiling fiat_curve25519_adx_square.S
+[61/479] Compiling fiat_curve25519_adx_mul.S
+[63/479] Compiling Logging Locks.swift
+[63/479] Compiling tls_method.cc
+[65/479] Compiling DequeModule Deque+Codable.swift
+[65/479] Compiling tls_record.cc
+[66/479] Compiling tls13_enc.cc
+[67/479] Compiling tls13_server.cc
+[68/479] Compiling tls13_client.cc
+[70/479] Compiling FountainCoreTests FountainCoreTests.swift
+[70/479] Compiling t1_enc.cc
+[71/479] Compiling tls13_both.cc
+[72/479] Compiling ssl_x509.cc
+[73/479] Compiling ssl_versions.cc
+[74/479] Compiling ssl_transcript.cc
+[75/479] Compiling ssl_stat.cc
+[76/479] Compiling ssl_privkey.cc
+[77/479] Compiling ssl_session.cc
+[78/479] Compiling ssl_key_share.cc
+[79/479] Compiling ssl_file.cc
+[80/479] Compiling ssl_lib.cc
+[82/479] Compiling Yams AliasDereferencingStrategy.swift
+[82/479] Compiling ssl_cert.cc
+[83/479] Compiling ssl_credential.cc
+[84/479] Compiling ssl_cipher.cc
+[85/479] Compiling ssl_buffer.cc
+[86/479] Compiling ssl_aead_ctx.cc
+[87/479] Compiling s3_pkt.cc
+[88/479] Compiling ssl_asn1.cc
+[89/479] Compiling s3_lib.cc
+[90/479] Compiling s3_both.cc
+[91/479] Compiling handshake.cc
+[92/479] Compiling handshake_server.cc
+[93/479] Compiling handshake_client.cc
+[94/479] Compiling handoff.cc
+[95/479] Compiling dtls_method.cc
+[96/479] Compiling dtls_record.cc
+[97/479] Compiling encrypted_client_hello.cc
+[98/479] Compiling extensions.cc
+[99/479] Compiling d1_srtp.cc
+[100/479] Compiling md5-x86_64-linux.S
+[101/479] Compiling md5-x86_64-apple.S
+[102/479] Compiling md5-586-linux.S
+[103/479] Compiling md5-586-apple.S
+[104/479] Compiling bio_ssl.cc
+[105/479] Compiling chacha20_poly1305_x86_64-linux.S
+[106/479] Compiling err_data.cc
+[107/479] Compiling chacha20_poly1305_x86_64-apple.S
+[108/479] Compiling d1_pkt.cc
+[109/479] Compiling chacha20_poly1305_armv8-win.S
+[110/479] Compiling chacha20_poly1305_armv8-linux.S
+[111/479] Compiling chacha20_poly1305_armv8-apple.S
+[112/479] Compiling chacha-x86_64-linux.S
+[113/479] Compiling d1_lib.cc
+[114/479] Compiling chacha-x86_64-apple.S
+[115/479] Compiling chacha-x86-linux.S
+[116/479] Compiling chacha-x86-apple.S
+[117/479] Compiling chacha-armv8-win.S
+[118/479] Compiling chacha-armv8-linux.S
+[119/479] Compiling chacha-armv8-apple.S
+[120/479] Compiling chacha-armv4-linux.S
+[121/479] Compiling aes128gcmsiv-x86_64-linux.S
+[122/479] Compiling aes128gcmsiv-x86_64-apple.S
+[123/479] Compiling x86_64-mont5-linux.S
+[124/479] Compiling x86_64-mont5-apple.S
+[125/479] Compiling x86_64-mont-linux.S
+[126/479] Compiling x86_64-mont-apple.S
+[127/479] Compiling d1_both.cc
+[128/479] Compiling x86-mont-linux.S
+[129/479] Compiling x86-mont-apple.S
+[130/479] Compiling vpaes-x86_64-linux.S
+[131/479] Compiling vpaes-x86_64-apple.S
+[131/479] Compiling vpaes-x86-linux.S
+[133/479] Compiling vpaes-armv8-win.S
+[134/479] Compiling vpaes-x86-apple.S
+[135/479] Compiling vpaes-armv8-linux.S
+[136/479] Compiling vpaes-armv7-linux.S
+[137/479] Compiling vpaes-armv8-apple.S
+[138/479] Compiling sha512-x86_64-apple.S
+[139/479] Compiling sha512-x86_64-linux.S
+[140/479] Compiling sha512-armv8-win.S
+[141/479] Compiling sha512-armv8-linux.S
+[142/479] Compiling sha512-armv8-apple.S
+[143/479] Compiling sha512-armv4-linux.S
+[144/479] Compiling sha512-586-linux.S
+[145/479] Compiling sha512-586-apple.S
+[146/479] Compiling sha256-x86_64-linux.S
+[147/479] Compiling sha256-x86_64-apple.S
+[148/479] Compiling sha256-armv8-win.S
+[149/479] Compiling sha256-armv8-linux.S
+[150/479] Compiling sha256-armv8-apple.S
+[151/479] Compiling sha256-armv4-linux.S
+[152/479] Compiling sha256-586-linux.S
+[153/479] Compiling sha256-586-apple.S
+[154/479] Compiling sha1-x86_64-linux.S
+[155/479] Compiling sha1-x86_64-apple.S
+[156/479] Compiling sha1-armv8-win.S
+[157/479] Compiling sha1-armv8-linux.S
+[158/479] Compiling sha1-armv8-apple.S
+[159/479] Compiling sha1-armv4-large-linux.S
+[160/479] Compiling sha1-586-linux.S
+[161/479] Compiling sha1-586-apple.S
+[162/479] Compiling rsaz-avx2-linux.S
+[163/479] Compiling rsaz-avx2-apple.S
+[164/479] Compiling rdrand-x86_64-linux.S
+[165/479] Compiling p256_beeu-x86_64-asm-linux.S
+[166/479] Compiling rdrand-x86_64-apple.S
+[167/479] Compiling p256_beeu-x86_64-asm-apple.S
+[168/479] Compiling p256_beeu-armv8-asm-win.S
+[169/479] Compiling p256_beeu-armv8-asm-linux.S
+[170/479] Compiling p256_beeu-armv8-asm-apple.S
+[171/479] Compiling p256-x86_64-asm-linux.S
+[172/479] Compiling p256-x86_64-asm-apple.S
+[173/479] Compiling p256-armv8-asm-win.S
+[174/479] Compiling p256-armv8-asm-linux.S
+[175/479] Compiling p256-armv8-asm-apple.S
+[176/479] Compiling ghashv8-armv8-win.S
+[177/479] Compiling ghashv8-armv8-linux.S
+[178/479] Compiling ghashv8-armv8-apple.S
+[179/479] Compiling ghashv8-armv7-linux.S
+[180/479] Compiling ghash-x86_64-linux.S
+[181/479] Compiling ghash-x86_64-apple.S
+[182/479] Compiling ghash-x86-linux.S
+[183/479] Compiling ghash-x86-apple.S
+[184/479] Compiling ghash-ssse3-x86_64-linux.S
+[185/479] Compiling ghash-ssse3-x86_64-apple.S
+[186/479] Compiling ghash-ssse3-x86-linux.S
+[187/479] Compiling ghash-ssse3-x86-apple.S
+[188/479] Compiling ghash-neon-armv8-win.S
+[189/479] Compiling ghash-neon-armv8-linux.S
+[190/479] Compiling ghash-neon-armv8-apple.S
+[191/479] Compiling ghash-armv4-linux.S
+[192/479] Compiling co-586-linux.S
+[193/479] Compiling bsaes-armv7-linux.S
+[194/479] Compiling co-586-apple.S
+[195/479] Compiling bn-armv8-win.S
+[196/479] Compiling bn-armv8-linux.S
+[197/479] Compiling bn-armv8-apple.S
+[198/479] Compiling bn-586-linux.S
+[199/479] Compiling bn-586-apple.S
+[200/479] Compiling armv8-mont-linux.S
+[201/479] Compiling armv8-mont-win.S
+[202/479] Compiling armv8-mont-apple.S
+[203/479] Compiling armv4-mont-linux.S
+[204/479] Compiling aesv8-gcm-armv8-linux.S
+[205/479] Compiling aesv8-gcm-armv8-win.S
+[206/479] Compiling aesv8-gcm-armv8-apple.S
+[207/479] Compiling aesv8-armv8-win.S
+[208/479] Compiling aesv8-armv8-linux.S
+[209/479] Compiling aesv8-armv8-apple.S
+[210/479] Compiling aesv8-armv7-linux.S
+[211/479] Compiling aesni-x86_64-linux.S
+[212/479] Compiling aesni-x86_64-apple.S
+[213/479] Compiling aesni-x86-linux.S
+[214/479] Compiling aesni-x86-apple.S
+[215/479] Compiling aesni-gcm-x86_64-linux.S
+[216/479] Compiling aesni-gcm-x86_64-apple.S
+[217/479] Compiling aes-gcm-avx2-x86_64-linux.S
+[218/479] Compiling aes-gcm-avx2-x86_64-apple.S
+[219/479] Compiling aes-gcm-avx10-x86_64-apple.S
+[220/479] Compiling aes-gcm-avx10-x86_64-linux.S
+[221/479] Compiling x_x509a.cc
+[222/479] Compiling x_sig.cc
+[223/479] Compiling x_val.cc
+[224/479] Compiling x_spki.cc
+[225/479] Compiling x_x509.cc
+[226/479] Compiling x_req.cc
+[227/479] Compiling x_pubkey.cc
+[228/479] Compiling x_exten.cc
+[229/479] Compiling x_name.cc
+[230/479] Compiling x_crl.cc
+[231/479] Compiling x_attrib.cc
+[232/479] Compiling x_algor.cc
+[233/479] Compiling x509spki.cc
+[234/479] Compiling x_all.cc
+[235/479] Compiling x509rset.cc
+[236/479] Compiling x509name.cc
+[237/479] Compiling x509cset.cc
+[238/479] Compiling x509_vpm.cc
+[239/479] Compiling x509_v3.cc
+[240/479] Compiling x509_vfy.cc
+[241/479] Compiling x509_txt.cc
+[242/479] Compiling x509_trs.cc
+[243/479] Compiling x509_set.cc
+[244/479] Compiling x509_req.cc
+[245/479] Compiling x509_obj.cc
+[246/479] Compiling x509_lu.cc
+[247/479] Compiling x509_def.cc
+[248/479] Compiling x509_ext.cc
+[249/479] Compiling x509_d2.cc
+[250/479] Compiling x509_cmp.cc
+[251/479] Compiling x509_att.cc
+[252/479] Compiling x509.cc
+[253/479] Compiling v3_skey.cc
+[254/479] Compiling v3_utl.cc
+[255/479] Compiling v3_purp.cc
+[256/479] Compiling v3_prn.cc
+[257/479] Compiling v3_pmaps.cc
+[258/479] Compiling v3_pcons.cc
+[259/479] Compiling v3_ocsp.cc
+[260/479] Compiling v3_ncons.cc
+[261/479] Compiling v3_int.cc
+[262/479] Compiling v3_lib.cc
+[263/479] Compiling v3_info.cc
+[264/479] Compiling v3_ia5.cc
+[265/479] Compiling v3_genn.cc
+[266/479] Compiling v3_extku.cc
+[267/479] Compiling v3_enum.cc
+[268/479] Compiling v3_crld.cc
+[269/479] Compiling v3_cpols.cc
+[270/479] Compiling v3_bitst.cc
+[271/479] Compiling v3_conf.cc
+[272/479] Compiling v3_bcons.cc
+[273/479] Compiling v3_akeya.cc
+[274/479] Compiling v3_alt.cc
+[275/479] Compiling v3_akey.cc
+[276/479] Compiling t_x509a.cc
+[277/479] Compiling t_x509.cc
+[278/479] Compiling t_req.cc
+[279/479] Compiling t_crl.cc
+[280/479] Compiling rsa_pss.cc
+[281/479] Compiling name_print.cc
+[282/479] Compiling i2d_pr.cc
+[283/479] Compiling policy.cc
+[284/479] Compiling by_file.cc
+[285/479] Compiling by_dir.cc
+[286/479] Compiling asn1_gen.cc
+[287/479] Compiling a_verify.cc
+[288/479] Compiling algorithm.cc
+[289/479] Compiling a_sign.cc
+[290/479] Compiling a_digest.cc
+[291/479] Compiling trust_token.cc
+[292/479] Compiling thread_win.cc
+[293/479] Compiling voprf.cc
+[294/479] Compiling pmbtoken.cc
+[295/479] Compiling thread_none.cc
+[295/479] Compiling thread_pthread.cc
+[297/479] Compiling thread.cc
+[298/479] Compiling stack.cc
+[299/479] Compiling siphash.cc
+[300/479] Compiling sha512.cc
+[301/479] Compiling slhdsa.cc
+[302/479] Compiling spake2plus.cc
+[303/479] Compiling sha256.cc
+[304/479] Compiling sha1.cc
+[305/479] Compiling rsa_extra.cc
+[306/479] Compiling rsa_print.cc
+[307/479] Compiling rsa_crypt.cc
+[308/479] Compiling rc4.cc
+[309/479] Compiling rsa_asn1.cc
+[310/479] Compiling refcount.cc
+[311/479] Compiling windows.cc
+[312/479] Compiling trusty.cc
+[313/479] Compiling rand.cc
+[314/479] Compiling urandom.cc
+[315/479] Compiling ios.cc
+[316/479] Compiling passive.cc
+[317/479] Compiling getentropy.cc
+[318/479] Compiling deterministic.cc
+[319/479] Compiling forkunsafe.cc
+[320/479] Compiling fork_detect.cc
+[321/479] Compiling poly1305_arm_asm.S
+[322/479] Compiling pool.cc
+[323/479] Compiling poly1305_arm.cc
+[324/479] Compiling poly1305.cc
+[325/479] Compiling poly1305_vec.cc
+[326/479] Compiling pkcs7.cc
+[327/479] Compiling pkcs8.cc
+[328/479] Compiling pkcs8_x509.cc
+[329/479] Compiling p5_pbev2.cc
+[330/479] Compiling pkcs7_x509.cc
+[331/479] Compiling pem_xaux.cc
+[332/479] Compiling pem_x509.cc
+[333/479] Compiling pem_pkey.cc
+[334/479] Compiling pem_pk8.cc
+[335/479] Compiling pem_oth.cc
+[336/479] Compiling obj_xref.cc
+[337/479] Compiling pem_info.cc
+[338/479] Compiling pem_lib.cc
+[339/479] Compiling pem_all.cc
+[340/479] Compiling obj.cc
+[341/479] Compiling mlkem.cc
+[342/479] Compiling mldsa.cc
+[343/479] Compiling md5.cc
+[344/479] Compiling mem.cc
+[345/479] Compiling md4.cc
+[346/479] Compiling lhash.cc
+[347/479] Compiling fips_shared_support.cc
+[348/479] Compiling poly_rq_mul.S
+[349/479] Compiling kyber.cc
+[350/479] Compiling ex_data.cc
+[351/479] Compiling hpke.cc
+[352/479] Compiling sign.cc
+[353/479] Compiling hrss.cc
+[354/479] Compiling scrypt.cc
+[355/479] Compiling print.cc
+[356/479] Compiling pbkdf.cc
+[357/479] Compiling p_x25519.cc
+[358/479] Compiling p_x25519_asn1.cc
+[359/479] Compiling p_rsa_asn1.cc
+[360/479] Compiling p_rsa.cc
+[361/479] Compiling p_hkdf.cc
+[362/479] Compiling p_ed25519_asn1.cc
+[363/479] Compiling p_ed25519.cc
+[364/479] Compiling p_ec_asn1.cc
+[365/479] Compiling p_ec.cc
+[366/479] Compiling p_dh_asn1.cc
+[367/479] Compiling p_dsa_asn1.cc
+[368/479] Compiling p_dh.cc
+[369/479] Compiling evp_ctx.cc
+[370/479] Compiling evp.cc
+[371/479] Compiling evp_asn1.cc
+[372/479] Compiling err.cc
+[373/479] Compiling engine.cc
+[374/479] Compiling ecdh.cc
+[375/479] Compiling ecdsa_asn1.cc
+[376/479] Compiling ec_derive.cc
+[377/479] Compiling hash_to_curve.cc
+[378/479] Compiling dsa_asn1.cc
+[379/479] Compiling ec_asn1.cc
+[380/479] Compiling digest_extra.cc
+[381/479] Compiling dsa.cc
+[382/479] Compiling params.cc
+[383/479] Compiling dh_asn1.cc
+[384/479] Compiling spake25519.cc
+[385/479] Compiling x25519-asm-arm.S
+[386/479] Compiling des.cc
+[387/479] Compiling crypto.cc
+[388/479] Compiling cpu_intel.cc
+[389/479] Compiling cpu_arm_linux.cc
+[390/479] Compiling curve25519_64_adx.cc
+[391/479] Compiling cpu_arm_freebsd.cc
+[392/479] Compiling curve25519.cc
+[393/479] Compiling cpu_aarch64_win.cc
+[394/479] Compiling cpu_aarch64_sysreg.cc
+[395/479] Compiling cpu_aarch64_openbsd.cc
+[396/479] Compiling cpu_aarch64_linux.cc
+[397/479] Compiling cpu_aarch64_fuchsia.cc
+[398/479] Compiling cpu_aarch64_apple.cc
+[399/479] Compiling conf.cc
+[400/479] Compiling tls_cbc.cc
+[401/479] Compiling get_cipher.cc
+[402/479] Compiling e_tls.cc
+[403/479] Compiling e_rc4.cc
+[404/479] Compiling e_rc2.cc
+[405/479] Compiling e_null.cc
+[406/479] Compiling e_des.cc
+[407/479] Compiling e_chacha20poly1305.cc
+[408/479] Compiling derive_key.cc
+[409/479] Compiling e_aesctrhmac.cc
+[410/479] Compiling e_aesgcmsiv.cc
+[411/479] Compiling chacha.cc
+[412/479] Compiling unicode.cc
+[413/479] Compiling cbb.cc
+[414/479] Compiling ber.cc
+[415/479] Compiling cbs.cc
+[416/479] Compiling asn1_compat.cc
+[417/479] Compiling buf.cc
+[418/479] Compiling bn_asn1.cc
+[419/479] Compiling blake2.cc
+[420/479] Compiling convert.cc
+[421/479] Compiling socket_helper.cc
+[422/479] Compiling socket.cc
+[423/479] Compiling printf.cc
+[424/479] Compiling pair.cc
+[425/479] Compiling file.cc
+[426/479] Compiling hexdump.cc
+[427/479] Compiling fd.cc
+[428/479] Compiling errno.cc
+[429/479] Compiling bio_mem.cc
+[430/479] Compiling connect.cc
+[431/479] Compiling base64.cc
+[432/479] Compiling bio.cc
+[433/479] Compiling tasn_typ.cc
+[434/479] Compiling tasn_utl.cc
+[435/479] Compiling tasn_fre.cc
+[436/479] Compiling tasn_new.cc
+[437/479] Compiling tasn_enc.cc
+[438/479] Compiling posix_time.cc
+[439/479] Compiling f_string.cc
+[440/479] Compiling tasn_dec.cc
+[441/479] Compiling f_int.cc
+[442/479] Compiling asn1_par.cc
+[443/479] Compiling asn_pack.cc
+[444/479] Compiling asn1_lib.cc
+[445/479] Compiling a_utctm.cc
+[446/479] Compiling a_type.cc
+[447/479] Compiling a_time.cc
+[448/479] Compiling a_strnid.cc
+[449/479] Compiling a_octet.cc
+[450/479] Compiling a_strex.cc
+[451/479] Compiling a_object.cc
+[452/479] Compiling a_mbstr.cc
+[453/479] Compiling a_i2d_fp.cc
+[453/479] Compiling a_int.cc
+[455/479] Compiling a_gentm.cc
+[456/479] Compiling a_dup.cc
+[457/479] Compiling a_d2i_fp.cc
+[458/479] Compiling a_bool.cc
+[459/479] Compiling CAsyncHTTPClient CAsyncHTTPClient.c
+[460/479] Write sources
+[462/479] Compiling a_bitstr.cc
+[463/479] Write sources
+[464/481] Compiling c-nioatomics.c
+[465/481] Compiling bcm.cc
+[466/481] Compiling c-atomics.c
+[468/482] Compiling NIOConcurrencyHelpers NIOAtomic.swift
+[469/482] Compiling Atomics OptionalRawRepresentable.swift
+[470/483] Compiling Algorithms AdjacentPairs.swift
+Building for production...
+[0/470] Write sources
+[32/470] Compiling _AtomicsShims.c
+[33/470] Compiling writer.c
+[34/470] Compiling reader.c
+[35/470] Compiling _NumericsShims _NumericsShims.c
+[36/470] Write swift-version--4EAD98957C2213E4.txt
+[37/470] Compiling CNIOWindows shim.c
+[38/470] Compiling parser.c
+[39/472] Compiling api.c
+[40/473] Compiling emitter.c
+[41/473] Compiling scanner.c
+[43/475] Compiling _NIOBase64 Base64.swift
+[44/475] Compiling _NIODataStructures Heap.swift
+[45/477] Compiling RealModule AlgebraicField.swift
+[45/477] Compiling CNIOWindows WSAStartup.c
+[46/477] Compiling CNIOWASI CNIOWASI.c
+[47/477] Compiling CNIOPosix event_loop_id.c
+[48/477] Compiling CNIOLinux shim.c
+[50/477] Compiling FountainCore Models.swift
+[50/477] Compiling CNIOLinux liburing_shims.c
+[52/478] Compiling FountainCoreTests FountainCoreTests.swift
+[52/478] Compiling CNIOLLHTTP c_nio_http.c
+[54/478] Compiling InternalCollectionsUtilities FixedWidthInteger+roundUpToPowerOfTwo.swift
+[54/478] Compiling CNIOExtrasZlib empty.c
+[55/478] Compiling CNIOLLHTTP c_nio_api.c
+[56/479] Compiling CNIODarwin shim.c
+[57/479] Compiling CNIOLLHTTP c_nio_llhttp.c
+[58/479] Compiling CNIOBoringSSLShims shims.c
+[59/479] Compiling fiat_p256_adx_sqr.S
+[60/479] Compiling fiat_p256_adx_mul.S
+[61/479] Compiling fiat_curve25519_adx_square.S
+[62/479] Compiling fiat_curve25519_adx_mul.S
+[64/479] Compiling Logging Locks.swift
+[64/479] Compiling tls_method.cc
+[65/479] Compiling tls_record.cc
+[67/479] Compiling DequeModule Deque+Codable.swift
+[67/479] Compiling tls13_server.cc
+[68/479] Compiling tls13_enc.cc
+[69/479] Compiling tls13_client.cc
+[70/479] Compiling tls13_both.cc
+[71/479] Compiling t1_enc.cc
+[72/479] Compiling ssl_transcript.cc
+[73/479] Compiling ssl_versions.cc
+[74/479] Compiling ssl_x509.cc
+[75/479] Compiling ssl_stat.cc
+[76/479] Compiling ssl_privkey.cc
+[77/479] Compiling ssl_session.cc
+[78/479] Compiling ssl_key_share.cc
+[79/479] Compiling ssl_lib.cc
+[80/479] Compiling ssl_file.cc
+[81/479] Compiling ssl_credential.cc
+[82/479] Compiling ssl_cipher.cc
+[83/479] Compiling ssl_buffer.cc
+[84/479] Compiling ssl_cert.cc
+[85/479] Compiling s3_pkt.cc
+[86/479] Compiling ssl_asn1.cc
+[87/479] Compiling ssl_aead_ctx.cc
+[89/479] Compiling Yams AliasDereferencingStrategy.swift
+[89/479] Compiling s3_both.cc
+[90/479] Compiling s3_lib.cc
+[91/479] Compiling handshake.cc
+[92/479] Compiling handshake_server.cc
+[93/479] Compiling handoff.cc
+[94/479] Compiling handshake_client.cc
+[95/479] Compiling extensions.cc
+[96/479] Compiling d1_srtp.cc
+[97/479] Compiling dtls_method.cc
+[98/479] Compiling dtls_record.cc
+[99/479] Compiling encrypted_client_hello.cc
+[100/479] Compiling md5-x86_64-linux.S
+[101/479] Compiling md5-x86_64-apple.S
+[102/479] Compiling md5-586-linux.S
+[103/479] Compiling md5-586-apple.S
+[104/479] Compiling d1_pkt.cc
+[105/479] Compiling bio_ssl.cc
+[106/479] Compiling chacha20_poly1305_x86_64-apple.S
+[107/479] Compiling chacha20_poly1305_x86_64-linux.S
+[108/479] Compiling err_data.cc
+[109/479] Compiling chacha20_poly1305_armv8-linux.S
+[110/479] Compiling chacha20_poly1305_armv8-win.S
+[111/479] Compiling chacha20_poly1305_armv8-apple.S
+[112/479] Compiling chacha-x86_64-apple.S
+[113/479] Compiling chacha-x86_64-linux.S
+[114/479] Compiling chacha-x86-linux.S
+[115/479] Compiling chacha-x86-apple.S
+[116/479] Compiling chacha-armv8-win.S
+[117/479] Compiling d1_lib.cc
+[118/479] Compiling chacha-armv8-linux.S
+[119/479] Compiling chacha-armv8-apple.S
+[120/479] Compiling chacha-armv4-linux.S
+[121/479] Compiling aes128gcmsiv-x86_64-linux.S
+[122/479] Compiling aes128gcmsiv-x86_64-apple.S
+[123/479] Compiling x86_64-mont5-linux.S
+[124/479] Compiling x86_64-mont5-apple.S
+[125/479] Compiling x86_64-mont-linux.S
+[126/479] Compiling x86_64-mont-apple.S
+[127/479] Compiling d1_both.cc
+[128/479] Compiling x86-mont-linux.S
+[129/479] Compiling x86-mont-apple.S
+[130/479] Compiling vpaes-x86_64-linux.S
+[131/479] Compiling vpaes-x86-linux.S
+[132/479] Compiling vpaes-x86_64-apple.S
+[133/479] Compiling vpaes-x86-apple.S
+[134/479] Compiling vpaes-armv8-win.S
+[135/479] Compiling vpaes-armv8-linux.S
+[136/479] Compiling vpaes-armv7-linux.S
+[137/479] Compiling vpaes-armv8-apple.S
+[138/479] Compiling sha512-x86_64-linux.S
+[139/479] Compiling sha512-x86_64-apple.S
+[140/479] Compiling sha512-armv8-win.S
+[141/479] Compiling sha512-armv8-linux.S
+[142/479] Compiling sha512-armv8-apple.S
+[143/479] Compiling sha512-armv4-linux.S
+[144/479] Compiling sha512-586-linux.S
+[145/479] Compiling sha512-586-apple.S
+[146/479] Compiling sha256-x86_64-linux.S
+[147/479] Compiling sha256-x86_64-apple.S
+[148/479] Compiling sha256-armv8-win.S
+[149/479] Compiling sha256-armv8-linux.S
+[150/479] Compiling sha256-armv8-apple.S
+[151/479] Compiling sha256-armv4-linux.S
+[152/479] Compiling sha256-586-linux.S
+[153/479] Compiling sha256-586-apple.S
+[154/479] Compiling sha1-x86_64-linux.S
+[155/479] Compiling sha1-armv8-win.S
+[156/479] Compiling sha1-x86_64-apple.S
+[157/479] Compiling sha1-armv8-linux.S
+[158/479] Compiling sha1-armv8-apple.S
+[159/479] Compiling sha1-armv4-large-linux.S
+[160/479] Compiling sha1-586-linux.S
+[161/479] Compiling sha1-586-apple.S
+[162/479] Compiling rsaz-avx2-linux.S
+[163/479] Compiling rsaz-avx2-apple.S
+[164/479] Compiling rdrand-x86_64-apple.S
+[165/479] Compiling rdrand-x86_64-linux.S
+[166/479] Compiling p256_beeu-x86_64-asm-linux.S
+[167/479] Compiling p256_beeu-x86_64-asm-apple.S
+[168/479] Compiling p256_beeu-armv8-asm-win.S
+[169/479] Compiling p256_beeu-armv8-asm-apple.S
+[170/479] Compiling p256_beeu-armv8-asm-linux.S
+[171/479] Compiling p256-x86_64-asm-linux.S
+[172/479] Compiling p256-x86_64-asm-apple.S
+[173/479] Compiling p256-armv8-asm-win.S
+[174/479] Compiling p256-armv8-asm-linux.S
+[175/479] Compiling p256-armv8-asm-apple.S
+[176/479] Compiling ghashv8-armv8-win.S
+[177/479] Compiling ghashv8-armv8-apple.S
+[178/479] Compiling ghashv8-armv8-linux.S
+[179/479] Compiling ghashv8-armv7-linux.S
+[179/479] Compiling ghash-x86_64-linux.S
+[181/479] Compiling ghash-x86_64-apple.S
+[182/479] Compiling ghash-x86-apple.S
+[183/479] Compiling ghash-x86-linux.S
+[184/479] Compiling ghash-ssse3-x86_64-apple.S
+[185/479] Compiling ghash-ssse3-x86_64-linux.S
+[186/479] Compiling ghash-ssse3-x86-linux.S
+[187/479] Compiling ghash-neon-armv8-win.S
+[187/479] Compiling ghash-ssse3-x86-apple.S
+[189/479] Compiling ghash-neon-armv8-linux.S
+[190/479] Compiling ghash-neon-armv8-apple.S
+[191/479] Compiling ghash-armv4-linux.S
+[192/479] Compiling co-586-apple.S
+[193/479] Compiling co-586-linux.S
+[194/479] Compiling bsaes-armv7-linux.S
+[195/479] Compiling bn-armv8-win.S
+[196/479] Compiling bn-armv8-linux.S
+[197/479] Compiling bn-586-linux.S
+[198/479] Compiling bn-armv8-apple.S
+[199/479] Compiling bn-586-apple.S
+[200/479] Compiling armv8-mont-win.S
+[201/479] Compiling armv8-mont-linux.S
+[202/479] Compiling armv8-mont-apple.S
+[203/479] Compiling armv4-mont-linux.S
+[204/479] Compiling aesv8-gcm-armv8-linux.S
+[205/479] Compiling aesv8-gcm-armv8-win.S
+[206/479] Compiling aesv8-gcm-armv8-apple.S
+[207/479] Compiling aesv8-armv8-win.S
+[208/479] Compiling aesv8-armv8-linux.S
+[209/479] Compiling aesv8-armv7-linux.S
+[210/479] Compiling aesv8-armv8-apple.S
+[211/479] Compiling aesni-x86_64-linux.S
+[212/479] Compiling aesni-x86_64-apple.S
+[213/479] Compiling aesni-x86-linux.S
+[214/479] Compiling aesni-x86-apple.S
+[215/479] Compiling aesni-gcm-x86_64-linux.S
+[216/479] Compiling aesni-gcm-x86_64-apple.S
+[217/479] Compiling aes-gcm-avx2-x86_64-linux.S
+[218/479] Compiling aes-gcm-avx2-x86_64-apple.S
+[219/479] Compiling aes-gcm-avx10-x86_64-linux.S
+[220/479] Compiling aes-gcm-avx10-x86_64-apple.S
+[221/479] Compiling x_val.cc
+[222/479] Compiling x_x509a.cc
+[223/479] Compiling x_sig.cc
+[224/479] Compiling x_spki.cc
+[225/479] Compiling x_x509.cc
+[226/479] Compiling x_req.cc
+[227/479] Compiling x_exten.cc
+[228/479] Compiling x_pubkey.cc
+[229/479] Compiling x_crl.cc
+[230/479] Compiling x_name.cc
+[231/479] Compiling x_attrib.cc
+[232/479] Compiling x_algor.cc
+[233/479] Compiling x509spki.cc
+[234/479] Compiling x509rset.cc
+[235/479] Compiling x_all.cc
+[236/479] Compiling x509name.cc
+[237/479] Compiling x509cset.cc
+[238/479] Compiling x509_vpm.cc
+[239/479] Compiling x509_v3.cc
+[240/479] Compiling x509_vfy.cc
+[241/479] Compiling x509_txt.cc
+[242/479] Compiling x509_trs.cc
+[243/479] Compiling x509_set.cc
+[244/479] Compiling x509_req.cc
+[245/479] Compiling x509_obj.cc
+[246/479] Compiling x509_lu.cc
+[247/479] Compiling x509_def.cc
+[248/479] Compiling x509_ext.cc
+[249/479] Compiling x509_d2.cc
+[250/479] Compiling x509_cmp.cc
+[251/479] Compiling x509.cc
+[252/479] Compiling x509_att.cc
+[253/479] Compiling v3_skey.cc
+[254/479] Compiling v3_utl.cc
+[255/479] Compiling v3_purp.cc
+[256/479] Compiling v3_prn.cc
+[257/479] Compiling v3_pmaps.cc
+[258/479] Compiling v3_pcons.cc
+[259/479] Compiling v3_ocsp.cc
+[260/479] Compiling v3_ncons.cc
+[261/479] Compiling v3_int.cc
+[262/479] Compiling v3_lib.cc
+[263/479] Compiling v3_info.cc
+[264/479] Compiling v3_ia5.cc
+[265/479] Compiling v3_extku.cc
+[266/479] Compiling v3_genn.cc
+[267/479] Compiling v3_enum.cc
+[268/479] Compiling v3_crld.cc
+[269/479] Compiling v3_cpols.cc
+[270/479] Compiling v3_bitst.cc
+[271/479] Compiling v3_conf.cc
+[272/479] Compiling v3_bcons.cc
+[273/479] Compiling v3_alt.cc
+[274/479] Compiling v3_akeya.cc
+[275/479] Compiling v3_akey.cc
+[276/479] Compiling t_x509a.cc
+[277/479] Compiling t_x509.cc
+[278/479] Compiling t_crl.cc
+[279/479] Compiling t_req.cc
+[280/479] Compiling rsa_pss.cc
+[281/479] Compiling name_print.cc
+[282/479] Compiling policy.cc
+[283/479] Compiling i2d_pr.cc
+[284/479] Compiling by_file.cc
+[285/479] Compiling by_dir.cc
+[286/479] Compiling asn1_gen.cc
+[287/479] Compiling algorithm.cc
+[288/479] Compiling a_verify.cc
+[289/479] Compiling a_sign.cc
+[290/479] Compiling a_digest.cc
+[291/479] Compiling trust_token.cc
+[292/479] Compiling voprf.cc
+[293/479] Compiling thread_win.cc
+[294/479] Compiling pmbtoken.cc
+[295/479] Compiling thread_pthread.cc
+[296/479] Compiling thread_none.cc
+[297/479] Compiling thread.cc
+[298/479] Compiling stack.cc
+[299/479] Compiling sha512.cc
+[300/479] Compiling slhdsa.cc
+[301/479] Compiling siphash.cc
+[302/479] Compiling spake2plus.cc
+[303/479] Compiling sha256.cc
+[304/479] Compiling sha1.cc
+[305/479] Compiling rsa_print.cc
+[306/479] Compiling rsa_extra.cc
+[307/479] Compiling rsa_crypt.cc
+[308/479] Compiling rc4.cc
+[309/479] Compiling refcount.cc
+[310/479] Compiling rsa_asn1.cc
+[311/479] Compiling windows.cc
+[312/479] Compiling trusty.cc
+[313/479] Compiling rand.cc
+[314/479] Compiling ios.cc
+[315/479] Compiling urandom.cc
+[316/479] Compiling passive.cc
+[317/479] Compiling getentropy.cc
+[318/479] Compiling forkunsafe.cc
+[319/479] Compiling deterministic.cc
+[320/479] Compiling fork_detect.cc
+[321/479] Compiling poly1305_arm_asm.S
+[322/479] Compiling pool.cc
+[323/479] Compiling poly1305_arm.cc
+[324/479] Compiling poly1305.cc
+[325/479] Compiling poly1305_vec.cc
+[326/479] Compiling pkcs7.cc
+[327/479] Compiling pkcs8.cc
+[328/479] Compiling pkcs8_x509.cc
+[329/479] Compiling p5_pbev2.cc
+[330/479] Compiling pkcs7_x509.cc
+[331/479] Compiling pem_x509.cc
+[332/479] Compiling pem_xaux.cc
+[333/479] Compiling pem_pkey.cc
+[334/479] Compiling pem_pk8.cc
+[335/479] Compiling pem_oth.cc
+[336/479] Compiling obj_xref.cc
+[337/479] Compiling pem_info.cc
+[338/479] Compiling pem_lib.cc
+[339/479] Compiling pem_all.cc
+[340/479] Compiling obj.cc
+[341/479] Compiling mlkem.cc
+[342/479] Compiling mldsa.cc
+[343/479] Compiling md5.cc
+[344/479] Compiling md4.cc
+[345/479] Compiling mem.cc
+[346/479] Compiling lhash.cc
+[347/479] Compiling fips_shared_support.cc
+[348/479] Compiling poly_rq_mul.S
+[349/479] Compiling kyber.cc
+[350/479] Compiling ex_data.cc
+[351/479] Compiling hpke.cc
+[352/479] Compiling sign.cc
+[353/479] Compiling scrypt.cc
+[354/479] Compiling hrss.cc
+[355/479] Compiling print.cc
+[356/479] Compiling pbkdf.cc
+[357/479] Compiling p_x25519.cc
+[358/479] Compiling p_x25519_asn1.cc
+[359/479] Compiling p_rsa_asn1.cc
+[360/479] Compiling p_hkdf.cc
+[361/479] Compiling p_rsa.cc
+[362/479] Compiling p_ed25519_asn1.cc
+[363/479] Compiling p_ed25519.cc
+[364/479] Compiling p_ec_asn1.cc
+[365/479] Compiling p_ec.cc
+[366/479] Compiling p_dh_asn1.cc
+[367/479] Compiling p_dsa_asn1.cc
+[368/479] Compiling p_dh.cc
+[369/479] Compiling evp_ctx.cc
+[370/479] Compiling evp.cc
+[371/479] Compiling err.cc
+[372/479] Compiling evp_asn1.cc
+[373/479] Compiling engine.cc
+[374/479] Compiling ecdh.cc
+[375/479] Compiling ecdsa_asn1.cc
+[376/479] Compiling ec_derive.cc
+[377/479] Compiling hash_to_curve.cc
+[378/479] Compiling dsa_asn1.cc
+[379/479] Compiling ec_asn1.cc
+[380/479] Compiling dsa.cc
+[381/479] Compiling digest_extra.cc
+[382/479] Compiling params.cc
+[383/479] Compiling dh_asn1.cc
+[384/479] Compiling spake25519.cc
+[385/479] Compiling x25519-asm-arm.S
+[386/479] Compiling des.cc
+[387/479] Compiling crypto.cc
+[388/479] Compiling cpu_intel.cc
+[389/479] Compiling curve25519_64_adx.cc
+[390/479] Compiling cpu_arm_linux.cc
+[391/479] Compiling cpu_arm_freebsd.cc
+[392/479] Compiling curve25519.cc
+[393/479] Compiling cpu_aarch64_win.cc
+[394/479] Compiling cpu_aarch64_sysreg.cc
+[395/479] Compiling cpu_aarch64_openbsd.cc
+[396/479] Compiling cpu_aarch64_linux.cc
+[397/479] Compiling cpu_aarch64_fuchsia.cc
+[398/479] Compiling cpu_aarch64_apple.cc
+[399/479] Compiling conf.cc
+[400/479] Compiling tls_cbc.cc
+[401/479] Compiling get_cipher.cc
+[402/479] Compiling e_tls.cc
+[403/479] Compiling e_rc4.cc
+[404/479] Compiling e_null.cc
+[405/479] Compiling e_rc2.cc
+[406/479] Compiling e_des.cc
+[407/479] Compiling e_chacha20poly1305.cc
+[408/479] Compiling e_aesctrhmac.cc
+[409/479] Compiling derive_key.cc
+[410/479] Compiling e_aesgcmsiv.cc
+[411/479] Compiling chacha.cc
+[412/479] Compiling unicode.cc
+[413/479] Compiling ber.cc
+[414/479] Compiling cbb.cc
+[415/479] Compiling cbs.cc
+[416/479] Compiling asn1_compat.cc
+[417/479] Compiling buf.cc
+[418/479] Compiling bn_asn1.cc
+[419/479] Compiling convert.cc
+[420/479] Compiling blake2.cc
+[421/479] Compiling socket_helper.cc
+[422/479] Compiling socket.cc
+[423/479] Compiling printf.cc
+[424/479] Compiling pair.cc
+[425/479] Compiling hexdump.cc
+[426/479] Compiling file.cc
+[427/479] Compiling fd.cc
+[428/479] Compiling errno.cc
+[429/479] Compiling connect.cc
+[430/479] Compiling bio_mem.cc
+[431/479] Compiling base64.cc
+[432/479] Compiling bio.cc
+[433/479] Compiling tasn_typ.cc
+[434/479] Compiling tasn_utl.cc
+[435/479] Compiling tasn_fre.cc
+[436/479] Compiling tasn_new.cc
+[437/479] Compiling posix_time.cc
+[438/479] Compiling f_string.cc
+[439/479] Compiling tasn_enc.cc
+[440/479] Compiling tasn_dec.cc
+[441/479] Compiling f_int.cc
+[442/479] Compiling asn1_par.cc
+[443/479] Compiling asn_pack.cc
+[444/479] Compiling asn1_lib.cc
+[445/479] Compiling a_type.cc
+[446/479] Compiling a_time.cc
+[447/479] Compiling a_utctm.cc
+[448/479] Compiling a_strnid.cc
+[449/479] Compiling a_octet.cc
+[450/479] Compiling a_strex.cc
+[451/479] Compiling a_object.cc
+[452/479] Compiling a_mbstr.cc
+[453/479] Compiling a_i2d_fp.cc
+[454/479] Compiling a_int.cc
+[455/479] Compiling a_gentm.cc
+[456/479] Compiling a_dup.cc
+[457/479] Compiling a_d2i_fp.cc
+[458/479] Compiling a_bool.cc
+[459/479] Compiling CAsyncHTTPClient CAsyncHTTPClient.c
+[460/479] Write sources
+[461/479] Compiling a_bitstr.cc
+[462/479] Write sources
+[464/481] Compiling c-nioatomics.c
+[465/481] Compiling c-atomics.c
+[466/482] Compiling bcm.cc
+[468/482] Compiling NIOConcurrencyHelpers NIOAtomic.swift
+[469/482] Compiling Atomics OptionalRawRepresentable.swift
+[470/483] Compiling Algorithms AdjacentPairs.swift
+[471/483] Compiling NIOCore AddressedEnvelope.swift
+[472/485] Compiling NIOEmbedded AsyncTestingChannel.swift
+[473/485] Compiling NIOPosix BSDSocketAPICommon.swift
+[474/486] Compiling NIO Exports.swift
+[475/490] Compiling NIOFoundationCompat ByteBuffer-foundation.swift
+[476/490] Compiling NIOTLS ApplicationProtocolNegotiationHandler.swift
+[477/492] Compiling NIOSOCKS SOCKSClientHandler.swift
+[478/492] Compiling NIOTransportServices AcceptHandler.swift
+Building for production...
+[0/470] Write sources
+[32/470] Compiling _NumericsShims _NumericsShims.c
+[33/470] Compiling _AtomicsShims.c
+[34/470] Compiling writer.c
+[35/470] Compiling reader.c
+[36/470] Compiling parser.c
+[37/470] Compiling CNIOWindows shim.c
+[38/470] Compiling CNIOWindows WSAStartup.c
+[39/470] Compiling CNIOWASI CNIOWASI.c
+[40/470] Compiling api.c
+[41/470] Compiling CNIOPosix event_loop_id.c
+[42/470] Compiling CNIOLinux liburing_shims.c
+[43/470] Compiling CNIOLinux shim.c
+[44/470] Compiling CNIOLLHTTP c_nio_http.c
+[45/470] Compiling emitter.c
+[46/470] Compiling CNIOExtrasZlib empty.c
+[47/470] Compiling CNIOLLHTTP c_nio_api.c
+[48/470] Compiling CNIODarwin shim.c
+[49/470] Write swift-version--4EAD98957C2213E4.txt
+[50/470] Compiling scanner.c
+[51/470] Compiling fiat_p256_adx_sqr.S
+[52/470] Compiling fiat_p256_adx_mul.S
+[53/472] Compiling CNIOBoringSSLShims shims.c
+[54/474] Compiling CNIOLLHTTP c_nio_llhttp.c
+[56/475] Compiling _NIOBase64 Base64.swift
+[57/476] Compiling _NIODataStructures Heap.swift
+[58/477] Compiling RealModule AlgebraicField.swift
+[58/477] Compiling fiat_curve25519_adx_square.S
+[60/477] Compiling FountainCore Models.swift
+[60/477] Compiling fiat_curve25519_adx_mul.S
+[62/478] Compiling FountainCoreTests FountainCoreTests.swift
+[63/478] Compiling InternalCollectionsUtilities FixedWidthInteger+roundUpToPowerOfTwo.swift
+[63/478] Compiling tls_record.cc
+[65/478] Compiling Logging Locks.swift
+[65/479] Compiling tls_method.cc
+[66/479] Compiling tls13_server.cc
+[67/479] Compiling tls13_enc.cc
+[69/479] Compiling DequeModule Deque+Codable.swift
+[69/479] Compiling tls13_client.cc
+[70/479] Compiling t1_enc.cc
+[71/479] Compiling tls13_both.cc
+[72/479] Compiling ssl_x509.cc
+[73/479] Compiling ssl_versions.cc
+[74/479] Compiling ssl_transcript.cc
+[75/479] Compiling ssl_stat.cc
+[76/479] Compiling ssl_privkey.cc
+[77/479] Compiling ssl_session.cc
+[78/479] Compiling ssl_key_share.cc
+[79/479] Compiling ssl_file.cc
+[80/479] Compiling ssl_lib.cc
+[81/479] Compiling ssl_credential.cc
+[82/479] Compiling ssl_cipher.cc
+[84/479] Compiling Yams AliasDereferencingStrategy.swift
+[84/479] Compiling ssl_buffer.cc
+[85/479] Compiling ssl_asn1.cc
+[86/479] Compiling ssl_cert.cc
+[87/479] Compiling ssl_aead_ctx.cc
+[88/479] Compiling s3_pkt.cc
+[89/479] Compiling s3_lib.cc
+[90/479] Compiling s3_both.cc
+[91/479] Compiling handshake_server.cc
+[92/479] Compiling handshake.cc
+[93/479] Compiling handshake_client.cc
+[94/479] Compiling handoff.cc
+[95/479] Compiling dtls_record.cc
+[96/479] Compiling encrypted_client_hello.cc
+[97/479] Compiling dtls_method.cc
+[98/479] Compiling extensions.cc
+[99/479] Compiling d1_srtp.cc
+[100/479] Compiling md5-x86_64-linux.S
+[101/479] Compiling md5-x86_64-apple.S
+[102/479] Compiling md5-586-linux.S
+[103/479] Compiling bio_ssl.cc
+[104/479] Compiling md5-586-apple.S
+[105/479] Compiling chacha20_poly1305_x86_64-linux.S
+[106/479] Compiling d1_pkt.cc
+[107/479] Compiling err_data.cc
+[108/479] Compiling chacha20_poly1305_armv8-win.S
+[109/479] Compiling chacha20_poly1305_x86_64-apple.S
+[110/479] Compiling chacha20_poly1305_armv8-linux.S
+[111/479] Compiling d1_lib.cc
+[112/479] Compiling chacha20_poly1305_armv8-apple.S
+[113/479] Compiling chacha-x86_64-linux.S
+[114/479] Compiling chacha-x86_64-apple.S
+[115/479] Compiling chacha-x86-linux.S
+[116/479] Compiling chacha-x86-apple.S
+[117/479] Compiling chacha-armv8-win.S
+[118/479] Compiling chacha-armv8-linux.S
+[119/479] Compiling chacha-armv8-apple.S
+[120/479] Compiling chacha-armv4-linux.S
+[121/479] Compiling aes128gcmsiv-x86_64-linux.S
+[122/479] Compiling aes128gcmsiv-x86_64-apple.S
+[123/479] Compiling d1_both.cc
+[124/479] Compiling x86_64-mont5-linux.S
+[125/479] Compiling x86_64-mont5-apple.S
+[126/479] Compiling x86_64-mont-linux.S
+[127/479] Compiling x86_64-mont-apple.S
+[128/479] Compiling x86-mont-linux.S
+[129/479] Compiling x86-mont-apple.S
+[130/479] Compiling vpaes-x86_64-apple.S
+[131/479] Compiling vpaes-x86_64-linux.S
+[132/479] Compiling vpaes-x86-linux.S
+[133/479] Compiling vpaes-x86-apple.S
+[134/479] Compiling vpaes-armv8-win.S
+[135/479] Compiling vpaes-armv8-apple.S
+[135/479] Compiling vpaes-armv8-linux.S
+[137/479] Compiling vpaes-armv7-linux.S
+[138/479] Compiling sha512-x86_64-linux.S
+[139/479] Compiling sha512-x86_64-apple.S
+[140/479] Compiling sha512-armv8-linux.S
+[141/479] Compiling sha512-armv8-win.S
+[142/479] Compiling sha512-armv8-apple.S
+[143/479] Compiling sha512-armv4-linux.S
+[144/479] Compiling sha512-586-linux.S
+[145/479] Compiling sha512-586-apple.S
+[146/479] Compiling sha256-x86_64-linux.S
+[147/479] Compiling sha256-x86_64-apple.S
+[148/479] Compiling sha256-armv8-win.S
+[149/479] Compiling sha256-armv8-linux.S
+[150/479] Compiling sha256-armv8-apple.S
+[151/479] Compiling sha256-armv4-linux.S
+[152/479] Compiling sha256-586-linux.S
+[153/479] Compiling sha256-586-apple.S
+[154/479] Compiling sha1-x86_64-linux.S
+[155/479] Compiling sha1-x86_64-apple.S
+[156/479] Compiling sha1-armv8-win.S
+[157/479] Compiling sha1-armv8-linux.S
+[158/479] Compiling sha1-armv8-apple.S
+[159/479] Compiling sha1-armv4-large-linux.S
+[160/479] Compiling sha1-586-linux.S
+[161/479] Compiling sha1-586-apple.S
+[162/479] Compiling rsaz-avx2-linux.S
+[163/479] Compiling rsaz-avx2-apple.S
+[164/479] Compiling rdrand-x86_64-linux.S
+[165/479] Compiling rdrand-x86_64-apple.S
+[166/479] Compiling p256_beeu-x86_64-asm-linux.S
+[167/479] Compiling p256_beeu-x86_64-asm-apple.S
+[168/479] Compiling p256_beeu-armv8-asm-win.S
+[169/479] Compiling p256_beeu-armv8-asm-linux.S
+[170/479] Compiling p256_beeu-armv8-asm-apple.S
+[171/479] Compiling p256-x86_64-asm-linux.S
+[172/479] Compiling p256-armv8-asm-win.S
+[173/479] Compiling p256-x86_64-asm-apple.S
+[174/479] Compiling p256-armv8-asm-linux.S
+[175/479] Compiling p256-armv8-asm-apple.S
+[176/479] Compiling ghashv8-armv8-win.S
+[177/479] Compiling ghashv8-armv8-apple.S
+[178/479] Compiling ghashv8-armv8-linux.S
+[179/479] Compiling ghashv8-armv7-linux.S
+[180/479] Compiling ghash-x86_64-linux.S
+[181/479] Compiling ghash-x86_64-apple.S
+[182/479] Compiling ghash-x86-linux.S
+[183/479] Compiling ghash-x86-apple.S
+[184/479] Compiling ghash-ssse3-x86_64-linux.S
+[185/479] Compiling ghash-ssse3-x86_64-apple.S
+[186/479] Compiling ghash-ssse3-x86-linux.S
+[187/479] Compiling ghash-ssse3-x86-apple.S
+[188/479] Compiling ghash-neon-armv8-win.S
+[189/479] Compiling ghash-neon-armv8-linux.S
+[190/479] Compiling ghash-neon-armv8-apple.S
+[191/479] Compiling ghash-armv4-linux.S
+[192/479] Compiling co-586-apple.S
+[193/479] Compiling co-586-linux.S
+[194/479] Compiling bsaes-armv7-linux.S
+[195/479] Compiling bn-armv8-win.S
+[196/479] Compiling bn-armv8-linux.S
+[197/479] Compiling bn-armv8-apple.S
+[198/479] Compiling bn-586-linux.S
+[199/479] Compiling armv8-mont-win.S
+[200/479] Compiling bn-586-apple.S
+[201/479] Compiling armv8-mont-linux.S
+[202/479] Compiling armv8-mont-apple.S
+[203/479] Compiling armv4-mont-linux.S
+[204/479] Compiling aesv8-gcm-armv8-win.S
+[205/479] Compiling aesv8-gcm-armv8-linux.S
+[206/479] Compiling aesv8-gcm-armv8-apple.S
+[207/479] Compiling aesv8-armv8-win.S
+[208/479] Compiling aesv8-armv8-linux.S
+[209/479] Compiling aesv8-armv7-linux.S
+[210/479] Compiling aesv8-armv8-apple.S
+[211/479] Compiling aesni-x86_64-linux.S
+[212/479] Compiling aesni-x86_64-apple.S
+[213/479] Compiling aesni-x86-linux.S
+[214/479] Compiling aesni-x86-apple.S
+[215/479] Compiling aesni-gcm-x86_64-linux.S
+[216/479] Compiling aesni-gcm-x86_64-apple.S
+[217/479] Compiling aes-gcm-avx2-x86_64-apple.S
+[218/479] Compiling aes-gcm-avx2-x86_64-linux.S
+[219/479] Compiling aes-gcm-avx10-x86_64-linux.S
+[220/479] Compiling aes-gcm-avx10-x86_64-apple.S
+[221/479] Compiling x_x509a.cc
+[222/479] Compiling x_sig.cc
+[223/479] Compiling x_val.cc
+[224/479] Compiling x_spki.cc
+[225/479] Compiling x_x509.cc
+[226/479] Compiling x_req.cc
+[227/479] Compiling x_pubkey.cc
+[228/479] Compiling x_name.cc
+[229/479] Compiling x_exten.cc
+[230/479] Compiling x_crl.cc
+[231/479] Compiling x_attrib.cc
+[232/479] Compiling x_algor.cc
+[233/479] Compiling x509spki.cc
+[234/479] Compiling x_all.cc
+[235/479] Compiling x509rset.cc
+[236/479] Compiling x509name.cc
+[237/479] Compiling x509cset.cc
+[238/479] Compiling x509_vpm.cc
+[239/479] Compiling x509_v3.cc
+[240/479] Compiling x509_vfy.cc
+[241/479] Compiling x509_txt.cc
+[242/479] Compiling x509_trs.cc
+[243/479] Compiling x509_set.cc
+[244/479] Compiling x509_req.cc
+[245/479] Compiling x509_obj.cc
+[246/479] Compiling x509_lu.cc
+[247/479] Compiling x509_ext.cc
+[248/479] Compiling x509_def.cc
+[249/479] Compiling x509_d2.cc
+[250/479] Compiling x509_cmp.cc
+[251/479] Compiling x509.cc
+[252/479] Compiling x509_att.cc
+[253/479] Compiling v3_skey.cc
+[254/479] Compiling v3_utl.cc
+[255/479] Compiling v3_purp.cc
+[256/479] Compiling v3_prn.cc
+[257/479] Compiling v3_pmaps.cc
+[258/479] Compiling v3_pcons.cc
+[259/479] Compiling v3_ocsp.cc
+[260/479] Compiling v3_ncons.cc
+[261/479] Compiling v3_int.cc
+[262/479] Compiling v3_lib.cc
+[263/479] Compiling v3_info.cc
+[264/479] Compiling v3_ia5.cc
+[265/479] Compiling v3_genn.cc
+[266/479] Compiling v3_extku.cc
+[267/479] Compiling v3_enum.cc
+[268/479] Compiling v3_crld.cc
+[269/479] Compiling v3_cpols.cc
+[270/479] Compiling v3_bitst.cc
+[271/479] Compiling v3_conf.cc
+[272/479] Compiling v3_bcons.cc
+[273/479] Compiling v3_alt.cc
+[274/479] Compiling v3_akeya.cc
+[275/479] Compiling v3_akey.cc
+[276/479] Compiling t_x509a.cc
+[277/479] Compiling t_x509.cc
+[278/479] Compiling t_crl.cc
+[279/479] Compiling t_req.cc
+[280/479] Compiling rsa_pss.cc
+[281/479] Compiling name_print.cc
+[282/479] Compiling i2d_pr.cc
+[283/479] Compiling policy.cc
+[284/479] Compiling by_file.cc
+[285/479] Compiling by_dir.cc
+[286/479] Compiling algorithm.cc
+[287/479] Compiling asn1_gen.cc
+[288/479] Compiling a_verify.cc
+[289/479] Compiling a_sign.cc
+[290/479] Compiling trust_token.cc
+[291/479] Compiling a_digest.cc
+[292/479] Compiling thread_win.cc
+[293/479] Compiling voprf.cc
+[294/479] Compiling pmbtoken.cc
+[295/479] Compiling thread.cc
+[296/479] Compiling thread_pthread.cc
+[297/479] Compiling thread_none.cc
+[298/479] Compiling stack.cc
+[299/479] Compiling sha512.cc
+[300/479] Compiling slhdsa.cc
+[301/479] Compiling siphash.cc
+[302/479] Compiling sha256.cc
+[303/479] Compiling spake2plus.cc
+[304/479] Compiling sha1.cc
+[305/479] Compiling rsa_extra.cc
+[306/479] Compiling rsa_print.cc
+[307/479] Compiling rc4.cc
+[308/479] Compiling rsa_asn1.cc
+[309/479] Compiling rsa_crypt.cc
+[310/479] Compiling refcount.cc
+[311/479] Compiling windows.cc
+[312/479] Compiling trusty.cc
+[313/479] Compiling rand.cc
+[314/479] Compiling ios.cc
+[315/479] Compiling urandom.cc
+[316/479] Compiling passive.cc
+[317/479] Compiling getentropy.cc
+[318/479] Compiling deterministic.cc
+[319/479] Compiling forkunsafe.cc
+[320/479] Compiling fork_detect.cc
+[321/479] Compiling poly1305_arm_asm.S
+[322/479] Compiling pool.cc
+[323/479] Compiling poly1305_arm.cc
+[324/479] Compiling poly1305.cc
+[325/479] Compiling poly1305_vec.cc
+[326/479] Compiling pkcs7.cc
+[327/479] Compiling pkcs8.cc
+[328/479] Compiling pkcs8_x509.cc
+[329/479] Compiling p5_pbev2.cc
+[330/479] Compiling pkcs7_x509.cc
+[331/479] Compiling pem_xaux.cc
+[332/479] Compiling pem_x509.cc
+[333/479] Compiling pem_pkey.cc
+[334/479] Compiling pem_pk8.cc
+[335/479] Compiling pem_oth.cc
+[336/479] Compiling obj_xref.cc
+[337/479] Compiling pem_info.cc
+[338/479] Compiling obj.cc
+[339/479] Compiling pem_all.cc
+[340/479] Compiling pem_lib.cc
+[341/479] Compiling mlkem.cc
+[342/479] Compiling mldsa.cc
+[343/479] Compiling md5.cc
+[344/479] Compiling md4.cc
+[345/479] Compiling mem.cc
+[346/479] Compiling lhash.cc
+[347/479] Compiling fips_shared_support.cc
+[348/479] Compiling poly_rq_mul.S
+[349/479] Compiling ex_data.cc
+[350/479] Compiling kyber.cc
+[351/479] Compiling hpke.cc
+[352/479] Compiling sign.cc
+[353/479] Compiling hrss.cc
+[354/479] Compiling scrypt.cc
+[355/479] Compiling print.cc
+[356/479] Compiling pbkdf.cc
+[357/479] Compiling p_x25519.cc
+[358/479] Compiling p_x25519_asn1.cc
+[359/479] Compiling p_rsa_asn1.cc
+[360/479] Compiling p_rsa.cc
+[361/479] Compiling p_hkdf.cc
+[362/479] Compiling p_ed25519_asn1.cc
+[363/479] Compiling p_ed25519.cc
+[364/479] Compiling p_ec.cc
+[365/479] Compiling p_ec_asn1.cc
+[366/479] Compiling p_dh_asn1.cc
+[367/479] Compiling p_dsa_asn1.cc
+[368/479] Compiling p_dh.cc
+[369/479] Compiling evp_ctx.cc
+[370/479] Compiling evp.cc
+[371/479] Compiling evp_asn1.cc
+[372/479] Compiling engine.cc
+[373/479] Compiling err.cc
+[374/479] Compiling ecdsa_asn1.cc
+[375/479] Compiling ecdh.cc
+[376/479] Compiling ec_derive.cc
+[377/479] Compiling hash_to_curve.cc
+[378/479] Compiling dsa_asn1.cc
+[379/479] Compiling ec_asn1.cc
+[380/479] Compiling dsa.cc
+[381/479] Compiling digest_extra.cc
+[382/479] Compiling params.cc
+[383/479] Compiling dh_asn1.cc
+[384/479] Compiling spake25519.cc
+[385/479] Compiling x25519-asm-arm.S
+[386/479] Compiling des.cc
+[387/479] Compiling crypto.cc
+[388/479] Compiling cpu_intel.cc
+[389/479] Compiling curve25519_64_adx.cc
+[390/479] Compiling cpu_arm_linux.cc
+[391/479] Compiling cpu_arm_freebsd.cc
+[392/479] Compiling curve25519.cc
+[393/479] Compiling cpu_aarch64_win.cc
+[394/479] Compiling cpu_aarch64_openbsd.cc
+[395/479] Compiling cpu_aarch64_sysreg.cc
+[396/479] Compiling cpu_aarch64_linux.cc
+[397/479] Compiling cpu_aarch64_fuchsia.cc
+[398/479] Compiling cpu_aarch64_apple.cc
+[399/479] Compiling conf.cc
+[400/479] Compiling tls_cbc.cc
+[401/479] Compiling get_cipher.cc
+[402/479] Compiling e_tls.cc
+[403/479] Compiling e_rc4.cc
+[404/479] Compiling e_rc2.cc
+[405/479] Compiling e_null.cc
+[406/479] Compiling e_des.cc
+[407/479] Compiling e_chacha20poly1305.cc
+[408/479] Compiling e_aesgcmsiv.cc
+[409/479] Compiling derive_key.cc
+[410/479] Compiling e_aesctrhmac.cc
+[411/479] Compiling chacha.cc
+[412/479] Compiling unicode.cc
+[413/479] Compiling cbb.cc
+[414/479] Compiling cbs.cc
+[415/479] Compiling ber.cc
+[416/479] Compiling asn1_compat.cc
+[417/479] Compiling buf.cc
+[418/479] Compiling bn_asn1.cc
+[419/479] Compiling convert.cc
+[420/479] Compiling blake2.cc
+[421/479] Compiling socket_helper.cc
+[422/479] Compiling socket.cc
+[423/479] Compiling printf.cc
+[424/479] Compiling pair.cc
+[425/479] Compiling hexdump.cc
+[426/479] Compiling file.cc
+[427/479] Compiling fd.cc
+[428/479] Compiling errno.cc
+[429/479] Compiling connect.cc
+[430/479] Compiling bio_mem.cc
+[431/479] Compiling base64.cc
+[432/479] Compiling bio.cc
+[433/479] Compiling tasn_typ.cc
+[434/479] Compiling tasn_utl.cc
+[435/479] Compiling tasn_fre.cc
+[436/479] Compiling tasn_new.cc
+[437/479] Compiling tasn_enc.cc
+[438/479] Compiling posix_time.cc
+[439/479] Compiling f_string.cc
+[440/479] Compiling tasn_dec.cc
+[441/479] Compiling f_int.cc
+[442/479] Compiling asn_pack.cc
+[443/479] Compiling asn1_par.cc
+[444/479] Compiling asn1_lib.cc
+[445/479] Compiling a_utctm.cc
+[446/479] Compiling a_type.cc
+[447/479] Compiling a_time.cc
+[448/479] Compiling a_strnid.cc
+[449/479] Compiling a_octet.cc
+[450/479] Compiling a_strex.cc
+[451/479] Compiling a_object.cc
+[452/479] Compiling a_mbstr.cc
+[453/479] Compiling a_i2d_fp.cc
+[454/479] Compiling a_int.cc
+[455/479] Compiling a_gentm.cc
+[456/479] Compiling a_dup.cc
+[457/479] Compiling a_d2i_fp.cc
+[458/479] Compiling a_bool.cc
+[459/479] Compiling CAsyncHTTPClient CAsyncHTTPClient.c
+[459/479] Write sources
+[463/479] Compiling a_bitstr.cc
+[464/481] Compiling c-nioatomics.c
+[465/481] Compiling c-atomics.c
+[466/481] Compiling bcm.cc
+[468/482] Compiling NIOConcurrencyHelpers NIOAtomic.swift
+[469/482] Compiling Atomics OptionalRawRepresentable.swift
+[470/483] Compiling Algorithms AdjacentPairs.swift
+[471/483] Compiling NIOCore AddressedEnvelope.swift
+[472/485] Compiling NIOEmbedded AsyncTestingChannel.swift
+[473/485] Compiling NIOPosix BSDSocketAPICommon.swift
+[474/486] Compiling NIO Exports.swift
+[475/490] Compiling NIOFoundationCompat ByteBuffer-foundation.swift
+[476/490] Compiling NIOTLS ApplicationProtocolNegotiationHandler.swift
+[477/492] Compiling NIOSOCKS SOCKSClientHandler.swift
+[478/492] Compiling NIOTransportServices AcceptHandler.swift
+[479/492] Compiling NIOHTTP1 ByteCollectionUtils.swift
+[480/494] Compiling NIOSSL AndroidCABundle.swift
+[481/494] Compiling NIOHTTPCompression HTTPCompression.swift
+[482/494] Compiling NIOHPACK DynamicHeaderTable.swift
+[483/495] Compiling NIOHTTP2 ConnectionStateMachine.swift
+[484/496] Compiling AsyncHTTPClient AnyAsyncSequence.swift
+[485/497] Compiling FountainCodex ClientGenerator.swift
+[486/500] Compiling clientgen_service main.swift
+[486/500] Write Objects.LinkFileList
+[488/500] Compiling ClientGeneratorTests ClientGeneratorTests.swift
+/workspace/codex-deployer/Tests/ClientGeneratorTests/SpecValidatorTests.swift:6:13: warning: variable 'op' was never mutated; consider changing to 'let' constant
+ 4 | final class SpecValidatorTests: XCTestCase {
+ 5 |     func testDuplicateOperationIdThrows() throws {
+ 6 |         var op = OpenAPISpec.Operation(operationId: "op", parameters: nil, requestBody: nil, responses: nil, security: nil)
+   |             `- warning: variable 'op' was never mutated; consider changing to 'let' constant
+ 7 |         let item = OpenAPISpec.PathItem(get: op, post: nil, put: nil, delete: nil)
+ 8 |         var spec = OpenAPISpec(title: "API", servers: nil, components: nil, paths: [
+
+/workspace/codex-deployer/Tests/ClientGeneratorTests/SpecValidatorTests.swift:8:13: warning: variable 'spec' was never mutated; consider changing to 'let' constant
+ 6 |         var op = OpenAPISpec.Operation(operationId: "op", parameters: nil, requestBody: nil, responses: nil, security: nil)
+ 7 |         let item = OpenAPISpec.PathItem(get: op, post: nil, put: nil, delete: nil)
+ 8 |         var spec = OpenAPISpec(title: "API", servers: nil, components: nil, paths: [
+   |             `- warning: variable 'spec' was never mutated; consider changing to 'let' constant
+ 9 |             "/a": item,
+10 |             "/b": item
+
+/workspace/codex-deployer/Tests/ClientGeneratorTests/SpecValidatorTests.swift:18:13: warning: variable 'paramSchema' was never mutated; consider changing to 'let' constant
+16 | 
+17 |     func testUnresolvedSchemaReferenceThrows() throws {
+18 |         var paramSchema = OpenAPISpec.Schema()
+   |             `- warning: variable 'paramSchema' was never mutated; consider changing to 'let' constant
+19 |         paramSchema.ref = "#/components/schemas/Missing"
+20 |         let param = OpenAPISpec.Parameter(name: "id", location: "path", required: true, schema: paramSchema)
+
+/workspace/codex-deployer/Tests/ClientGeneratorTests/SpecValidatorTests.swift:21:13: warning: variable 'op' was never mutated; consider changing to 'let' constant
+19 |         paramSchema.ref = "#/components/schemas/Missing"
+20 |         let param = OpenAPISpec.Parameter(name: "id", location: "path", required: true, schema: paramSchema)
+21 |         var op = OpenAPISpec.Operation(operationId: "get", parameters: [param], requestBody: nil, responses: nil, security: nil)
+   |             `- warning: variable 'op' was never mutated; consider changing to 'let' constant
+22 |         let item = OpenAPISpec.PathItem(get: op, post: nil, put: nil, delete: nil)
+23 |         let components = OpenAPISpec.Components(schemas: [:], securitySchemes: nil)
+
+/workspace/codex-deployer/Tests/ClientGeneratorTests/SpecValidatorTests.swift:24:13: warning: variable 'spec' was never mutated; consider changing to 'let' constant
+22 |         let item = OpenAPISpec.PathItem(get: op, post: nil, put: nil, delete: nil)
+23 |         let components = OpenAPISpec.Components(schemas: [:], securitySchemes: nil)
+24 |         var spec = OpenAPISpec(title: "API", servers: nil, components: components, paths: ["/item/{id}": item])
+   |             `- warning: variable 'spec' was never mutated; consider changing to 'let' constant
+25 |         XCTAssertThrowsError(try SpecValidator.validate(spec)) { error in
+26 |             XCTAssertTrue("\(error)".contains("unresolved reference"))
+[488/500] Linking clientgen-service
+[490/500] Compiling PublishingFrontend DNSProvider.swift
+[491/504] Compiling publishing_frontend main.swift
+[491/504] Write Objects.LinkFileList
+[493/504] Compiling PublishingFrontendTests PublishingFrontendTests.swift
+/workspace/codex-deployer/Tests/PublishingFrontendTests/PublishingFrontendTests.swift:35:37: warning: result of call to 'changeCurrentDirectoryPath' is unused
+33 |         try yaml.write(to: fileURL, atomically: true, encoding: .utf8)
+34 |         let cwd = FileManager.default.currentDirectoryPath
+35 |         defer { FileManager.default.changeCurrentDirectoryPath(cwd) }
+   |                                     `- warning: result of call to 'changeCurrentDirectoryPath' is unused
+36 |         FileManager.default.changeCurrentDirectoryPath(dir.path)
+37 |         let config = try loadPublishingConfig()
+
+/workspace/codex-deployer/Tests/PublishingFrontendTests/PublishingFrontendTests.swift:36:29: warning: result of call to 'changeCurrentDirectoryPath' is unused
+34 |         let cwd = FileManager.default.currentDirectoryPath
+35 |         defer { FileManager.default.changeCurrentDirectoryPath(cwd) }
+36 |         FileManager.default.changeCurrentDirectoryPath(dir.path)
+   |                             `- warning: result of call to 'changeCurrentDirectoryPath' is unused
+37 |         let config = try loadPublishingConfig()
+38 |         XCTAssertEqual(config.port, 1234)
+[494/504] Compiling gateway_server CertificateManager.swift
+[494/504] Write Objects.LinkFileList
+[496/504] Compiling DNSTests APIClientTests.swift
+[496/504] Linking publishing-frontend
+[497/504] Linking gateway-server
+[499/505] Compiling IntegrationRuntimeTests CertificateManagerTests.swift
+[499/505] /workspace/codex-deployer/.build/x86_64-unknown-linux-gnu/release/FountainCoachPackageDiscoveredTests.derived/all-discovered-tests.swift
+[500/505] Write sources
+[502/506] Compiling FountainCoachPackageDiscoveredTests ClientGeneratorTests.swift
+[502/506] /workspace/codex-deployer/.build/x86_64-unknown-linux-gnu/release/FountainCoachPackageTests.derived/runner.swift
+[503/506] Write sources
+[505/507] Compiling FountainCoachPackageTests runner.swift
+[505/507] Write Objects.LinkFileList
+[506/507] Linking FountainCoachPackageTests.xctest
+Build complete! (172.33s)
+Test Suite 'All tests' started at 2025-08-02 07:40:54.702
+Test Suite 'release.xctest' started at 2025-08-02 07:40:54.729
+Test Suite 'FountainCoreTests' started at 2025-08-02 07:40:54.729
+Test Case 'FountainCoreTests.testTodoDecoding' started at 2025-08-02 07:40:54.729
+Test Case 'FountainCoreTests.testTodoDecoding' passed (0.005 seconds)
+Test Case 'FountainCoreTests.testTodoEncodingRoundTrip' started at 2025-08-02 07:40:54.734
+Test Case 'FountainCoreTests.testTodoEncodingRoundTrip' passed (0.001 seconds)
+Test Suite 'FountainCoreTests' passed at 2025-08-02 07:40:54.735
+	 Executed 2 tests, with 0 failures (0 unexpected) in 0.006 (0.006) seconds
+Test Suite 'CertificateManagerTests' started at 2025-08-02 07:40:54.735
+Test Case 'CertificateManagerTests.testTriggerNowRunsScript' started at 2025-08-02 07:40:54.735
+Test Case 'CertificateManagerTests.testTriggerNowRunsScript' passed (1.006 seconds)
+Test Suite 'CertificateManagerTests' passed at 2025-08-02 07:40:55.741
+	 Executed 1 test, with 0 failures (0 unexpected) in 1.006 (1.006) seconds
+Test Suite 'GatewayPluginDefaultTests' started at 2025-08-02 07:40:55.741
+Test Case 'GatewayPluginDefaultTests.testDefaultImplementationsPassThrough' started at 2025-08-02 07:40:55.741
+Test Case 'GatewayPluginDefaultTests.testDefaultImplementationsPassThrough' passed (0.001 seconds)
+Test Suite 'GatewayPluginDefaultTests' passed at 2025-08-02 07:40:55.741
+	 Executed 1 test, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
+Test Suite 'GatewayServerTests' started at 2025-08-02 07:40:55.741
+Test Case 'GatewayServerTests.testHealthEndpointResponds' started at 2025-08-02 07:40:55.742
+Test Case 'GatewayServerTests.testHealthEndpointResponds' passed (0.12 seconds)
+Test Case 'GatewayServerTests.testMetricsEndpointResponds' started at 2025-08-02 07:40:55.862
+Test Case 'GatewayServerTests.testMetricsEndpointResponds' passed (0.104 seconds)
+Test Suite 'GatewayServerTests' passed at 2025-08-02 07:40:55.965
+	 Executed 2 tests, with 0 failures (0 unexpected) in 0.224 (0.224) seconds
+Test Suite 'HTTPKernelTests' started at 2025-08-02 07:40:55.966
+Test Case 'HTTPKernelTests.testKernelRoutesRequest' started at 2025-08-02 07:40:55.966
+Test Case 'HTTPKernelTests.testKernelRoutesRequest' passed (0.0 seconds)
+Test Suite 'HTTPKernelTests' passed at 2025-08-02 07:40:55.966
+	 Executed 1 test, with 0 failures (0 unexpected) in 0.0 (0.0) seconds
+Test Suite 'HTTPResponseDefaultsTests' started at 2025-08-02 07:40:55.966
+Test Case 'HTTPResponseDefaultsTests.testNoBodyCodable' started at 2025-08-02 07:40:55.966
+Test Case 'HTTPResponseDefaultsTests.testNoBodyCodable' passed (0.001 seconds)
+Test Case 'HTTPResponseDefaultsTests.testResponseDefaults' started at 2025-08-02 07:40:55.966
+Test Case 'HTTPResponseDefaultsTests.testResponseDefaults' passed (0.0 seconds)
+Test Suite 'HTTPResponseDefaultsTests' passed at 2025-08-02 07:40:55.967
+	 Executed 2 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
+Test Suite 'LoggingPluginTests' started at 2025-08-02 07:40:55.967
+Test Case 'LoggingPluginTests.testLoggingPluginPassThrough' started at 2025-08-02 07:40:55.967
+-> GET /
+<- 200 for /
+Test Case 'LoggingPluginTests.testLoggingPluginPassThrough' passed (0.0 seconds)
+Test Suite 'LoggingPluginTests' passed at 2025-08-02 07:40:55.967
+	 Executed 1 test, with 0 failures (0 unexpected) in 0.0 (0.0) seconds
+Test Suite 'NIOHTTPServerTests' started at 2025-08-02 07:40:55.967
+Test Case 'NIOHTTPServerTests.testServerResponds' started at 2025-08-02 07:40:55.967
+Test Case 'NIOHTTPServerTests.testServerResponds' passed (0.002 seconds)
+Test Suite 'NIOHTTPServerTests' passed at 2025-08-02 07:40:55.969
+	 Executed 1 test, with 0 failures (0 unexpected) in 0.002 (0.002) seconds
+Test Suite 'PublishingFrontendPluginTests' started at 2025-08-02 07:40:55.969
+Test Case 'PublishingFrontendPluginTests.testPluginServesFile' started at 2025-08-02 07:40:55.969
+Test Case 'PublishingFrontendPluginTests.testPluginServesFile' passed (1.332 seconds)
+Test Suite 'PublishingFrontendPluginTests' passed at 2025-08-02 07:40:57.301
+	 Executed 1 test, with 0 failures (0 unexpected) in 1.332 (1.332) seconds
+Test Suite 'URLSessionHTTPClientTests' started at 2025-08-02 07:40:57.301
+Test Case 'URLSessionHTTPClientTests.testExecutePerformsRequest' started at 2025-08-02 07:40:57.301
+Test Case 'URLSessionHTTPClientTests.testExecutePerformsRequest' passed (0.002 seconds)
+Test Suite 'URLSessionHTTPClientTests' passed at 2025-08-02 07:40:57.303
+	 Executed 1 test, with 0 failures (0 unexpected) in 0.002 (0.002) seconds
+Test Suite 'PublishingFrontendTests' started at 2025-08-02 07:40:57.303
+Test Case 'PublishingFrontendTests.testLoadPublishingConfigParsesYaml' started at 2025-08-02 07:40:57.303
+Test Case 'PublishingFrontendTests.testLoadPublishingConfigParsesYaml' passed (0.013 seconds)
+Test Case 'PublishingFrontendTests.testPublishingConfigDefaultValues' started at 2025-08-02 07:40:57.316
+Test Case 'PublishingFrontendTests.testPublishingConfigDefaultValues' passed (0.0 seconds)
+Test Case 'PublishingFrontendTests.testServerServesIndex' started at 2025-08-02 07:40:57.316
+Test Case 'PublishingFrontendTests.testServerServesIndex' passed (0.005 seconds)
+Test Suite 'PublishingFrontendTests' passed at 2025-08-02 07:40:57.321
+	 Executed 3 tests, with 0 failures (0 unexpected) in 0.018 (0.018) seconds
+Test Suite 'ClientGeneratorTests' started at 2025-08-02 07:40:57.321
+Test Case 'ClientGeneratorTests.testClientFilesGenerated' started at 2025-08-02 07:40:57.321
+Test Case 'ClientGeneratorTests.testClientFilesGenerated' passed (0.006 seconds)
+Test Suite 'ClientGeneratorTests' passed at 2025-08-02 07:40:57.326
+	 Executed 1 test, with 0 failures (0 unexpected) in 0.006 (0.006) seconds
+Test Suite 'OpenAPISwiftTypeTests' started at 2025-08-02 07:40:57.327
+Test Case 'OpenAPISwiftTypeTests.testSchemaPropertySwiftType' started at 2025-08-02 07:40:57.327
+Test Case 'OpenAPISwiftTypeTests.testSchemaPropertySwiftType' passed (0.0 seconds)
+Test Case 'OpenAPISwiftTypeTests.testSchemaRefSwiftType' started at 2025-08-02 07:40:57.327
+Test Case 'OpenAPISwiftTypeTests.testSchemaRefSwiftType' passed (0.0 seconds)
+Test Suite 'OpenAPISwiftTypeTests' passed at 2025-08-02 07:40:57.327
+	 Executed 2 tests, with 0 failures (0 unexpected) in 0.0 (0.0) seconds
+Test Suite 'SecurityRequirementTests' started at 2025-08-02 07:40:57.327
+Test Case 'SecurityRequirementTests.testDecodesSchemesFromJSON' started at 2025-08-02 07:40:57.327
+Test Case 'SecurityRequirementTests.testDecodesSchemesFromJSON' passed (0.101 seconds)
+Test Case 'SecurityRequirementTests.testEncodesSchemesToJSON' started at 2025-08-02 07:40:57.427
+Test Case 'SecurityRequirementTests.testEncodesSchemesToJSON' passed (0.001 seconds)
+Test Suite 'SecurityRequirementTests' passed at 2025-08-02 07:40:57.428
+	 Executed 2 tests, with 0 failures (0 unexpected) in 0.101 (0.101) seconds
+Test Suite 'SpecLoaderTests' started at 2025-08-02 07:40:57.428
+Test Case 'SpecLoaderTests.testLoadsJSONRemovingCopyright' started at 2025-08-02 07:40:57.428
+Test Case 'SpecLoaderTests.testLoadsJSONRemovingCopyright' passed (0.012 seconds)
+Test Case 'SpecLoaderTests.testLoadsYAMLAndNormalizesInfoTitle' started at 2025-08-02 07:40:57.441
+Test Case 'SpecLoaderTests.testLoadsYAMLAndNormalizesInfoTitle' passed (0.006 seconds)
+Test Suite 'SpecLoaderTests' passed at 2025-08-02 07:40:57.447
+	 Executed 2 tests, with 0 failures (0 unexpected) in 0.019 (0.019) seconds
+Test Suite 'SpecValidatorTests' started at 2025-08-02 07:40:57.447
+Test Case 'SpecValidatorTests.testDuplicateOperationIdThrows' started at 2025-08-02 07:40:57.447
+Test Case 'SpecValidatorTests.testDuplicateOperationIdThrows' passed (0.0 seconds)
+Test Case 'SpecValidatorTests.testUnresolvedSchemaReferenceThrows' started at 2025-08-02 07:40:57.448
+Test Case 'SpecValidatorTests.testUnresolvedSchemaReferenceThrows' passed (0.0 seconds)
+Test Suite 'SpecValidatorTests' passed at 2025-08-02 07:40:57.448
+	 Executed 2 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
+Test Suite 'StringExtensionTests' started at 2025-08-02 07:40:57.448
+Test Case 'StringExtensionTests.testCamelCased' started at 2025-08-02 07:40:57.448
+Test Case 'StringExtensionTests.testCamelCased' passed (0.0 seconds)
+Test Suite 'StringExtensionTests' passed at 2025-08-02 07:40:57.448
+	 Executed 1 test, with 0 failures (0 unexpected) in 0.0 (0.0) seconds
+Test Suite 'APIClientTests' started at 2025-08-02 07:40:57.448
+Test Case 'APIClientTests.testBearerInitializerSetsHeader' started at 2025-08-02 07:40:57.448
+Test Case 'APIClientTests.testBearerInitializerSetsHeader' passed (0.0 seconds)
+Test Case 'APIClientTests.testSendDecodesResponse' started at 2025-08-02 07:40:57.448
+Test Case 'APIClientTests.testSendDecodesResponse' passed (0.0 seconds)
+Test Suite 'APIClientTests' passed at 2025-08-02 07:40:57.449
+	 Executed 2 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
+Test Suite 'DNSClientTests' started at 2025-08-02 07:40:57.449
+Test Case 'DNSClientTests.testRoute53CreateRecordStub' started at 2025-08-02 07:40:57.449
+Test Case 'DNSClientTests.testRoute53CreateRecordStub' passed (0.001 seconds)
+Test Case 'DNSClientTests.testRoute53DeleteRecordStub' started at 2025-08-02 07:40:57.449
+Test Case 'DNSClientTests.testRoute53DeleteRecordStub' passed (0.0 seconds)
+Test Case 'DNSClientTests.testRoute53Stub' started at 2025-08-02 07:40:57.450
+Test Case 'DNSClientTests.testRoute53Stub' passed (0.0 seconds)
+Test Case 'DNSClientTests.testRoute53UpdateRecordStub' started at 2025-08-02 07:40:57.450
+Test Case 'DNSClientTests.testRoute53UpdateRecordStub' passed (0.0 seconds)
+Test Suite 'DNSClientTests' passed at 2025-08-02 07:40:57.450
+	 Executed 4 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
+Test Suite 'DeleteZoneRequestTests' started at 2025-08-02 07:40:57.450
+Test Case 'DeleteZoneRequestTests.testPathBuilderEncodesZoneId' started at 2025-08-02 07:40:57.450
+Test Case 'DeleteZoneRequestTests.testPathBuilderEncodesZoneId' passed (0.001 seconds)
+Test Suite 'DeleteZoneRequestTests' passed at 2025-08-02 07:40:57.451
+	 Executed 1 test, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
+Test Suite 'GetRecordRequestTests' started at 2025-08-02 07:40:57.451
+Test Case 'GetRecordRequestTests.testPathBuilderReplacesRecordId' started at 2025-08-02 07:40:57.451
+Test Case 'GetRecordRequestTests.testPathBuilderReplacesRecordId' passed (0.0 seconds)
+Test Suite 'GetRecordRequestTests' passed at 2025-08-02 07:40:57.451
+	 Executed 1 test, with 0 failures (0 unexpected) in 0.0 (0.0) seconds
+Test Suite 'HetznerDNSClientTests' started at 2025-08-02 07:40:57.451
+Test Case 'HetznerDNSClientTests.testCreateRecordRequest' started at 2025-08-02 07:40:57.451
+Test Case 'HetznerDNSClientTests.testCreateRecordRequest' passed (0.001 seconds)
+Test Case 'HetznerDNSClientTests.testCreateRecordSetsContentTypeHeader' started at 2025-08-02 07:40:57.452
+Test Case 'HetznerDNSClientTests.testCreateRecordSetsContentTypeHeader' passed (0.0 seconds)
+Test Case 'HetznerDNSClientTests.testDeleteRecordRequest' started at 2025-08-02 07:40:57.452
+Test Case 'HetznerDNSClientTests.testDeleteRecordRequest' passed (0.0 seconds)
+Test Case 'HetznerDNSClientTests.testListZonesPathBuilder' started at 2025-08-02 07:40:57.453
+Test Case 'HetznerDNSClientTests.testListZonesPathBuilder' passed (0.0 seconds)
+Test Case 'HetznerDNSClientTests.testUpdateRecordRequest' started at 2025-08-02 07:40:57.453
+Test Case 'HetznerDNSClientTests.testUpdateRecordRequest' passed (0.0 seconds)
+Test Suite 'HetznerDNSClientTests' passed at 2025-08-02 07:40:57.453
+	 Executed 5 tests, with 0 failures (0 unexpected) in 0.002 (0.002) seconds
+Test Suite 'ListRecordsRequestTests' started at 2025-08-02 07:40:57.453
+Test Case 'ListRecordsRequestTests.testPathBuilderEncodesQuery' started at 2025-08-02 07:40:57.453
+Test Case 'ListRecordsRequestTests.testPathBuilderEncodesQuery' passed (0.0 seconds)
+Test Suite 'ListRecordsRequestTests' passed at 2025-08-02 07:40:57.453
+	 Executed 1 test, with 0 failures (0 unexpected) in 0.0 (0.0) seconds
+Test Suite 'release.xctest' passed at 2025-08-02 07:40:57.453
+	 Executed 40 tests, with 0 failures (0 unexpected) in 2.723 (2.723) seconds
+Test Suite 'All tests' passed at 2025-08-02 07:40:57.453
+	 Executed 40 tests, with 0 failures (0 unexpected) in 2.723 (2.723) seconds
+◇ Test run started.
+↳ Testing Library Version: 6.1 (43b6f88e2f2712e)
+↳ Target Platform: x86_64-unknown-linux-gnu
+✔ Test run with 0 tests passed after 0.001 seconds.
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- document NoBody placeholder type for empty request bodies
- test HTTPResponse defaults and NoBody codable
- update coverage report and documentation highlights

## Testing
- `swift build -c release -Xswiftc -O -Xswiftc -warnings-as-errors`
- `swift test -c release --enable-code-coverage`

------
https://chatgpt.com/codex/tasks/task_e_688dbe2cb82c8325b28973864c1fa773