### PR TITLE
Document Hetzner DNS requests and add coverage tests

### DIFF
--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -5,20 +5,20 @@
 Running `swift test --enable-code-coverage` and analysing with `llvm-cov` produced the following totals:
 
 ```
-TOTAL                                          31439   26679    15.14%   14032 11547    17.71%   98722   81746    17.20%
+TOTAL                                          31455   26675    15.20%   14048 11541    17.85%   98751   81733    17.23%
 ```
 
-The repository contains **98,722** executable lines, with **16,976** lines covered (approx. **17.20%** line coverage).
+The repository contains **98,751** executable lines, with **17,018** lines covered (approx. **17.23%** line coverage).
 
 ### Repository source coverage
 
 Ignoring third-party packages under `.build/checkouts`, the totals are:
 
 ```
-TOTAL                                           933     334    64.20%     408    76    81.37%    2092     622    70.27%
+TOTAL                                           945     327    65.40%     420    70    83.33%    2116     605    71.41%
 ```
 
-Within repository sources there are **2,092** lines, with **1,470** covered, giving **70.27%** line coverage.
+Within repository sources there are **2,116** lines, with **1,511** covered, giving **71.41%** line coverage.
 
 Coverage results are recalculated after each test run to monitor progress. The project strives for ever more comprehensive test suites across all modules. Recent additions include unit tests for ``APIClient``. New tests now verify ``URLSessionHTTPClient`` behavior and the ``Supervisor`` process termination logic.
 Additional tests now cover ``OpenAPISpec.swiftType`` and the ``camelCased`` string helper. A new ``GatewayServerTests`` suite raises total tests to **27**.
@@ -34,6 +34,7 @@ The new ``HTTPResponseDefaultsTests`` increase the total test count to **40**.
 The new ``AsyncHTTPClientDriverTests`` bring the total test count to **41**.
 The new ``CreatePrimaryServerRequestTests`` and ``GetPrimaryServerRequestTests`` raise the total test count to **49**.
 Additional plugin rewrite and raw data tests raise the total test count to **51**.
+The new ``validateZoneFile`` and ``updatePrimaryServer`` request tests raise the total test count to **55**.
 
 ---
 © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/PublishingFrontend/HetznerDNSClient/Requests/updatePrimaryServer.swift
+++ b/Sources/PublishingFrontend/HetznerDNSClient/Requests/updatePrimaryServer.swift
@@ -1,14 +1,24 @@
 import Foundation
 
+/// Parameters for ``updatePrimaryServer`` identifying the server to modify.
 public struct updatePrimaryServerParameters: Codable {
+    /// The identifier of the primary server to update.
     public let primaryserverid: String
 }
 
