### PR TITLE
Document ServerGenerator helpers and expand Todo tests

### DIFF
--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -5,20 +5,20 @@
 Running `swift test --enable-code-coverage` and analysing with `llvm-cov` produced the following totals:
 
 ```
-TOTAL                                          31455   26675    15.20%   14048 11541    17.85%   98751   81733    17.23%
+TOTAL                                          31462   26681    15.20%   14055 11545    17.86%   98765   81754    17.22%
 ```
 
-The repository contains **98,751** executable lines, with **17,018** lines covered (approx. **17.23%** line coverage).
+The repository contains **98,765** executable lines, with **17,011** lines covered (approx. **17.22%** line coverage).
 
 ### Repository source coverage
 
 Ignoring third-party packages under `.build/checkouts`, the totals are:
 
 ```
-TOTAL                                           945     327    65.40%     420    70    83.33%    2116     605    71.41%
+TOTAL                                           950     327    65.58%     425    70    83.53%    2128     605    71.57%
 ```
 
-Within repository sources there are **2,116** lines, with **1,511** covered, giving **71.41%** line coverage.
+Within repository sources there are **2,128** lines, with **1,523** covered, giving **71.57%** line coverage.
 
 Coverage results are recalculated after each test run to monitor progress. The project strives for ever more comprehensive test suites across all modules. Recent additions include unit tests for ``APIClient``. New tests now verify ``URLSessionHTTPClient`` behavior and the ``Supervisor`` process termination logic.
 Additional tests now cover ``OpenAPISpec.swiftType`` and the ``camelCased`` string helper. A new ``GatewayServerTests`` suite raises total tests to **27**.
@@ -35,6 +35,7 @@ The new ``AsyncHTTPClientDriverTests`` bring the total test count to **41**.
 The new ``CreatePrimaryServerRequestTests`` and ``GetPrimaryServerRequestTests`` raise the total test count to **49**.
 Additional plugin rewrite and raw data tests raise the total test count to **51**.
 The new ``validateZoneFile`` and ``updatePrimaryServer`` request tests raise the total test count to **55**.
+The new ``TodoEquality`` and ``TodoDecodingFailsForMissingName`` tests bring the total test count to **57**.
 
 ---
 © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainCodex/ServerGenerator/ServerGenerator.swift
+++ b/Sources/FountainCodex/ServerGenerator/ServerGenerator.swift
@@ -16,6 +16,8 @@ public enum ServerGenerator {
         try emitKernel(to: url)
     }
 
