### PR TITLE
Document server internals and expand tests

### DIFF
--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -5,20 +5,20 @@
 Running `swift test --enable-code-coverage` and analysing with `llvm-cov` produced the following totals:
 
 ```
-TOTAL                                          31410   26686    15.04%   14012 11547    17.59%   98652   81754    17.13%
+TOTAL                                          31439   26679    15.14%   14032 11547    17.71%   98722   81746    17.20%
 ```
 
-The repository contains **98,652** executable lines, with **16,898** lines covered (approx. **17.13%** line coverage).
+The repository contains **98,722** executable lines, with **16,976** lines covered (approx. **17.20%** line coverage).
 
 ### Repository source coverage
 
 Ignoring third-party packages under `.build/checkouts`, the totals are:
 
 ```
-TOTAL                                           1032     397    61.53%     480   108    77.50%    2305     772    66.51%
+TOTAL                                           933     334    64.20%     408    76    81.37%    2092     622    70.27%
 ```
 
-Within repository sources there are **2,305** lines, with **1,533** covered, giving **66.51%** line coverage.
+Within repository sources there are **2,092** lines, with **1,470** covered, giving **70.27%** line coverage.
 
 Coverage results are recalculated after each test run to monitor progress. The project strives for ever more comprehensive test suites across all modules. Recent additions include unit tests for ``APIClient``. New tests now verify ``URLSessionHTTPClient`` behavior and the ``Supervisor`` process termination logic.
 Additional tests now cover ``OpenAPISpec.swiftType`` and the ``camelCased`` string helper. A new ``GatewayServerTests`` suite raises total tests to **27**.
@@ -33,6 +33,7 @@ The new ``SecurityRequirementTests`` bring the total test count to **38**.
 The new ``HTTPResponseDefaultsTests`` increase the total test count to **40**.
 The new ``AsyncHTTPClientDriverTests`` bring the total test count to **41**.
 The new ``CreatePrimaryServerRequestTests`` and ``GetPrimaryServerRequestTests`` raise the total test count to **49**.
+Additional plugin rewrite and raw data tests raise the total test count to **51**.
 
 ---
 © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/GatewayApp/GatewayServer.swift
