### PR TITLE
Add AsyncHTTPClientDriver tests and documentation

### DIFF
--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -5,20 +5,20 @@
 Running `swift test --enable-code-coverage` and analysing with `llvm-cov` produced the following totals:
 
 ```
-TOTAL                                          31341   28161    10.15%   13963 12278    12.07%   98519   87809    10.87%
+TOTAL                                          31354   26696    14.86%   13972 11558    17.28%   98547   81789    17.01%
 ```
 
-The repository contains **98,519** executable lines, with **10,710** lines covered (approx. **10.87%** line coverage).
+The repository contains **98,547** executable lines, with **16,758** lines covered (approx. **17.01%** line coverage).
 
 ### Repository source coverage
 
 Ignoring third-party packages under `.build/checkouts`, the totals are:
 
 ```
-TOTAL                                            963     406    57.84%     431   117    72.85%    2172     800    63.17%
+TOTAL                                            976     400    59.02%     440   114    74.09%    2200     785    64.32%
 ```
 
-Within repository sources there are **2,172** lines, with **1,372** covered, giving **63.17%** line coverage.
+Within repository sources there are **2,200** lines, with **1,415** covered, giving **64.32%** line coverage.
 
 Coverage results are recalculated after each test run to monitor progress. The project strives for ever more comprehensive test suites across all modules. Recent additions include unit tests for ``APIClient``. New tests now verify ``URLSessionHTTPClient`` behavior and the ``Supervisor`` process termination logic.
 Additional tests now cover ``OpenAPISpec.swiftType`` and the ``camelCased`` string helper. A new ``GatewayServerTests`` suite raises total tests to **27**.
@@ -31,6 +31,7 @@ The added ``PublishingConfigDefaultValues`` test raises the suite to **35** test
 The new ``TodoEncodingRoundTrip`` test brings the total test count to **36**.
 The new ``SecurityRequirementTests`` bring the total test count to **38**.
 The new ``HTTPResponseDefaultsTests`` increase the total test count to **40**.
+The new ``AsyncHTTPClientDriverTests`` bring the total test count to **41**.
 
 ---
 © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainCodex/IntegrationRuntime/AsyncHTTPClientDriver.swift
+++ b/Sources/FountainCodex/IntegrationRuntime/AsyncHTTPClientDriver.swift
@@ -2,6 +2,12 @@ import AsyncHTTPClient
 import NIOCore
 import NIOHTTP1
 
+/// HTTP client adapter backed by ``AsyncHTTPClient``.
+///
+/// This driver conforms to ``HTTPClientProtocol`` by forwarding requests
+/// to an instance of ``AsyncHTTPClient``. It is mainly used in tests and
+/// generated clients where a lightweight, event-loop based HTTP client
+/// is desirable.
 public final class AsyncHTTPClientDriver: HTTPClientProtocol, @unchecked Sendable {
     /// Underlying async HTTP client used for requests.
     let client: HTTPClient

--- a/Tests/IntegrationRuntimeTests/AsyncHTTPClientDriverTests.swift
+++ b/Tests/IntegrationRuntimeTests/AsyncHTTPClientDriverTests.swift
@@ -1,0 +1,26 @@
+import XCTest
+import NIOCore
+import NIOHTTP1
+@testable import FountainCodex
+
+final class AsyncHTTPClientDriverTests: XCTestCase {
+    /// Ensures the driver performs requests and returns responses.
+    func testExecutePerformsRequest() async throws {
+        let kernel = HTTPKernel { req in
+            XCTAssertEqual(req.headers["X-Req"], "1")
+            return HTTPResponse(status: 200, headers: ["X-Reply": "ok"], body: Data("pong".utf8))
+        }
+        let server = NIOHTTPServer(kernel: kernel)
+        let port = try await server.start(port: 0)
+
+        let client = AsyncHTTPClientDriver()
+        let (buffer, headers) = try await client.execute(method: .GET, url: "http://127.0.0.1:\(port)", headers: HTTPHeaders([( "X-Req", "1")]), body: nil)
+        XCTAssertEqual(buffer.getString(at: 0, length: buffer.readableBytes), "pong")
+        XCTAssertEqual(headers.first(name: "X-Reply"), "ok")
+
+        try await client.shutdown()
+        try await server.stop()
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,7 @@ As modules gain documentation, brief summaries are added here.
 - **HTTPKernel** – simple asynchronous router used by the gateway and publishing frontend.
 - **HetznerDNSClient** – Swift wrapper for the Hetzner DNS API with typed requests.
 - **DNSProvider** – abstraction over DNS APIs with stubs for Route53.
-- **AsyncHTTPClientDriver** and **URLSessionHTTPClient** – documented HTTP clients powering network requests.
+- **AsyncHTTPClientDriver** and **URLSessionHTTPClient** – documented HTTP clients powering network requests. The former now includes top-level class docs and dedicated tests verifying request execution.
 - **NIOHTTPServer** – documented server adapter built on SwiftNIO.
 - **HTTPHandler** – internal request dispatcher within `NIOHTTPServer` is now thoroughly documented.
 - **LoggingPlugin** – prints requests and responses for debugging.


### PR DESCRIPTION
## Summary
- document AsyncHTTPClientDriver adapter
- exercise AsyncHTTPClientDriver with a live request test
- record improved coverage metrics

## Testing
- `swift build -c release -Xswiftc -O -Xswiftc -warnings-as-errors`
- `swift test -c release --enable-code-coverage`


------
https://chatgpt.com/codex/tasks/task_e_688dc33c3c0c8325b333b41cfa461582