+    /// Writes a minimal `HTTPRequest` type used by generated servers.
+    /// - Parameter url: Directory to place the generated source file in.
     private static func emitHTTPRequest(to url: URL) throws {
         let output = """
         import Foundation
@@ -39,6 +41,8 @@ public enum ServerGenerator {
         try (output + "\n").write(to: url.appendingPathComponent("HTTPRequest.swift"), atomically: true, encoding: .utf8)
     }
 
+    /// Writes a minimal `HTTPResponse` type used by generated servers.
+    /// - Parameter url: Directory to place the generated source file in.
     private static func emitHTTPResponse(to url: URL) throws {
         let output = """
         import Foundation
@@ -58,6 +62,10 @@ public enum ServerGenerator {
         try (output + "\n").write(to: url.appendingPathComponent("HTTPResponse.swift"), atomically: true, encoding: .utf8)
     }
 
+    /// Emits a default `Handlers` struct with stubs for each operation.
+    /// - Parameters:
+    ///   - spec: Source specification describing server operations.
+    ///   - url: Directory where the file should be generated.
     private static func emitHandlers(from spec: OpenAPISpec, to url: URL) throws {
         var output = "import Foundation\n\npublic struct Handlers {\n    public init() {}\n"
         if let paths = spec.paths {
@@ -80,6 +88,10 @@ public enum ServerGenerator {
         try output.write(to: url.appendingPathComponent("Handlers.swift"), atomically: true, encoding: .utf8)
     }
 
+    /// Emits a routing table that dispatches requests to generated handlers.
+    /// - Parameters:
+    ///   - spec: Source specification describing paths and methods.
+    ///   - url: Directory where the file should be generated.
     private static func emitRouter(from spec: OpenAPISpec, to url: URL) throws {
         var output = "import Foundation\n\npublic struct Router {\n    public var handlers: Handlers\n\n    public init(handlers: Handlers = Handlers()) {\n        self.handlers = handlers\n    }\n\n    public func route(_ request: HTTPRequest) async throws -> HTTPResponse {\n        switch (request.method, request.path) {\n"
         if let paths = spec.paths {
@@ -102,6 +114,8 @@ public enum ServerGenerator {
         try output.write(to: url.appendingPathComponent("Router.swift"), atomically: true, encoding: .utf8)
     }
 
+    /// Emits an `HTTPKernel` that wires the router into a service boundary.
+    /// - Parameter url: Directory to place the generated source file in.
     private static func emitKernel(to url: URL) throws {
         let output = """
         import Foundation
@@ -121,6 +135,8 @@ public enum ServerGenerator {
         try (output + "\n").write(to: url.appendingPathComponent("HTTPKernel.swift"), atomically: true, encoding: .utf8)
     }
 
+    /// Emits a lightweight `URLProtocol`-based HTTP server for testing.
+    /// - Parameter url: Directory to place the generated source file in.
     private static func emitHTTPServer(to url: URL) throws {
         let output = """
         import Foundation

--- a/Tests/FountainCoreTests/FountainCoreTests.swift
+++ b/Tests/FountainCoreTests/FountainCoreTests.swift
@@ -15,6 +15,17 @@ final class FountainCoreTests: XCTestCase {
         let decoded = try JSONDecoder().decode(Todo.self, from: data)
         XCTAssertEqual(decoded, original)
     }
+
+    func testTodoEquality() {
+        let a = Todo(id: 1, name: "A")
+        let b = Todo(id: 1, name: "A")
+        XCTAssertEqual(a, b)
+    }
+
+    func testTodoDecodingFailsForMissingName() {
+        let json = #"{"id":1}"#.data(using: .utf8)!
+        XCTAssertThrowsError(try JSONDecoder().decode(Todo.self, from: json))
+    }
 }
 
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -44,6 +44,7 @@ As modules gain documentation, brief summaries are added here.
 - **GatewayServer** – internal components like the certificate manager and plugin stack are now described.
 - **APIClient.baseURL**, **session**, and **defaultHeaders** – stored properties document connection details.
 - **HetznerDNSClient.api** – underlying HTTP client property now documented.
+- **ServerGenerator emit helpers** – private functions now describe generated source responsibilities.
 
 Documentation coverage will expand alongside test coverage.
 

--- a/logs/build-20250802-100315.log
+++ b/logs/build-20250802-100315.log
@@ -1,0 +1,319 @@
+[0/1] Planning build
+Building for production...
+[0/12] Write sources
+[5/18] Write swift-version--4EAD98957C2213E4.txt
+[7/23] Compiling _NIOBase64 Base64.swift
+[8/24] Compiling RealModule AlgebraicField.swift
+[9/24] Compiling _NIODataStructures Heap.swift
+[10/25] Compiling NIOConcurrencyHelpers NIOAtomic.swift
+[11/27] Compiling FountainCore Models.swift
+[12/28] Compiling InternalCollectionsUtilities FixedWidthInteger+roundUpToPowerOfTwo.swift
+[13/29] Compiling Logging Locks.swift
+[14/30] Compiling Atomics OptionalRawRepresentable.swift
+[15/30] Compiling DequeModule Deque+Codable.swift
+[16/31] Compiling FountainCoreTests FountainCoreTests.swift
+[17/31] Compiling Algorithms AdjacentPairs.swift
+[18/31] Compiling Yams AliasDereferencingStrategy.swift
+[19/31] Compiling NIOCore AddressedEnvelope.swift
+[20/33] Compiling NIOEmbedded AsyncTestingChannel.swift
+[21/33] Compiling NIOPosix BSDSocketAPICommon.swift
+[22/34] Compiling NIO Exports.swift
+[23/38] Compiling NIOFoundationCompat ByteBuffer-foundation.swift
+[24/38] Compiling NIOTLS ApplicationProtocolNegotiationHandler.swift
+[25/40] Compiling NIOSOCKS SOCKSClientHandler.swift
+[26/40] Compiling NIOTransportServices AcceptHandler.swift
+[27/40] Compiling NIOHTTP1 ByteCollectionUtils.swift
+[28/42] Compiling NIOSSL AndroidCABundle.swift
+[29/42] Compiling NIOHTTPCompression HTTPCompression.swift
+[30/42] Compiling NIOHPACK DynamicHeaderTable.swift
+[31/43] Compiling NIOHTTP2 ConnectionStateMachine.swift
+[32/44] Compiling AsyncHTTPClient AnyAsyncSequence.swift
+[33/45] Compiling FountainCodex ClientGenerator.swift
+[34/48] Compiling clientgen_service main.swift
+[34/48] Write Objects.LinkFileList
+[36/48] Compiling ClientGeneratorTests ClientGeneratorTests.swift
+/workspace/codex-deployer/Tests/ClientGeneratorTests/SpecValidatorTests.swift:6:13: warning: variable 'op' was never mutated; consider changing to 'let' constant
+ 4 | final class SpecValidatorTests: XCTestCase {
+ 5 |     func testDuplicateOperationIdThrows() throws {
+ 6 |         var op = OpenAPISpec.Operation(operationId: "op", parameters: nil, requestBody: nil, responses: nil, security: nil)
+   |             `- warning: variable 'op' was never mutated; consider changing to 'let' constant
+ 7 |         let item = OpenAPISpec.PathItem(get: op, post: nil, put: nil, delete: nil)
+ 8 |         var spec = OpenAPISpec(title: "API", servers: nil, components: nil, paths: [
+
+/workspace/codex-deployer/Tests/ClientGeneratorTests/SpecValidatorTests.swift:8:13: warning: variable 'spec' was never mutated; consider changing to 'let' constant
+ 6 |         var op = OpenAPISpec.Operation(operationId: "op", parameters: nil, requestBody: nil, responses: nil, security: nil)
+ 7 |         let item = OpenAPISpec.PathItem(get: op, post: nil, put: nil, delete: nil)
+ 8 |         var spec = OpenAPISpec(title: "API", servers: nil, components: nil, paths: [
+   |             `- warning: variable 'spec' was never mutated; consider changing to 'let' constant
+ 9 |             "/a": item,
+10 |             "/b": item
+
+/workspace/codex-deployer/Tests/ClientGeneratorTests/SpecValidatorTests.swift:18:13: warning: variable 'paramSchema' was never mutated; consider changing to 'let' constant
+16 | 
+17 |     func testUnresolvedSchemaReferenceThrows() throws {
+18 |         var paramSchema = OpenAPISpec.Schema()
+   |             `- warning: variable 'paramSchema' was never mutated; consider changing to 'let' constant
+19 |         paramSchema.ref = "#/components/schemas/Missing"
+20 |         let param = OpenAPISpec.Parameter(name: "id", location: "path", required: true, schema: paramSchema)
+
+/workspace/codex-deployer/Tests/ClientGeneratorTests/SpecValidatorTests.swift:21:13: warning: variable 'op' was never mutated; consider changing to 'let' constant
+19 |         paramSchema.ref = "#/components/schemas/Missing"
+20 |         let param = OpenAPISpec.Parameter(name: "id", location: "path", required: true, schema: paramSchema)
+21 |         var op = OpenAPISpec.Operation(operationId: "get", parameters: [param], requestBody: nil, responses: nil, security: nil)
+   |             `- warning: variable 'op' was never mutated; consider changing to 'let' constant
+22 |         let item = OpenAPISpec.PathItem(get: op, post: nil, put: nil, delete: nil)
+23 |         let components = OpenAPISpec.Components(schemas: [:], securitySchemes: nil)
+
+/workspace/codex-deployer/Tests/ClientGeneratorTests/SpecValidatorTests.swift:24:13: warning: variable 'spec' was never mutated; consider changing to 'let' constant
+22 |         let item = OpenAPISpec.PathItem(get: op, post: nil, put: nil, delete: nil)
+23 |         let components = OpenAPISpec.Components(schemas: [:], securitySchemes: nil)
+24 |         var spec = OpenAPISpec(title: "API", servers: nil, components: components, paths: ["/item/{id}": item])
+   |             `- warning: variable 'spec' was never mutated; consider changing to 'let' constant
+25 |         XCTAssertThrowsError(try SpecValidator.validate(spec)) { error in
+26 |             XCTAssertTrue("\(error)".contains("unresolved reference"))
+[36/48] Linking clientgen-service
+[38/48] Compiling PublishingFrontend DNSProvider.swift
+[39/52] Compiling publishing_frontend main.swift
+[39/52] Write Objects.LinkFileList
+[41/52] Compiling PublishingFrontendTests HetznerDNSRequestTests.swift
+/workspace/codex-deployer/Tests/PublishingFrontendTests/PublishingFrontendTests.swift:35:37: warning: result of call to 'changeCurrentDirectoryPath' is unused
+33 |         try yaml.write(to: fileURL, atomically: true, encoding: .utf8)
+34 |         let cwd = FileManager.default.currentDirectoryPath
+35 |         defer { FileManager.default.changeCurrentDirectoryPath(cwd) }
+   |                                     `- warning: result of call to 'changeCurrentDirectoryPath' is unused
+36 |         FileManager.default.changeCurrentDirectoryPath(dir.path)
+37 |         let config = try loadPublishingConfig()
+
+/workspace/codex-deployer/Tests/PublishingFrontendTests/PublishingFrontendTests.swift:36:29: warning: result of call to 'changeCurrentDirectoryPath' is unused
+34 |         let cwd = FileManager.default.currentDirectoryPath
+35 |         defer { FileManager.default.changeCurrentDirectoryPath(cwd) }
+36 |         FileManager.default.changeCurrentDirectoryPath(dir.path)
+   |                             `- warning: result of call to 'changeCurrentDirectoryPath' is unused
+37 |         let config = try loadPublishingConfig()
+38 |         XCTAssertEqual(config.port, 1234)
+[42/52] Compiling gateway_server CertificateManager.swift
+[42/52] Write Objects.LinkFileList
+[44/52] Compiling DNSTests APIClientTests.swift
+[44/52] Linking publishing-frontend
+[45/52] Linking gateway-server
+[47/53] Compiling IntegrationRuntimeTests AsyncHTTPClientDriverTests.swift
+[47/53] /workspace/codex-deployer/.build/x86_64-unknown-linux-gnu/release/FountainCoachPackageDiscoveredTests.derived/all-discovered-tests.swift
+[48/53] Write sources
+[50/54] Compiling FountainCoachPackageDiscoveredTests ClientGeneratorTests.swift
+[50/54] /workspace/codex-deployer/.build/x86_64-unknown-linux-gnu/release/FountainCoachPackageTests.derived/runner.swift
+[51/54] Write sources
+[53/55] Compiling FountainCoachPackageTests runner.swift
+[53/55] Write Objects.LinkFileList
+[54/55] Linking FountainCoachPackageTests.xctest
+Build complete! (125.65s)
+Test Suite 'All tests' started at 2025-08-02 10:08:51.886
+Test Suite 'release.xctest' started at 2025-08-02 10:08:51.899
+Test Suite 'ClientGeneratorTests' started at 2025-08-02 10:08:51.899
+Test Case 'ClientGeneratorTests.testClientFilesGenerated' started at 2025-08-02 10:08:51.899
+Test Case 'ClientGeneratorTests.testClientFilesGenerated' passed (0.011 seconds)
+Test Suite 'ClientGeneratorTests' passed at 2025-08-02 10:08:51.910
+	 Executed 1 test, with 0 failures (0 unexpected) in 0.011 (0.011) seconds
+Test Suite 'OpenAPISwiftTypeTests' started at 2025-08-02 10:08:51.910
+Test Case 'OpenAPISwiftTypeTests.testSchemaPropertySwiftType' started at 2025-08-02 10:08:51.910
+Test Case 'OpenAPISwiftTypeTests.testSchemaPropertySwiftType' passed (0.0 seconds)
+Test Case 'OpenAPISwiftTypeTests.testSchemaRefSwiftType' started at 2025-08-02 10:08:51.911
+Test Case 'OpenAPISwiftTypeTests.testSchemaRefSwiftType' passed (0.0 seconds)
+Test Suite 'OpenAPISwiftTypeTests' passed at 2025-08-02 10:08:51.911
+	 Executed 2 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
+Test Suite 'SecurityRequirementTests' started at 2025-08-02 10:08:51.911
+Test Case 'SecurityRequirementTests.testDecodesSchemesFromJSON' started at 2025-08-02 10:08:51.911
+Test Case 'SecurityRequirementTests.testDecodesSchemesFromJSON' passed (0.0 seconds)
+Test Case 'SecurityRequirementTests.testEncodesSchemesToJSON' started at 2025-08-02 10:08:51.911
+Test Case 'SecurityRequirementTests.testEncodesSchemesToJSON' passed (0.001 seconds)
+Test Suite 'SecurityRequirementTests' passed at 2025-08-02 10:08:51.912
+	 Executed 2 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
+Test Suite 'SpecLoaderTests' started at 2025-08-02 10:08:51.912
+Test Case 'SpecLoaderTests.testLoadsJSONRemovingCopyright' started at 2025-08-02 10:08:51.912
+Test Case 'SpecLoaderTests.testLoadsJSONRemovingCopyright' passed (0.001 seconds)
+Test Case 'SpecLoaderTests.testLoadsYAMLAndNormalizesInfoTitle' started at 2025-08-02 10:08:51.914
+Test Case 'SpecLoaderTests.testLoadsYAMLAndNormalizesInfoTitle' passed (0.012 seconds)
+Test Suite 'SpecLoaderTests' passed at 2025-08-02 10:08:51.926
+	 Executed 2 tests, with 0 failures (0 unexpected) in 0.013 (0.013) seconds
+Test Suite 'SpecValidatorTests' started at 2025-08-02 10:08:51.926
+Test Case 'SpecValidatorTests.testDuplicateOperationIdThrows' started at 2025-08-02 10:08:51.926
+Test Case 'SpecValidatorTests.testDuplicateOperationIdThrows' passed (0.101 seconds)
+Test Case 'SpecValidatorTests.testUnresolvedSchemaReferenceThrows' started at 2025-08-02 10:08:52.027
+Test Case 'SpecValidatorTests.testUnresolvedSchemaReferenceThrows' passed (0.0 seconds)
+Test Suite 'SpecValidatorTests' passed at 2025-08-02 10:08:52.027
+	 Executed 2 tests, with 0 failures (0 unexpected) in 0.101 (0.101) seconds
+Test Suite 'StringExtensionTests' started at 2025-08-02 10:08:52.027
+Test Case 'StringExtensionTests.testCamelCased' started at 2025-08-02 10:08:52.027
+Test Case 'StringExtensionTests.testCamelCased' passed (0.101 seconds)
+Test Suite 'StringExtensionTests' passed at 2025-08-02 10:08:52.128
+	 Executed 1 test, with 0 failures (0 unexpected) in 0.101 (0.101) seconds
+Test Suite 'FountainCoreTests' started at 2025-08-02 10:08:52.128
+Test Case 'FountainCoreTests.testTodoDecoding' started at 2025-08-02 10:08:52.128
+Test Case 'FountainCoreTests.testTodoDecoding' passed (0.0 seconds)
+Test Case 'FountainCoreTests.testTodoDecodingFailsForMissingName' started at 2025-08-02 10:08:52.128
+Test Case 'FountainCoreTests.testTodoDecodingFailsForMissingName' passed (0.0 seconds)
+Test Case 'FountainCoreTests.testTodoEncodingRoundTrip' started at 2025-08-02 10:08:52.128
+Test Case 'FountainCoreTests.testTodoEncodingRoundTrip' passed (0.0 seconds)
+Test Case 'FountainCoreTests.testTodoEquality' started at 2025-08-02 10:08:52.129
+Test Case 'FountainCoreTests.testTodoEquality' passed (0.0 seconds)
+Test Suite 'FountainCoreTests' passed at 2025-08-02 10:08:52.129
+	 Executed 4 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
+Test Suite 'HetznerDNSRequestTests' started at 2025-08-02 10:08:52.129
+Test Case 'HetznerDNSRequestTests.testUpdatePrimaryServerMethodIsPut' started at 2025-08-02 10:08:52.129
+Test Case 'HetznerDNSRequestTests.testUpdatePrimaryServerMethodIsPut' passed (0.0 seconds)
+Test Case 'HetznerDNSRequestTests.testUpdatePrimaryServerPathIncludesID' started at 2025-08-02 10:08:52.129
+Test Case 'HetznerDNSRequestTests.testUpdatePrimaryServerPathIncludesID' passed (0.001 seconds)
+Test Case 'HetznerDNSRequestTests.testValidateZoneFileMethodIsPost' started at 2025-08-02 10:08:52.130
+Test Case 'HetznerDNSRequestTests.testValidateZoneFileMethodIsPost' passed (0.0 seconds)
+Test Case 'HetznerDNSRequestTests.testValidateZoneFilePath' started at 2025-08-02 10:08:52.131
+Test Case 'HetznerDNSRequestTests.testValidateZoneFilePath' passed (0.0 seconds)
+Test Suite 'HetznerDNSRequestTests' passed at 2025-08-02 10:08:52.131
+	 Executed 4 tests, with 0 failures (0 unexpected) in 0.002 (0.002) seconds
+Test Suite 'PublishingFrontendTests' started at 2025-08-02 10:08:52.131
+Test Case 'PublishingFrontendTests.testLoadPublishingConfigParsesYaml' started at 2025-08-02 10:08:52.131
+Test Case 'PublishingFrontendTests.testLoadPublishingConfigParsesYaml' passed (0.002 seconds)
+Test Case 'PublishingFrontendTests.testPublishingConfigDefaultValues' started at 2025-08-02 10:08:52.133
+Test Case 'PublishingFrontendTests.testPublishingConfigDefaultValues' passed (0.0 seconds)
+Test Case 'PublishingFrontendTests.testServerServesIndex' started at 2025-08-02 10:08:52.134
+Test Case 'PublishingFrontendTests.testServerServesIndex' passed (0.017 seconds)
+Test Suite 'PublishingFrontendTests' passed at 2025-08-02 10:08:52.151
+	 Executed 3 tests, with 0 failures (0 unexpected) in 0.02 (0.02) seconds
+Test Suite 'Route53ClientTests' started at 2025-08-02 10:08:52.151
+Test Case 'Route53ClientTests.testCreateRecordThrows' started at 2025-08-02 10:08:52.151
+Test Case 'Route53ClientTests.testCreateRecordThrows' passed (0.0 seconds)
+Test Case 'Route53ClientTests.testDeleteRecordThrows' started at 2025-08-02 10:08:52.151
+Test Case 'Route53ClientTests.testDeleteRecordThrows' passed (0.0 seconds)
+Test Case 'Route53ClientTests.testListZonesThrows' started at 2025-08-02 10:08:52.152
+Test Case 'Route53ClientTests.testListZonesThrows' passed (0.0 seconds)
+Test Case 'Route53ClientTests.testUpdateRecordThrows' started at 2025-08-02 10:08:52.152
+Test Case 'Route53ClientTests.testUpdateRecordThrows' passed (0.0 seconds)
+Test Suite 'Route53ClientTests' passed at 2025-08-02 10:08:52.152
+	 Executed 4 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
+Test Suite 'APIClientTests' started at 2025-08-02 10:08:52.152
+Test Case 'APIClientTests.testBearerInitializerSetsHeader' started at 2025-08-02 10:08:52.152
+Test Case 'APIClientTests.testBearerInitializerSetsHeader' passed (0.0 seconds)
+Test Case 'APIClientTests.testRawDataResponse' started at 2025-08-02 10:08:52.152
+Test Case 'APIClientTests.testRawDataResponse' passed (0.0 seconds)
+Test Case 'APIClientTests.testSendDecodesResponse' started at 2025-08-02 10:08:52.153
+Test Case 'APIClientTests.testSendDecodesResponse' passed (0.0 seconds)
+Test Suite 'APIClientTests' passed at 2025-08-02 10:08:52.153
+	 Executed 3 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
+Test Suite 'CreatePrimaryServerRequestTests' started at 2025-08-02 10:08:52.153
+Test Case 'CreatePrimaryServerRequestTests.testMethodIsPOST' started at 2025-08-02 10:08:52.153
+Test Case 'CreatePrimaryServerRequestTests.testMethodIsPOST' passed (0.0 seconds)
+Test Case 'CreatePrimaryServerRequestTests.testPathIsCorrect' started at 2025-08-02 10:08:52.153
+Test Case 'CreatePrimaryServerRequestTests.testPathIsCorrect' passed (0.0 seconds)
+Test Suite 'CreatePrimaryServerRequestTests' passed at 2025-08-02 10:08:52.153
+	 Executed 2 tests, with 0 failures (0 unexpected) in 0.0 (0.0) seconds
+Test Suite 'DNSClientTests' started at 2025-08-02 10:08:52.153
+Test Case 'DNSClientTests.testRoute53CreateRecordStub' started at 2025-08-02 10:08:52.153
+Test Case 'DNSClientTests.testRoute53CreateRecordStub' passed (0.0 seconds)
+Test Case 'DNSClientTests.testRoute53DeleteRecordStub' started at 2025-08-02 10:08:52.154
+Test Case 'DNSClientTests.testRoute53DeleteRecordStub' passed (0.0 seconds)
+Test Case 'DNSClientTests.testRoute53Stub' started at 2025-08-02 10:08:52.154
+Test Case 'DNSClientTests.testRoute53Stub' passed (0.001 seconds)
+Test Case 'DNSClientTests.testRoute53UpdateRecordStub' started at 2025-08-02 10:08:52.155
+Test Case 'DNSClientTests.testRoute53UpdateRecordStub' passed (0.0 seconds)
+Test Suite 'DNSClientTests' passed at 2025-08-02 10:08:52.155
+	 Executed 4 tests, with 0 failures (0 unexpected) in 0.002 (0.002) seconds
+Test Suite 'DeleteZoneRequestTests' started at 2025-08-02 10:08:52.155
+Test Case 'DeleteZoneRequestTests.testPathBuilderEncodesZoneId' started at 2025-08-02 10:08:52.155
+Test Case 'DeleteZoneRequestTests.testPathBuilderEncodesZoneId' passed (0.0 seconds)
+Test Suite 'DeleteZoneRequestTests' passed at 2025-08-02 10:08:52.155
+	 Executed 1 test, with 0 failures (0 unexpected) in 0.0 (0.0) seconds
+Test Suite 'GetPrimaryServerRequestTests' started at 2025-08-02 10:08:52.155
+Test Case 'GetPrimaryServerRequestTests.testMethodIsGET' started at 2025-08-02 10:08:52.155
+Test Case 'GetPrimaryServerRequestTests.testMethodIsGET' passed (0.1 seconds)
+Test Case 'GetPrimaryServerRequestTests.testPathBuilderReplacesId' started at 2025-08-02 10:08:52.256
+Test Case 'GetPrimaryServerRequestTests.testPathBuilderReplacesId' passed (0.0 seconds)
+Test Suite 'GetPrimaryServerRequestTests' passed at 2025-08-02 10:08:52.256
+	 Executed 2 tests, with 0 failures (0 unexpected) in 0.101 (0.101) seconds
+Test Suite 'GetRecordRequestTests' started at 2025-08-02 10:08:52.256
+Test Case 'GetRecordRequestTests.testPathBuilderReplacesRecordId' started at 2025-08-02 10:08:52.256
+Test Case 'GetRecordRequestTests.testPathBuilderReplacesRecordId' passed (0.0 seconds)
+Test Suite 'GetRecordRequestTests' passed at 2025-08-02 10:08:52.256
+	 Executed 1 test, with 0 failures (0 unexpected) in 0.0 (0.0) seconds
+Test Suite 'HetznerDNSClientTests' started at 2025-08-02 10:08:52.256
+Test Case 'HetznerDNSClientTests.testCreateRecordRequest' started at 2025-08-02 10:08:52.256
+Test Case 'HetznerDNSClientTests.testCreateRecordRequest' passed (0.001 seconds)
+Test Case 'HetznerDNSClientTests.testCreateRecordSetsContentTypeHeader' started at 2025-08-02 10:08:52.258
+Test Case 'HetznerDNSClientTests.testCreateRecordSetsContentTypeHeader' passed (0.0 seconds)
+Test Case 'HetznerDNSClientTests.testDeleteRecordRequest' started at 2025-08-02 10:08:52.258
+Test Case 'HetznerDNSClientTests.testDeleteRecordRequest' passed (0.0 seconds)
+Test Case 'HetznerDNSClientTests.testListZonesPathBuilder' started at 2025-08-02 10:08:52.258
+Test Case 'HetznerDNSClientTests.testListZonesPathBuilder' passed (0.0 seconds)
+Test Case 'HetznerDNSClientTests.testUpdateRecordRequest' started at 2025-08-02 10:08:52.259
+Test Case 'HetznerDNSClientTests.testUpdateRecordRequest' passed (0.0 seconds)
+Test Suite 'HetznerDNSClientTests' passed at 2025-08-02 10:08:52.259
+	 Executed 5 tests, with 0 failures (0 unexpected) in 0.003 (0.003) seconds
+Test Suite 'ListRecordsRequestTests' started at 2025-08-02 10:08:52.259
+Test Case 'ListRecordsRequestTests.testPathBuilderEncodesQuery' started at 2025-08-02 10:08:52.259
+Test Case 'ListRecordsRequestTests.testPathBuilderEncodesQuery' passed (0.0 seconds)
+Test Suite 'ListRecordsRequestTests' passed at 2025-08-02 10:08:52.259
+	 Executed 1 test, with 0 failures (0 unexpected) in 0.0 (0.0) seconds
+Test Suite 'AsyncHTTPClientDriverTests' started at 2025-08-02 10:08:52.259
+Test Case 'AsyncHTTPClientDriverTests.testExecutePerformsRequest' started at 2025-08-02 10:08:52.259
+Test Case 'AsyncHTTPClientDriverTests.testExecutePerformsRequest' passed (0.006 seconds)
+Test Suite 'AsyncHTTPClientDriverTests' passed at 2025-08-02 10:08:52.265
+	 Executed 1 test, with 0 failures (0 unexpected) in 0.006 (0.006) seconds
+Test Suite 'CertificateManagerTests' started at 2025-08-02 10:08:52.265
+Test Case 'CertificateManagerTests.testTriggerNowRunsScript' started at 2025-08-02 10:08:52.265
+Test Case 'CertificateManagerTests.testTriggerNowRunsScript' passed (1.004 seconds)
+Test Suite 'CertificateManagerTests' passed at 2025-08-02 10:08:53.269
+	 Executed 1 test, with 0 failures (0 unexpected) in 1.004 (1.004) seconds
+Test Suite 'GatewayPluginDefaultTests' started at 2025-08-02 10:08:53.269
+Test Case 'GatewayPluginDefaultTests.testDefaultImplementationsPassThrough' started at 2025-08-02 10:08:53.269
+Test Case 'GatewayPluginDefaultTests.testDefaultImplementationsPassThrough' passed (0.0 seconds)
+Test Suite 'GatewayPluginDefaultTests' passed at 2025-08-02 10:08:53.269
+	 Executed 1 test, with 0 failures (0 unexpected) in 0.0 (0.0) seconds
+Test Suite 'GatewayServerTests' started at 2025-08-02 10:08:53.269
+Test Case 'GatewayServerTests.testHealthEndpointResponds' started at 2025-08-02 10:08:53.269
+Test Case 'GatewayServerTests.testHealthEndpointResponds' passed (0.104 seconds)
+Test Case 'GatewayServerTests.testMetricsEndpointResponds' started at 2025-08-02 10:08:53.374
+Test Case 'GatewayServerTests.testMetricsEndpointResponds' passed (0.103 seconds)
+Test Case 'GatewayServerTests.testPluginCanRewriteRequestAndResponse' started at 2025-08-02 10:08:53.476
+Test Case 'GatewayServerTests.testPluginCanRewriteRequestAndResponse' passed (0.103 seconds)
+Test Suite 'GatewayServerTests' passed at 2025-08-02 10:08:53.579
+	 Executed 3 tests, with 0 failures (0 unexpected) in 0.31 (0.31) seconds
+Test Suite 'HTTPKernelTests' started at 2025-08-02 10:08:53.579
+Test Case 'HTTPKernelTests.testKernelRoutesRequest' started at 2025-08-02 10:08:53.579
+Test Case 'HTTPKernelTests.testKernelRoutesRequest' passed (0.0 seconds)
+Test Suite 'HTTPKernelTests' passed at 2025-08-02 10:08:53.579
+	 Executed 1 test, with 0 failures (0 unexpected) in 0.0 (0.0) seconds
+Test Suite 'HTTPResponseDefaultsTests' started at 2025-08-02 10:08:53.579
+Test Case 'HTTPResponseDefaultsTests.testNoBodyCodable' started at 2025-08-02 10:08:53.579
+Test Case 'HTTPResponseDefaultsTests.testNoBodyCodable' passed (0.0 seconds)
+Test Case 'HTTPResponseDefaultsTests.testResponseDefaults' started at 2025-08-02 10:08:53.580
+Test Case 'HTTPResponseDefaultsTests.testResponseDefaults' passed (0.0 seconds)
+Test Suite 'HTTPResponseDefaultsTests' passed at 2025-08-02 10:08:53.580
+	 Executed 2 tests, with 0 failures (0 unexpected) in 0.0 (0.0) seconds
+Test Suite 'LoggingPluginTests' started at 2025-08-02 10:08:53.580
+Test Case 'LoggingPluginTests.testLoggingPluginPassThrough' started at 2025-08-02 10:08:53.580
+-> GET /
+<- 200 for /
+Test Case 'LoggingPluginTests.testLoggingPluginPassThrough' passed (0.0 seconds)
+Test Suite 'LoggingPluginTests' passed at 2025-08-02 10:08:53.580
+	 Executed 1 test, with 0 failures (0 unexpected) in 0.0 (0.0) seconds
+Test Suite 'NIOHTTPServerTests' started at 2025-08-02 10:08:53.580
+Test Case 'NIOHTTPServerTests.testServerResponds' started at 2025-08-02 10:08:53.580
+Test Case 'NIOHTTPServerTests.testServerResponds' passed (0.001 seconds)
+Test Suite 'NIOHTTPServerTests' passed at 2025-08-02 10:08:53.582
+	 Executed 1 test, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
+Test Suite 'PublishingFrontendPluginTests' started at 2025-08-02 10:08:53.582
+Test Case 'PublishingFrontendPluginTests.testPluginServesFile' started at 2025-08-02 10:08:53.582
+Test Case 'PublishingFrontendPluginTests.testPluginServesFile' passed (0.001 seconds)
+Test Suite 'PublishingFrontendPluginTests' passed at 2025-08-02 10:08:53.583
+	 Executed 1 test, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
+Test Suite 'URLSessionHTTPClientTests' started at 2025-08-02 10:08:53.583
+Test Case 'URLSessionHTTPClientTests.testExecutePerformsRequest' started at 2025-08-02 10:08:53.583
+Test Case 'URLSessionHTTPClientTests.testExecutePerformsRequest' passed (0.001 seconds)
+Test Suite 'URLSessionHTTPClientTests' passed at 2025-08-02 10:08:53.584
+	 Executed 1 test, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
+Test Suite 'release.xctest' passed at 2025-08-02 10:08:53.584
+	 Executed 57 tests, with 0 failures (0 unexpected) in 1.683 (1.683) seconds
+Test Suite 'All tests' passed at 2025-08-02 10:08:53.584
+	 Executed 57 tests, with 0 failures (0 unexpected) in 1.683 (1.683) seconds
+◇ Test run started.
+↳ Testing Library Version: 6.1 (43b6f88e2f2712e)
+↳ Target Platform: x86_64-unknown-linux-gnu
+✔ Test run with 0 tests passed after 0.001 seconds.
+\n© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- document ServerGenerator's private emit helpers
- add Todo equality and missing-name decoding tests
- refresh coverage report and test count

## Testing
- `swift build -c release -Xswiftc -O -Xswiftc -warnings-as-errors && swift test -c release --enable-code-coverage`


------
https://chatgpt.com/codex/tasks/task_e_688de1b6874483259f77828ccb21f822