+++ b/Sources/GatewayApp/GatewayServer.swift
@@ -7,9 +7,13 @@ import FountainCodex
 /// Provides built-in `/health` and `/metrics` endpoints used for monitoring.
 @MainActor
 public final class GatewayServer {
+    /// Underlying HTTP server handling TCP connections.
     private let server: NIOHTTPServer
+    /// Manages periodic certificate renewal scripts.
     private let manager: CertificateManager
+    /// Event loop group powering the SwiftNIO server.
     private let group: EventLoopGroup
+    /// Middleware components executed around request routing.
     private let plugins: [GatewayPlugin]
 
     /// Creates a new gateway server instance.

--- a/Sources/PublishingFrontend/DNSProvider.swift
+++ b/Sources/PublishingFrontend/DNSProvider.swift
@@ -17,6 +17,7 @@ public protocol DNSProvider {
 
 /// Concrete ``DNSProvider`` that talks to the Hetzner DNS API.
 public struct HetznerDNSClient: DNSProvider {
+    /// HTTP client used for communication with Hetzner's API.
     let api: APIClient
 
     /// Creates a new client with the given API token and session.

--- a/Sources/PublishingFrontend/HetznerDNSClient/APIClient.swift
+++ b/Sources/PublishingFrontend/HetznerDNSClient/APIClient.swift
@@ -20,8 +20,11 @@ extension URLSession: HTTPSession {
 
 /// Minimal HTTP client for executing ``APIRequest`` values.
 public struct APIClient {
+    /// Root endpoint used for all requests.
     let baseURL: URL
+    /// Transport layer performing network calls.
     let session: HTTPSession
+    /// Headers automatically attached to every request.
     let defaultHeaders: [String: String]
 
     /// Creates a new client with optional session and headers.

--- a/Tests/DNSTests/APIClientTests.swift
+++ b/Tests/DNSTests/APIClientTests.swift
@@ -44,6 +44,23 @@ final class APIClientTests: XCTestCase {
         _ = try await client.send(Ping())
         XCTAssertEqual(session.request?.value(forHTTPHeaderField: "Authorization"), "Bearer abc")
     }
+
+    func testRawDataResponse() async throws {
+        struct DataEcho: APIRequest {
+            struct Payload: Encodable { let msg: String }
+            typealias Body = Payload
+            typealias Response = Data
+            var method: String { "POST" }
+            var path: String { "/echo" }
+            var body: Payload? = Payload(msg: "hi")
+        }
+        let expected = Data([1, 2, 3])
+        let session = MockSession(responseData: expected)
+        let client = APIClient(baseURL: URL(string: "http://localhost")!, session: session)
+        let result: Data = try await client.send(DataEcho())
+        XCTAssertEqual(result, expected)
+        XCTAssertEqual(session.request?.value(forHTTPHeaderField: "Content-Type"), "application/json")
+    }
 }
 
 // © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Tests/IntegrationRuntimeTests/GatewayServerTests.swift
+++ b/Tests/IntegrationRuntimeTests/GatewayServerTests.swift
@@ -4,6 +4,7 @@ import Foundation
 import FoundationNetworking
 #endif
 @testable import gateway_server
+@testable import FountainCodex
 
 final class GatewayServerTests: XCTestCase {
 
@@ -32,6 +33,35 @@ final class GatewayServerTests: XCTestCase {
         XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 200)
         let body = try JSONSerialization.jsonObject(with: data) as? [String: [String]]
         XCTAssertNotNil(body?["metrics"])
+        try await server.stop()
+    }
+
+    @MainActor
+    func testPluginCanRewriteRequestAndResponse() async throws {
+        struct RewritePlugin: GatewayPlugin {
+            func prepare(_ request: HTTPRequest) async throws -> HTTPRequest {
+                if request.path == "/ping" {
+                    return HTTPRequest(method: request.method, path: "/health", headers: request.headers, body: request.body)
+                }
+                return request
+            }
+            func respond(_ response: HTTPResponse, for request: HTTPRequest) async throws -> HTTPResponse {
+                var res = response
+                res.headers["X-Rewritten"] = "true"
+                return res
+            }
+        }
+        let manager = CertificateManager(scriptPath: "/usr/bin/true", interval: 3600)
+        let server = GatewayServer(manager: manager, plugins: [RewritePlugin()])
+        Task { try await server.start(port: 9102) }
+        try await Task.sleep(nanoseconds: 100_000_000)
+        let url = URL(string: "http://127.0.0.1:9102/ping")!
+        let (data, response) = try await URLSession.shared.data(from: url)
+        XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 200)
+        let header = (response as? HTTPURLResponse)?.value(forHTTPHeaderField: "X-Rewritten")
+        XCTAssertEqual(header, "true")
+        let body = try JSONSerialization.jsonObject(with: data) as? [String: String]
+        XCTAssertEqual(body?["status"], "ok")
         try await server.stop()
     }
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -40,6 +40,9 @@ As modules gain documentation, brief summaries are added here.
 - **Route53Client** – stub methods now describe the unimplemented error responses.
 - **FountainOps Todo** – generated model now documents its properties.
 - **createPrimaryServer** and **getPrimaryServer** – request types now document server creation and retrieval.
+- **GatewayServer** – internal components like the certificate manager and plugin stack are now described.
+- **APIClient.baseURL**, **session**, and **defaultHeaders** – stored properties document connection details.
+- **HetznerDNSClient.api** – underlying HTTP client property now documented.
 
 Documentation coverage will expand alongside test coverage.
 


### PR DESCRIPTION
## Summary
- document GatewayServer internals for server, certificate manager, event loop group, and plugins
- clarify APIClient configuration properties and HetznerDNSClient's HTTP client
- add plugin rewrite and raw data APIClient tests to boost coverage

## Testing
- `swift build -c release -Xswiftc -O -Xswiftc -warnings-as-errors`
- `swift test -c release --enable-code-coverage`


------
https://chatgpt.com/codex/tasks/task_e_688dd898d478832594a851c795187f98