+/// Updates an existing primary DNS server configuration.
+///
+/// Corresponds to the `PUT /primary_servers/{PrimaryServerID}` endpoint.
 public struct updatePrimaryServer: APIRequest {
+    /// Body describing the new primary server configuration.
     public typealias Body = PrimaryServerCreate
+    /// Response returned after updating the primary server.
     public typealias Response = PrimaryServerResponse
+    /// HTTP method used for the request.
     public var method: String { "PUT" }
+    /// Identifies which primary server to update.
     public var parameters: updatePrimaryServerParameters
+    /// Constructed path for the request.
     public var path: String {
         var path = "/primary_servers/{PrimaryServerID}"
         let query: [String] = []
@@ -16,8 +26,13 @@ public struct updatePrimaryServer: APIRequest {
         if !query.isEmpty { path += "?" + query.joined(separator: "&") }
         return path
     }
+    /// Request body containing the updated server data.
     public var body: Body?
 
+    /// Creates a new request to update a primary server.
+    /// - Parameters:
+    ///   - parameters: Identifies the target primary server.
+    ///   - body: New server settings to apply.
     public init(parameters: updatePrimaryServerParameters, body: Body? = nil) {
         self.parameters = parameters
         self.body = body

--- a/Sources/PublishingFrontend/HetznerDNSClient/Requests/validateZoneFile.swift
+++ b/Sources/PublishingFrontend/HetznerDNSClient/Requests/validateZoneFile.swift
@@ -1,13 +1,25 @@
 import Foundation
 
+/// Validates a DNS zone file before importing it into Hetzner DNS.
+///
+/// Corresponds to the `POST /zones/file/validate` endpoint.
 public struct validateZoneFile: APIRequest {
+    /// The request carries no body payload.
     public typealias Body = NoBody
+    /// Response describing validation errors or success.
     public typealias Response = validateZoneFileResponse
+    /// HTTP method used by the API.
     public var method: String { "POST" }
+    /// Endpoint path for zone file validation.
     public var path: String { "/zones/file/validate" }
+    /// Placeholder body maintained for protocol conformance.
     public var body: Body?
 
+    /// Creates a new validation request.
+    /// - Parameter body: Unused placeholder body value.
     public init(body: Body? = nil) {
         self.body = body
     }
 }
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Tests/PublishingFrontendTests/HetznerDNSRequestTests.swift
+++ b/Tests/PublishingFrontendTests/HetznerDNSRequestTests.swift
@@ -1,0 +1,26 @@
+import XCTest
+@testable import PublishingFrontend
+
+final class HetznerDNSRequestTests: XCTestCase {
+    func testValidateZoneFileMethodIsPost() {
+        let request = validateZoneFile()
+        XCTAssertEqual(request.method, "POST")
+    }
+
+    func testValidateZoneFilePath() {
+        let request = validateZoneFile()
+        XCTAssertEqual(request.path, "/zones/file/validate")
+    }
+
+    func testUpdatePrimaryServerMethodIsPut() {
+        let req = updatePrimaryServer(parameters: updatePrimaryServerParameters(primaryserverid: "123"))
+        XCTAssertEqual(req.method, "PUT")
+    }
+
+    func testUpdatePrimaryServerPathIncludesID() {
+        let req = updatePrimaryServer(parameters: updatePrimaryServerParameters(primaryserverid: "123"))
+        XCTAssertEqual(req.path, "/primary_servers/123")
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/docs/README.md
+++ b/docs/README.md
@@ -40,6 +40,7 @@ As modules gain documentation, brief summaries are added here.
 - **Route53Client** – stub methods now describe the unimplemented error responses.
 - **FountainOps Todo** – generated model now documents its properties.
 - **createPrimaryServer** and **getPrimaryServer** – request types now document server creation and retrieval.
+- **validateZoneFile** and **updatePrimaryServer** – request types now document zone file validation and primary server updates.
 - **GatewayServer** – internal components like the certificate manager and plugin stack are now described.
 - **APIClient.baseURL**, **session**, and **defaultHeaders** – stored properties document connection details.
 - **HetznerDNSClient.api** – underlying HTTP client property now documented.

--- a/logs/build-20250802-095543.log
+++ b/logs/build-20250802-095543.log
@@ -1,0 +1,670 @@
+Building for production...
+[0/459] Write sources
+[27/459] Compiling _NumericsShims _NumericsShims.c
+[28/459] Compiling _AtomicsShims.c
+[29/459] Compiling writer.c
+[30/459] Compiling reader.c
+[31/459] Write swift-version--4EAD98957C2213E4.txt
+[32/459] Compiling CNIOWindows shim.c
+[33/459] Compiling parser.c
+[34/461] Compiling api.c
+[35/462] Compiling emitter.c
+[36/463] Compiling scanner.c
+[38/464] Compiling _NIOBase64 Base64.swift
+[39/465] Compiling RealModule AlgebraicField.swift
+[40/466] Compiling _NIODataStructures Heap.swift
+[40/466] Compiling CNIOWindows WSAStartup.c
+[41/466] Compiling CNIOWASI CNIOWASI.c
+[42/466] Compiling CNIOPosix event_loop_id.c
+[44/466] Compiling FountainCore Models.swift
+[44/466] Compiling CNIOLinux liburing_shims.c
+[46/466] Compiling InternalCollectionsUtilities FixedWidthInteger+roundUpToPowerOfTwo.swift
+[46/466] Compiling CNIOLLHTTP c_nio_http.c
+[47/467] Compiling CNIOLinux shim.c
+[48/467] Compiling CNIOLLHTTP c_nio_api.c
+[49/467] Compiling CNIOExtrasZlib empty.c
+[50/467] Compiling CNIODarwin shim.c
+[52/467] Compiling Logging Locks.swift
+[52/467] Compiling CNIOLLHTTP c_nio_llhttp.c
+[53/467] Compiling CNIOBoringSSLShims shims.c
+[54/467] Compiling fiat_p256_adx_sqr.S
+[55/467] Compiling fiat_p256_adx_mul.S
+[56/467] Compiling fiat_curve25519_adx_square.S
+[57/467] Compiling fiat_curve25519_adx_mul.S
+[59/467] Compiling DequeModule Deque+Codable.swift
+[59/467] Compiling tls_method.cc
+[60/467] Compiling tls_record.cc
+[61/467] Compiling tls13_enc.cc
+[62/467] Compiling tls13_server.cc
+[63/467] Compiling tls13_both.cc
+[64/467] Compiling tls13_client.cc
+[65/467] Compiling t1_enc.cc
+[66/467] Compiling ssl_x509.cc
+[67/467] Compiling ssl_versions.cc
+[68/467] Compiling ssl_transcript.cc
+[69/467] Compiling ssl_stat.cc
+[70/467] Compiling ssl_session.cc
+[71/467] Compiling ssl_key_share.cc
+[72/467] Compiling ssl_privkey.cc
+[73/467] Compiling ssl_lib.cc
+[74/467] Compiling ssl_file.cc
+[75/467] Compiling ssl_credential.cc
+[76/467] Compiling ssl_cipher.cc
+[77/467] Compiling ssl_buffer.cc
+[78/467] Compiling ssl_cert.cc
+[79/467] Compiling s3_pkt.cc
+[80/467] Compiling ssl_aead_ctx.cc
+[82/467] Compiling Yams AliasDereferencingStrategy.swift
+[82/467] Compiling ssl_asn1.cc
+[83/467] Compiling s3_lib.cc
+[84/467] Compiling s3_both.cc
+[85/467] Compiling handshake.cc
+[86/467] Compiling handshake_server.cc
+[87/467] Compiling handshake_client.cc
+[88/467] Compiling handoff.cc
+[89/467] Compiling dtls_method.cc
+[90/467] Compiling encrypted_client_hello.cc
+[91/467] Compiling dtls_record.cc
+[92/467] Compiling extensions.cc
+[93/467] Compiling d1_srtp.cc
+[94/467] Compiling md5-x86_64-linux.S
+[95/467] Compiling md5-x86_64-apple.S
+[96/467] Compiling md5-586-linux.S
+[97/467] Compiling md5-586-apple.S
+[98/467] Compiling err_data.cc
+[99/467] Compiling bio_ssl.cc
+[100/467] Compiling chacha20_poly1305_x86_64-apple.S
+[101/467] Compiling chacha20_poly1305_x86_64-linux.S
+[102/467] Compiling chacha20_poly1305_armv8-win.S
+[103/467] Compiling chacha20_poly1305_armv8-linux.S
+[104/467] Compiling d1_pkt.cc
+[105/467] Compiling d1_lib.cc
+[106/467] Compiling chacha20_poly1305_armv8-apple.S
+[107/467] Compiling chacha-x86_64-linux.S
+[108/467] Compiling chacha-x86_64-apple.S
+[109/467] Compiling chacha-x86-linux.S
+[110/467] Compiling chacha-x86-apple.S
+[111/467] Compiling chacha-armv8-win.S
+[112/467] Compiling chacha-armv8-linux.S
+[113/467] Compiling chacha-armv8-apple.S
+[114/467] Compiling chacha-armv4-linux.S
+[115/467] Compiling aes128gcmsiv-x86_64-linux.S
+[116/467] Compiling aes128gcmsiv-x86_64-apple.S
+[117/467] Compiling x86_64-mont5-apple.S
+[118/467] Compiling x86_64-mont5-linux.S
+[119/467] Compiling d1_both.cc
+[120/467] Compiling x86_64-mont-linux.S
+[121/467] Compiling x86_64-mont-apple.S
+[122/467] Compiling x86-mont-apple.S
+[123/467] Compiling vpaes-x86_64-linux.S
+[124/467] Compiling x86-mont-linux.S
+[125/467] Compiling vpaes-x86_64-apple.S
+[126/467] Compiling vpaes-x86-linux.S
+[127/467] Compiling vpaes-x86-apple.S
+[128/467] Compiling vpaes-armv8-win.S
+[129/467] Compiling vpaes-armv8-linux.S
+[130/467] Compiling vpaes-armv8-apple.S
+[131/467] Compiling vpaes-armv7-linux.S
+[132/467] Compiling sha512-x86_64-linux.S
+[133/467] Compiling sha512-x86_64-apple.S
+[134/467] Compiling sha512-armv8-win.S
+[135/467] Compiling sha512-armv8-linux.S
+[136/467] Compiling sha512-armv8-apple.S
+[137/467] Compiling sha512-armv4-linux.S
+[138/467] Compiling sha512-586-linux.S
+[139/467] Compiling sha512-586-apple.S
+[140/467] Compiling sha256-x86_64-linux.S
+[141/467] Compiling sha256-x86_64-apple.S
+[142/467] Compiling sha256-armv8-linux.S
+[143/467] Compiling sha256-armv8-win.S
+[144/467] Compiling sha256-armv8-apple.S
+[145/467] Compiling sha256-armv4-linux.S
+[146/467] Compiling sha256-586-linux.S
+[147/467] Compiling sha256-586-apple.S
+[148/467] Compiling sha1-x86_64-apple.S
+[149/467] Compiling sha1-armv8-win.S
+[150/467] Compiling sha1-x86_64-linux.S
+[151/467] Compiling sha1-armv8-linux.S
+[152/467] Compiling sha1-armv8-apple.S
+[153/467] Compiling sha1-armv4-large-linux.S
+[154/467] Compiling sha1-586-apple.S
+[155/467] Compiling sha1-586-linux.S
+[156/467] Compiling rsaz-avx2-linux.S
+[157/467] Compiling rsaz-avx2-apple.S
+[158/467] Compiling rdrand-x86_64-linux.S
+[159/467] Compiling rdrand-x86_64-apple.S
+[160/467] Compiling p256_beeu-x86_64-asm-linux.S
+[161/467] Compiling p256_beeu-x86_64-asm-apple.S
+[162/467] Compiling p256_beeu-armv8-asm-win.S
+[163/467] Compiling p256_beeu-armv8-asm-linux.S
+[164/467] Compiling p256_beeu-armv8-asm-apple.S
+[165/467] Compiling p256-x86_64-asm-linux.S
+[166/467] Compiling p256-x86_64-asm-apple.S
+[167/467] Compiling p256-armv8-asm-linux.S
+[168/467] Compiling p256-armv8-asm-win.S
+[169/467] Compiling p256-armv8-asm-apple.S
+[170/467] Compiling ghashv8-armv8-win.S
+[171/467] Compiling ghashv8-armv8-linux.S
+[172/467] Compiling ghashv8-armv8-apple.S
+[173/467] Compiling ghashv8-armv7-linux.S
+[174/467] Compiling ghash-x86_64-linux.S
+[175/467] Compiling ghash-x86_64-apple.S
+[176/467] Compiling ghash-x86-linux.S
+[177/467] Compiling ghash-ssse3-x86_64-linux.S
+[178/467] Compiling ghash-ssse3-x86_64-apple.S
+[179/467] Compiling ghash-x86-apple.S
+[180/467] Compiling ghash-ssse3-x86-linux.S
+[181/467] Compiling ghash-ssse3-x86-apple.S
+[182/467] Compiling ghash-neon-armv8-win.S
+[183/467] Compiling ghash-neon-armv8-linux.S
+[184/467] Compiling ghash-neon-armv8-apple.S
+[185/467] Compiling ghash-armv4-linux.S
+[186/467] Compiling co-586-linux.S
+[187/467] Compiling bsaes-armv7-linux.S
+[188/467] Compiling co-586-apple.S
+[189/467] Compiling bn-armv8-win.S
+[190/467] Compiling bn-armv8-linux.S
+[191/467] Compiling bn-armv8-apple.S
+[192/467] Compiling bn-586-apple.S
+[193/467] Compiling armv8-mont-win.S
+[194/467] Compiling bn-586-linux.S
+[195/467] Compiling armv8-mont-linux.S
+[196/467] Compiling armv8-mont-apple.S
+[197/467] Compiling armv4-mont-linux.S
+[198/467] Compiling aesv8-gcm-armv8-win.S
+[199/467] Compiling aesv8-gcm-armv8-linux.S
+[200/467] Compiling aesv8-gcm-armv8-apple.S
+[201/467] Compiling aesv8-armv8-win.S
+[202/467] Compiling aesv8-armv8-linux.S
+[203/467] Compiling aesv8-armv8-apple.S
+[204/467] Compiling aesv8-armv7-linux.S
+[205/467] Compiling aesni-x86_64-linux.S
+[206/467] Compiling aesni-x86_64-apple.S
+[207/467] Compiling aesni-x86-apple.S
+[208/467] Compiling aesni-x86-linux.S
+[209/467] Compiling aesni-gcm-x86_64-linux.S
+[210/467] Compiling aesni-gcm-x86_64-apple.S
+[211/467] Compiling aes-gcm-avx2-x86_64-linux.S
+[212/467] Compiling aes-gcm-avx2-x86_64-apple.S
+[213/467] Compiling aes-gcm-avx10-x86_64-linux.S
+[214/467] Compiling aes-gcm-avx10-x86_64-apple.S
+[215/467] Compiling x_sig.cc
+[216/467] Compiling x_val.cc
+[217/467] Compiling x_x509a.cc
+[218/467] Compiling x_spki.cc
+[219/467] Compiling x_x509.cc
+[220/467] Compiling x_req.cc
+[221/467] Compiling x_pubkey.cc
+[222/467] Compiling x_exten.cc
+[223/467] Compiling x_crl.cc
+[224/467] Compiling x_name.cc
+[225/467] Compiling x_attrib.cc
+[226/467] Compiling x_algor.cc
+[227/467] Compiling x509spki.cc
+[228/467] Compiling x509rset.cc
+[229/467] Compiling x_all.cc
+[230/467] Compiling x509cset.cc
+[231/467] Compiling x509name.cc
+[232/467] Compiling x509_vpm.cc
+[233/467] Compiling x509_v3.cc
+[234/467] Compiling x509_vfy.cc
+[235/467] Compiling x509_txt.cc
+[236/467] Compiling x509_trs.cc
+[237/467] Compiling x509_set.cc
+[238/467] Compiling x509_req.cc
+[239/467] Compiling x509_obj.cc
+[240/467] Compiling x509_def.cc
+[241/467] Compiling x509_ext.cc
+[242/467] Compiling x509_lu.cc
+[243/467] Compiling x509_d2.cc
+[244/467] Compiling x509_cmp.cc
+[245/467] Compiling x509.cc
+[246/467] Compiling x509_att.cc
+[247/467] Compiling v3_skey.cc
+[248/467] Compiling v3_utl.cc
+[249/467] Compiling v3_purp.cc
+[250/467] Compiling v3_prn.cc
+[251/467] Compiling v3_pmaps.cc
+[252/467] Compiling v3_pcons.cc
+[253/467] Compiling v3_ocsp.cc
+[254/467] Compiling v3_ncons.cc
+[255/467] Compiling v3_int.cc
+[256/467] Compiling v3_lib.cc
+[257/467] Compiling v3_info.cc
+[258/467] Compiling v3_ia5.cc
+[259/467] Compiling v3_genn.cc
+[260/467] Compiling v3_extku.cc
+[261/467] Compiling v3_enum.cc
+[262/467] Compiling v3_crld.cc
+[263/467] Compiling v3_cpols.cc
+[264/467] Compiling v3_conf.cc
+[265/467] Compiling v3_bitst.cc
+[266/467] Compiling v3_bcons.cc
+[267/467] Compiling v3_akeya.cc
+[268/467] Compiling v3_alt.cc
+[269/467] Compiling v3_akey.cc
+[270/467] Compiling t_x509a.cc
+[271/467] Compiling t_x509.cc
+[272/467] Compiling t_crl.cc
+[273/467] Compiling t_req.cc
+[274/467] Compiling rsa_pss.cc
+[275/467] Compiling i2d_pr.cc
+[276/467] Compiling name_print.cc
+[277/467] Compiling policy.cc
+[278/467] Compiling by_file.cc
+[279/467] Compiling by_dir.cc
+[280/467] Compiling algorithm.cc
+[281/467] Compiling asn1_gen.cc
+[282/467] Compiling a_verify.cc
+[283/467] Compiling a_sign.cc
+[284/467] Compiling trust_token.cc
+[285/467] Compiling a_digest.cc
+[286/467] Compiling voprf.cc
+[287/467] Compiling thread_win.cc
+[288/467] Compiling pmbtoken.cc
+[289/467] Compiling thread_pthread.cc
+[290/467] Compiling thread_none.cc
+[291/467] Compiling thread.cc
+[292/467] Compiling stack.cc
+[293/467] Compiling sha512.cc
+[294/467] Compiling siphash.cc
+[295/467] Compiling slhdsa.cc
+[296/467] Compiling spake2plus.cc
+[297/467] Compiling sha1.cc
+[298/467] Compiling sha256.cc
+[299/467] Compiling rsa_extra.cc
+[300/467] Compiling rsa_print.cc
+[301/467] Compiling rsa_crypt.cc
+[302/467] Compiling refcount.cc
+[303/467] Compiling rc4.cc
+[304/467] Compiling windows.cc
+[305/467] Compiling rsa_asn1.cc
+[306/467] Compiling urandom.cc
+[307/467] Compiling trusty.cc
+[308/467] Compiling rand.cc
+[309/467] Compiling ios.cc
+[310/467] Compiling passive.cc
+[311/467] Compiling getentropy.cc
+[312/467] Compiling forkunsafe.cc
+[313/467] Compiling deterministic.cc
+[314/467] Compiling fork_detect.cc
+[315/467] Compiling poly1305_arm_asm.S
+[316/467] Compiling pool.cc
+[317/467] Compiling poly1305.cc
+[318/467] Compiling poly1305_arm.cc
+[319/467] Compiling poly1305_vec.cc
+[320/467] Compiling pkcs7.cc
+[321/467] Compiling pkcs8_x509.cc
+[322/467] Compiling pkcs8.cc
+[323/467] Compiling p5_pbev2.cc
+[324/467] Compiling pkcs7_x509.cc
+[325/467] Compiling pem_xaux.cc
+[326/467] Compiling pem_pkey.cc
+[327/467] Compiling pem_x509.cc
+[328/467] Compiling pem_pk8.cc
+[329/467] Compiling pem_oth.cc
+[330/467] Compiling obj_xref.cc
+[331/467] Compiling pem_lib.cc
+[332/467] Compiling pem_info.cc
+[333/467] Compiling pem_all.cc
+[334/467] Compiling obj.cc
+[335/467] Compiling mlkem.cc
+[336/467] Compiling mldsa.cc
+[337/467] Compiling md5.cc
+[338/467] Compiling mem.cc
+[339/467] Compiling md4.cc
+[340/467] Compiling poly_rq_mul.S
+[341/467] Compiling lhash.cc
+[342/467] Compiling fips_shared_support.cc
+[343/467] Compiling kyber.cc
+[344/467] Compiling ex_data.cc
+[345/467] Compiling hpke.cc
+[346/467] Compiling hrss.cc
+[347/467] Compiling sign.cc
+[348/467] Compiling scrypt.cc
+[349/467] Compiling print.cc
+[350/467] Compiling pbkdf.cc
+[351/467] Compiling p_x25519.cc
+[352/467] Compiling p_x25519_asn1.cc
+[353/467] Compiling p_rsa_asn1.cc
+[354/467] Compiling p_rsa.cc
+[355/467] Compiling p_hkdf.cc
+[356/467] Compiling p_ed25519_asn1.cc
+[357/467] Compiling p_ed25519.cc
+[358/467] Compiling p_ec.cc
+[359/467] Compiling p_ec_asn1.cc
+[360/467] Compiling p_dh_asn1.cc
+[361/467] Compiling p_dsa_asn1.cc
+[362/467] Compiling p_dh.cc
+[363/467] Compiling evp_ctx.cc
+[364/467] Compiling evp.cc
+[365/467] Compiling evp_asn1.cc
+[366/467] Compiling err.cc
+[367/467] Compiling engine.cc
+[368/467] Compiling ecdh.cc
+[369/467] Compiling ec_derive.cc
+[370/467] Compiling ecdsa_asn1.cc
+[371/467] Compiling hash_to_curve.cc
+[372/467] Compiling ec_asn1.cc
+[373/467] Compiling dsa_asn1.cc
+[374/467] Compiling dsa.cc
+[375/467] Compiling digest_extra.cc
+[376/467] Compiling params.cc
+[377/467] Compiling dh_asn1.cc
+[378/467] Compiling spake25519.cc
+[379/467] Compiling x25519-asm-arm.S
+[380/467] Compiling des.cc
+[381/467] Compiling crypto.cc
+[382/467] Compiling cpu_intel.cc
+[383/467] Compiling cpu_arm_linux.cc
+[384/467] Compiling cpu_arm_freebsd.cc
+[385/467] Compiling curve25519.cc
+[386/467] Compiling curve25519_64_adx.cc
+[387/467] Compiling cpu_aarch64_win.cc
+[388/467] Compiling cpu_aarch64_sysreg.cc
+[389/467] Compiling cpu_aarch64_openbsd.cc
+[390/467] Compiling cpu_aarch64_linux.cc
+[391/467] Compiling cpu_aarch64_fuchsia.cc
+[392/467] Compiling cpu_aarch64_apple.cc
+[393/467] Compiling conf.cc
+[394/467] Compiling tls_cbc.cc
+[395/467] Compiling get_cipher.cc
+[396/467] Compiling e_tls.cc
+[397/467] Compiling e_rc4.cc
+[398/467] Compiling e_rc2.cc
+[399/467] Compiling e_null.cc
+[400/467] Compiling e_des.cc
+[401/467] Compiling e_chacha20poly1305.cc
+[402/467] Compiling e_aesctrhmac.cc
+[403/467] Compiling e_aesgcmsiv.cc
+[404/467] Compiling derive_key.cc
+[405/467] Compiling chacha.cc
+[406/467] Compiling unicode.cc
+[407/467] Compiling ber.cc
+[408/467] Compiling cbb.cc
+[409/467] Compiling cbs.cc
+[410/467] Compiling asn1_compat.cc
+[411/467] Compiling buf.cc
+[412/467] Compiling bn_asn1.cc
+[413/467] Compiling blake2.cc
+[414/467] Compiling convert.cc
+[415/467] Compiling socket_helper.cc
+[416/467] Compiling socket.cc
+[417/467] Compiling printf.cc
+[418/467] Compiling pair.cc
+[419/467] Compiling hexdump.cc
+[420/467] Compiling file.cc
+[421/467] Compiling errno.cc
+[422/467] Compiling fd.cc
+[423/467] Compiling connect.cc
+[424/467] Compiling bio_mem.cc
+[425/467] Compiling base64.cc
+[426/467] Compiling bio.cc
+[427/467] Compiling tasn_utl.cc
+[428/467] Compiling tasn_typ.cc
+[429/467] Compiling tasn_fre.cc
+[430/467] Compiling tasn_new.cc
+[431/467] Compiling tasn_enc.cc
+[432/467] Compiling posix_time.cc
+[433/467] Compiling f_string.cc
+[434/467] Compiling tasn_dec.cc
+[435/467] Compiling f_int.cc
+[436/467] Compiling asn_pack.cc
+[437/467] Compiling asn1_par.cc
+[438/467] Compiling asn1_lib.cc
+[439/467] Compiling a_type.cc
+[440/467] Compiling a_utctm.cc
+[441/467] Compiling a_time.cc
+[442/467] Compiling a_strnid.cc
+[443/467] Compiling a_octet.cc
+[444/467] Compiling a_strex.cc
+[445/467] Compiling a_object.cc
+[446/467] Compiling a_mbstr.cc
+[447/467] Compiling a_i2d_fp.cc
+[448/467] Compiling a_int.cc
+[449/467] Compiling a_gentm.cc
+[450/467] Compiling a_dup.cc
+[451/467] Compiling a_d2i_fp.cc
+[452/467] Compiling bcm.cc
+[453/467] Compiling a_bool.cc
+[454/467] Write sources
+[456/467] Compiling CAsyncHTTPClient CAsyncHTTPClient.c
+[457/467] Write sources
+[458/467] Compiling a_bitstr.cc
+[459/469] Compiling c-nioatomics.c
+[460/469] Compiling c-atomics.c
+[462/470] Compiling NIOConcurrencyHelpers NIOAtomic.swift
+[463/470] Compiling Atomics OptionalRawRepresentable.swift
+[464/471] Compiling Algorithms AdjacentPairs.swift
+[465/471] Compiling NIOCore AddressedEnvelope.swift
+[466/473] Compiling NIOEmbedded AsyncTestingChannel.swift
+[467/473] Compiling NIOPosix BSDSocketAPICommon.swift
+[468/474] Compiling NIO Exports.swift
+[469/478] Compiling NIOTLS ApplicationProtocolNegotiationHandler.swift
+[470/479] Compiling NIOSOCKS SOCKSClientHandler.swift
+[471/479] Compiling NIOFoundationCompat ByteBuffer-foundation.swift
+[472/480] Compiling NIOTransportServices AcceptHandler.swift
+[473/480] Compiling NIOHTTP1 ByteCollectionUtils.swift
+[474/482] Compiling NIOSSL AndroidCABundle.swift
+[475/482] Compiling NIOHTTPCompression HTTPCompression.swift
+[476/482] Compiling NIOHPACK DynamicHeaderTable.swift
+[477/483] Compiling NIOHTTP2 ConnectionStateMachine.swift
+[478/484] Compiling AsyncHTTPClient AnyAsyncSequence.swift
+[479/485] Compiling FountainCodex ClientGenerator.swift
+[480/487] Compiling clientgen_service main.swift
+[480/487] Write Objects.LinkFileList
+[481/487] Linking clientgen-service
+[483/487] Compiling PublishingFrontend DNSProvider.swift
+[484/489] Compiling publishing_frontend main.swift
+[484/489] Write Objects.LinkFileList
+[486/489] Compiling gateway_server CertificateManager.swift
+[486/489] Write Objects.LinkFileList
+[487/489] Linking publishing-frontend
+[488/489] Linking gateway-server
+Build complete! (431.30s)
+Test Suite 'All tests' started at 2025-08-02 09:54:34.998
+Test Suite 'release.xctest' started at 2025-08-02 09:54:35.030
+Test Suite 'ClientGeneratorTests' started at 2025-08-02 09:54:35.030
+Test Case 'ClientGeneratorTests.testClientFilesGenerated' started at 2025-08-02 09:54:35.030
+Test Case 'ClientGeneratorTests.testClientFilesGenerated' passed (0.031 seconds)
+Test Suite 'ClientGeneratorTests' passed at 2025-08-02 09:54:35.061
+	 Executed 1 test, with 0 failures (0 unexpected) in 0.031 (0.031) seconds
+Test Suite 'OpenAPISwiftTypeTests' started at 2025-08-02 09:54:35.061
+Test Case 'OpenAPISwiftTypeTests.testSchemaPropertySwiftType' started at 2025-08-02 09:54:35.061
+Test Case 'OpenAPISwiftTypeTests.testSchemaPropertySwiftType' passed (0.001 seconds)
+Test Case 'OpenAPISwiftTypeTests.testSchemaRefSwiftType' started at 2025-08-02 09:54:35.062
+Test Case 'OpenAPISwiftTypeTests.testSchemaRefSwiftType' passed (0.0 seconds)
+Test Suite 'OpenAPISwiftTypeTests' passed at 2025-08-02 09:54:35.062
+	 Executed 2 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
+Test Suite 'SecurityRequirementTests' started at 2025-08-02 09:54:35.062
+Test Case 'SecurityRequirementTests.testDecodesSchemesFromJSON' started at 2025-08-02 09:54:35.062
+Test Case 'SecurityRequirementTests.testDecodesSchemesFromJSON' passed (0.001 seconds)
+Test Case 'SecurityRequirementTests.testEncodesSchemesToJSON' started at 2025-08-02 09:54:35.063
+Test Case 'SecurityRequirementTests.testEncodesSchemesToJSON' passed (0.003 seconds)
+Test Suite 'SecurityRequirementTests' passed at 2025-08-02 09:54:35.066
+	 Executed 2 tests, with 0 failures (0 unexpected) in 0.004 (0.004) seconds
+Test Suite 'SpecLoaderTests' started at 2025-08-02 09:54:35.066
+Test Case 'SpecLoaderTests.testLoadsJSONRemovingCopyright' started at 2025-08-02 09:54:35.066
+Test Case 'SpecLoaderTests.testLoadsJSONRemovingCopyright' passed (0.003 seconds)
+Test Case 'SpecLoaderTests.testLoadsYAMLAndNormalizesInfoTitle' started at 2025-08-02 09:54:35.070
+Test Case 'SpecLoaderTests.testLoadsYAMLAndNormalizesInfoTitle' passed (0.011 seconds)
+Test Suite 'SpecLoaderTests' passed at 2025-08-02 09:54:35.081
+	 Executed 2 tests, with 0 failures (0 unexpected) in 0.015 (0.015) seconds
+Test Suite 'SpecValidatorTests' started at 2025-08-02 09:54:35.081
+Test Case 'SpecValidatorTests.testDuplicateOperationIdThrows' started at 2025-08-02 09:54:35.081
+Test Case 'SpecValidatorTests.testDuplicateOperationIdThrows' passed (0.001 seconds)
+Test Case 'SpecValidatorTests.testUnresolvedSchemaReferenceThrows' started at 2025-08-02 09:54:35.083
+Test Case 'SpecValidatorTests.testUnresolvedSchemaReferenceThrows' passed (0.0 seconds)
+Test Suite 'SpecValidatorTests' passed at 2025-08-02 09:54:35.083
+	 Executed 2 tests, with 0 failures (0 unexpected) in 0.002 (0.002) seconds
+Test Suite 'StringExtensionTests' started at 2025-08-02 09:54:35.083
+Test Case 'StringExtensionTests.testCamelCased' started at 2025-08-02 09:54:35.083
+Test Case 'StringExtensionTests.testCamelCased' passed (0.001 seconds)
+Test Suite 'StringExtensionTests' passed at 2025-08-02 09:54:35.084
+	 Executed 1 test, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
+Test Suite 'AsyncHTTPClientDriverTests' started at 2025-08-02 09:54:35.084
+Test Case 'AsyncHTTPClientDriverTests.testExecutePerformsRequest' started at 2025-08-02 09:54:35.084
+Test Case 'AsyncHTTPClientDriverTests.testExecutePerformsRequest' passed (0.027 seconds)
+Test Suite 'AsyncHTTPClientDriverTests' passed at 2025-08-02 09:54:35.110
+	 Executed 1 test, with 0 failures (0 unexpected) in 0.027 (0.027) seconds
+Test Suite 'CertificateManagerTests' started at 2025-08-02 09:54:35.110
+Test Case 'CertificateManagerTests.testTriggerNowRunsScript' started at 2025-08-02 09:54:35.110
+Test Case 'CertificateManagerTests.testTriggerNowRunsScript' passed (1.007 seconds)
+Test Suite 'CertificateManagerTests' passed at 2025-08-02 09:54:36.117
+	 Executed 1 test, with 0 failures (0 unexpected) in 1.007 (1.007) seconds
+Test Suite 'GatewayPluginDefaultTests' started at 2025-08-02 09:54:36.117
+Test Case 'GatewayPluginDefaultTests.testDefaultImplementationsPassThrough' started at 2025-08-02 09:54:36.117
+Test Case 'GatewayPluginDefaultTests.testDefaultImplementationsPassThrough' passed (0.001 seconds)
+Test Suite 'GatewayPluginDefaultTests' passed at 2025-08-02 09:54:36.118
+	 Executed 1 test, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
+Test Suite 'GatewayServerTests' started at 2025-08-02 09:54:36.118
+Test Case 'GatewayServerTests.testHealthEndpointResponds' started at 2025-08-02 09:54:36.118
+Test Case 'GatewayServerTests.testHealthEndpointResponds' passed (0.119 seconds)
+Test Case 'GatewayServerTests.testMetricsEndpointResponds' started at 2025-08-02 09:54:36.237
+Test Case 'GatewayServerTests.testMetricsEndpointResponds' passed (0.106 seconds)
+Test Case 'GatewayServerTests.testPluginCanRewriteRequestAndResponse' started at 2025-08-02 09:54:36.343
+Test Case 'GatewayServerTests.testPluginCanRewriteRequestAndResponse' passed (0.107 seconds)
+Test Suite 'GatewayServerTests' passed at 2025-08-02 09:54:36.450
+	 Executed 3 tests, with 0 failures (0 unexpected) in 0.331 (0.331) seconds
+Test Suite 'HTTPKernelTests' started at 2025-08-02 09:54:36.450
+Test Case 'HTTPKernelTests.testKernelRoutesRequest' started at 2025-08-02 09:54:36.450
+Test Case 'HTTPKernelTests.testKernelRoutesRequest' passed (0.001 seconds)
+Test Suite 'HTTPKernelTests' passed at 2025-08-02 09:54:36.451
+	 Executed 1 test, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
+Test Suite 'HTTPResponseDefaultsTests' started at 2025-08-02 09:54:36.451
+Test Case 'HTTPResponseDefaultsTests.testNoBodyCodable' started at 2025-08-02 09:54:36.451
+Test Case 'HTTPResponseDefaultsTests.testNoBodyCodable' passed (0.001 seconds)
+Test Case 'HTTPResponseDefaultsTests.testResponseDefaults' started at 2025-08-02 09:54:36.452
+Test Case 'HTTPResponseDefaultsTests.testResponseDefaults' passed (0.001 seconds)
+Test Suite 'HTTPResponseDefaultsTests' passed at 2025-08-02 09:54:36.452
+	 Executed 2 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
+Test Suite 'LoggingPluginTests' started at 2025-08-02 09:54:36.452
+Test Case 'LoggingPluginTests.testLoggingPluginPassThrough' started at 2025-08-02 09:54:36.452
+-> GET /
+<- 200 for /
+Test Case 'LoggingPluginTests.testLoggingPluginPassThrough' passed (0.001 seconds)
+Test Suite 'LoggingPluginTests' passed at 2025-08-02 09:54:36.453
+	 Executed 1 test, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
+Test Suite 'NIOHTTPServerTests' started at 2025-08-02 09:54:36.453
+Test Case 'NIOHTTPServerTests.testServerResponds' started at 2025-08-02 09:54:36.453
+Test Case 'NIOHTTPServerTests.testServerResponds' passed (0.004 seconds)
+Test Suite 'NIOHTTPServerTests' passed at 2025-08-02 09:54:36.457
+	 Executed 1 test, with 0 failures (0 unexpected) in 0.004 (0.004) seconds
+Test Suite 'PublishingFrontendPluginTests' started at 2025-08-02 09:54:36.457
+Test Case 'PublishingFrontendPluginTests.testPluginServesFile' started at 2025-08-02 09:54:36.457
+Test Case 'PublishingFrontendPluginTests.testPluginServesFile' passed (0.008 seconds)
+Test Suite 'PublishingFrontendPluginTests' passed at 2025-08-02 09:54:36.465
+	 Executed 1 test, with 0 failures (0 unexpected) in 0.008 (0.008) seconds
+Test Suite 'URLSessionHTTPClientTests' started at 2025-08-02 09:54:36.465
+Test Case 'URLSessionHTTPClientTests.testExecutePerformsRequest' started at 2025-08-02 09:54:36.465
+Test Case 'URLSessionHTTPClientTests.testExecutePerformsRequest' passed (0.002 seconds)
+Test Suite 'URLSessionHTTPClientTests' passed at 2025-08-02 09:54:36.467
+	 Executed 1 test, with 0 failures (0 unexpected) in 0.002 (0.002) seconds
+Test Suite 'FountainCoreTests' started at 2025-08-02 09:54:36.467
+Test Case 'FountainCoreTests.testTodoDecoding' started at 2025-08-02 09:54:36.467
+Test Case 'FountainCoreTests.testTodoDecoding' passed (0.002 seconds)
+Test Case 'FountainCoreTests.testTodoEncodingRoundTrip' started at 2025-08-02 09:54:36.469
+Test Case 'FountainCoreTests.testTodoEncodingRoundTrip' passed (0.001 seconds)
+Test Suite 'FountainCoreTests' passed at 2025-08-02 09:54:36.470
+	 Executed 2 tests, with 0 failures (0 unexpected) in 0.003 (0.003) seconds
+Test Suite 'APIClientTests' started at 2025-08-02 09:54:36.470
+Test Case 'APIClientTests.testBearerInitializerSetsHeader' started at 2025-08-02 09:54:36.470
+Test Case 'APIClientTests.testBearerInitializerSetsHeader' passed (0.001 seconds)
+Test Case 'APIClientTests.testRawDataResponse' started at 2025-08-02 09:54:36.471
+Test Case 'APIClientTests.testRawDataResponse' passed (0.002 seconds)
+Test Case 'APIClientTests.testSendDecodesResponse' started at 2025-08-02 09:54:36.473
+Test Case 'APIClientTests.testSendDecodesResponse' passed (0.001 seconds)
+Test Suite 'APIClientTests' passed at 2025-08-02 09:54:36.474
+	 Executed 3 tests, with 0 failures (0 unexpected) in 0.004 (0.004) seconds
+Test Suite 'CreatePrimaryServerRequestTests' started at 2025-08-02 09:54:36.474
+Test Case 'CreatePrimaryServerRequestTests.testMethodIsPOST' started at 2025-08-02 09:54:36.474
+Test Case 'CreatePrimaryServerRequestTests.testMethodIsPOST' passed (0.0 seconds)
+Test Case 'CreatePrimaryServerRequestTests.testPathIsCorrect' started at 2025-08-02 09:54:36.474
+Test Case 'CreatePrimaryServerRequestTests.testPathIsCorrect' passed (0.0 seconds)
+Test Suite 'CreatePrimaryServerRequestTests' passed at 2025-08-02 09:54:36.475
+	 Executed 2 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
+Test Suite 'DNSClientTests' started at 2025-08-02 09:54:36.475
+Test Case 'DNSClientTests.testRoute53CreateRecordStub' started at 2025-08-02 09:54:36.475
+Test Case 'DNSClientTests.testRoute53CreateRecordStub' passed (0.101 seconds)
+Test Case 'DNSClientTests.testRoute53DeleteRecordStub' started at 2025-08-02 09:54:36.576
+Test Case 'DNSClientTests.testRoute53DeleteRecordStub' passed (0.001 seconds)
+Test Case 'DNSClientTests.testRoute53Stub' started at 2025-08-02 09:54:36.576
+Test Case 'DNSClientTests.testRoute53Stub' passed (0.001 seconds)
+Test Case 'DNSClientTests.testRoute53UpdateRecordStub' started at 2025-08-02 09:54:36.577
+Test Case 'DNSClientTests.testRoute53UpdateRecordStub' passed (0.001 seconds)
+Test Suite 'DNSClientTests' passed at 2025-08-02 09:54:36.578
+	 Executed 4 tests, with 0 failures (0 unexpected) in 0.103 (0.103) seconds
+Test Suite 'DeleteZoneRequestTests' started at 2025-08-02 09:54:36.578
+Test Case 'DeleteZoneRequestTests.testPathBuilderEncodesZoneId' started at 2025-08-02 09:54:36.578
+Test Case 'DeleteZoneRequestTests.testPathBuilderEncodesZoneId' passed (0.002 seconds)
+Test Suite 'DeleteZoneRequestTests' passed at 2025-08-02 09:54:36.580
+	 Executed 1 test, with 0 failures (0 unexpected) in 0.002 (0.002) seconds
+Test Suite 'GetPrimaryServerRequestTests' started at 2025-08-02 09:54:36.580
+Test Case 'GetPrimaryServerRequestTests.testMethodIsGET' started at 2025-08-02 09:54:36.580
+Test Case 'GetPrimaryServerRequestTests.testMethodIsGET' passed (0.0 seconds)
+Test Case 'GetPrimaryServerRequestTests.testPathBuilderReplacesId' started at 2025-08-02 09:54:36.580
+Test Case 'GetPrimaryServerRequestTests.testPathBuilderReplacesId' passed (0.001 seconds)
+Test Suite 'GetPrimaryServerRequestTests' passed at 2025-08-02 09:54:36.581
+	 Executed 2 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
+Test Suite 'GetRecordRequestTests' started at 2025-08-02 09:54:36.581
+Test Case 'GetRecordRequestTests.testPathBuilderReplacesRecordId' started at 2025-08-02 09:54:36.581
+Test Case 'GetRecordRequestTests.testPathBuilderReplacesRecordId' passed (0.0 seconds)
+Test Suite 'GetRecordRequestTests' passed at 2025-08-02 09:54:36.581
+	 Executed 1 test, with 0 failures (0 unexpected) in 0.0 (0.0) seconds
+Test Suite 'HetznerDNSClientTests' started at 2025-08-02 09:54:36.581
+Test Case 'HetznerDNSClientTests.testCreateRecordRequest' started at 2025-08-02 09:54:36.582
+Test Case 'HetznerDNSClientTests.testCreateRecordRequest' passed (0.003 seconds)
+Test Case 'HetznerDNSClientTests.testCreateRecordSetsContentTypeHeader' started at 2025-08-02 09:54:36.584
+Test Case 'HetznerDNSClientTests.testCreateRecordSetsContentTypeHeader' passed (0.001 seconds)
+Test Case 'HetznerDNSClientTests.testDeleteRecordRequest' started at 2025-08-02 09:54:36.585
+Test Case 'HetznerDNSClientTests.testDeleteRecordRequest' passed (0.001 seconds)
+Test Case 'HetznerDNSClientTests.testListZonesPathBuilder' started at 2025-08-02 09:54:36.586
+Test Case 'HetznerDNSClientTests.testListZonesPathBuilder' passed (0.001 seconds)
+Test Case 'HetznerDNSClientTests.testUpdateRecordRequest' started at 2025-08-02 09:54:36.587
+Test Case 'HetznerDNSClientTests.testUpdateRecordRequest' passed (0.001 seconds)
+Test Suite 'HetznerDNSClientTests' passed at 2025-08-02 09:54:36.587
+	 Executed 5 tests, with 0 failures (0 unexpected) in 0.006 (0.006) seconds
+Test Suite 'ListRecordsRequestTests' started at 2025-08-02 09:54:36.587
+Test Case 'ListRecordsRequestTests.testPathBuilderEncodesQuery' started at 2025-08-02 09:54:36.587
+Test Case 'ListRecordsRequestTests.testPathBuilderEncodesQuery' passed (0.0 seconds)
+Test Suite 'ListRecordsRequestTests' passed at 2025-08-02 09:54:36.588
+	 Executed 1 test, with 0 failures (0 unexpected) in 0.0 (0.0) seconds
+Test Suite 'HetznerDNSRequestTests' started at 2025-08-02 09:54:36.588
+Test Case 'HetznerDNSRequestTests.testUpdatePrimaryServerMethodIsPut' started at 2025-08-02 09:54:36.588
+Test Case 'HetznerDNSRequestTests.testUpdatePrimaryServerMethodIsPut' passed (0.0 seconds)
+Test Case 'HetznerDNSRequestTests.testUpdatePrimaryServerPathIncludesID' started at 2025-08-02 09:54:36.588
+Test Case 'HetznerDNSRequestTests.testUpdatePrimaryServerPathIncludesID' passed (0.0 seconds)
+Test Case 'HetznerDNSRequestTests.testValidateZoneFileMethodIsPost' started at 2025-08-02 09:54:36.588
+Test Case 'HetznerDNSRequestTests.testValidateZoneFileMethodIsPost' passed (0.0 seconds)
+Test Case 'HetznerDNSRequestTests.testValidateZoneFilePath' started at 2025-08-02 09:54:36.588
+Test Case 'HetznerDNSRequestTests.testValidateZoneFilePath' passed (0.0 seconds)
+Test Suite 'HetznerDNSRequestTests' passed at 2025-08-02 09:54:36.589
+	 Executed 4 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
+Test Suite 'PublishingFrontendTests' started at 2025-08-02 09:54:36.589
+Test Case 'PublishingFrontendTests.testLoadPublishingConfigParsesYaml' started at 2025-08-02 09:54:36.589
+Test Case 'PublishingFrontendTests.testLoadPublishingConfigParsesYaml' passed (0.004 seconds)
+Test Case 'PublishingFrontendTests.testPublishingConfigDefaultValues' started at 2025-08-02 09:54:36.593
+Test Case 'PublishingFrontendTests.testPublishingConfigDefaultValues' passed (0.0 seconds)
+Test Case 'PublishingFrontendTests.testServerServesIndex' started at 2025-08-02 09:54:36.594
+Test Case 'PublishingFrontendTests.testServerServesIndex' passed (0.009 seconds)
+Test Suite 'PublishingFrontendTests' passed at 2025-08-02 09:54:36.603
+	 Executed 3 tests, with 0 failures (0 unexpected) in 0.014 (0.014) seconds
+Test Suite 'Route53ClientTests' started at 2025-08-02 09:54:36.603
+Test Case 'Route53ClientTests.testCreateRecordThrows' started at 2025-08-02 09:54:36.603
+Test Case 'Route53ClientTests.testCreateRecordThrows' passed (0.001 seconds)
+Test Case 'Route53ClientTests.testDeleteRecordThrows' started at 2025-08-02 09:54:36.604
+Test Case 'Route53ClientTests.testDeleteRecordThrows' passed (0.001 seconds)
+Test Case 'Route53ClientTests.testListZonesThrows' started at 2025-08-02 09:54:36.604
+Test Case 'Route53ClientTests.testListZonesThrows' passed (0.0 seconds)
+Test Case 'Route53ClientTests.testUpdateRecordThrows' started at 2025-08-02 09:54:36.605
+Test Case 'Route53ClientTests.testUpdateRecordThrows' passed (0.0 seconds)
+Test Suite 'Route53ClientTests' passed at 2025-08-02 09:54:36.605
+	 Executed 4 tests, with 0 failures (0 unexpected) in 0.002 (0.002) seconds
+Test Suite 'release.xctest' passed at 2025-08-02 09:54:36.605
+	 Executed 55 tests, with 0 failures (0 unexpected) in 1.572 (1.572) seconds
+Test Suite 'All tests' passed at 2025-08-02 09:54:36.605
+	 Executed 55 tests, with 0 failures (0 unexpected) in 1.572 (1.572) seconds
+◇ Test run started.
+↳ Testing Library Version: 6.1 (43b6f88e2f2712e)
+↳ Target Platform: x86_64-unknown-linux-gnu
+✔ Test run with 0 tests passed after 0.002 seconds.


### PR DESCRIPTION
## Summary
- document validateZoneFile and updatePrimaryServer requests in Hetzner DNS client
- add unit tests for validateZoneFile and updatePrimaryServer requests
- record coverage progress

## Testing
- `swift build -c release -Xswiftc -O -Xswiftc -warnings-as-errors`
- `swift test -c release --enable-code-coverage`


------
https://chatgpt.com/codex/tasks/task_e_688ddcdad8588325a16c094f3ff3972c