### PR TITLE
Document DNS models and expand server test coverage

### DIFF
--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -5,20 +5,20 @@
 Running `swift test --enable-code-coverage` and analysing with `llvm-cov` produced the following totals:
 
 ```
-TOTAL                                          31462   26681    15.20%   14055 11545    17.86%   98765   81754    17.22%
+TOTAL                                          31516   26416    16.18%   14094 11322    19.67%   98875   81315    17.76%
 ```
 
-The repository contains **98,765** executable lines, with **17,011** lines covered (approx. **17.22%** line coverage).
+The repository contains **98,875** executable lines, with **17,560** lines covered (approx. **17.76%** line coverage).
 
 ### Repository source coverage
 
 Ignoring third-party packages under `.build/checkouts`, the totals are:
 
 ```
-TOTAL                                           950     327    65.58%     425    70    83.53%    2128     605    71.57%
+TOTAL                                          1129     387    65.72%     555   103    81.44%    2493     754    69.76%
 ```
 
-Within repository sources there are **2,128** lines, with **1,523** covered, giving **71.57%** line coverage.
+Within repository sources there are **2,493** lines, with **1,739** covered, giving **69.76%** line coverage.
 
 Coverage results are recalculated after each test run to monitor progress. The project strives for ever more comprehensive test suites across all modules. Recent additions include unit tests for ``APIClient``. New tests now verify ``URLSessionHTTPClient`` behavior and the ``Supervisor`` process termination logic.
 Additional tests now cover ``OpenAPISpec.swiftType`` and the ``camelCased`` string helper. A new ``GatewayServerTests`` suite raises total tests to **27**.
@@ -36,6 +36,7 @@ The new ``CreatePrimaryServerRequestTests`` and ``GetPrimaryServerRequestTests``
 Additional plugin rewrite and raw data tests raise the total test count to **51**.
 The new ``validateZoneFile`` and ``updatePrimaryServer`` request tests raise the total test count to **55**.
 The new ``TodoEquality`` and ``TodoDecodingFailsForMissingName`` tests bring the total test count to **57**.
+The new ``NIOHTTPServer`` port reuse and concurrency tests and Hetzner DNS model round-trip checks bring the total test count to **62**.
 
 ---
 © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/PublishingFrontend/HetznerDNSClient/Models.swift
+++ b/Sources/PublishingFrontend/HetznerDNSClient/Models.swift
@@ -1,6 +1,8 @@
 // Models for Hetzner DNS API
 
+/// Request body for creating multiple DNS records in a single batch.
 public struct BulkRecordsCreateRequest: Codable {
+    /// New records to be created atomically.
     public let records: [RecordCreate]
 }
 
@@ -118,8 +120,13 @@ public struct ZonesResponse: Codable {
     public let zones: [Zone]
 }
 
+/// Response for validating a DNS zone file.
 public struct validateZoneFileResponse: Codable {
+    /// Number of records parsed from the zone file.
     public let parsed_records: Int
+    /// Records that passed validation checks.
     public let valid_records: [Record]
 }
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
 

--- a/Tests/IntegrationRuntimeTests/NIOHTTPServerTests.swift
+++ b/Tests/IntegrationRuntimeTests/NIOHTTPServerTests.swift
@@ -17,6 +17,35 @@ final class NIOHTTPServerTests: XCTestCase {
         XCTAssertEqual(String(data: data, encoding: .utf8), "hi")
         try await server.stop()
     }
+
+    /// Stopping the server should free the port allowing a subsequent bind.
+    func testServerReleasesPortOnStop() async throws {
+        let kernel = HTTPKernel { _ in HTTPResponse(status: 204) }
+        let server = NIOHTTPServer(kernel: kernel)
+        let port = try await server.start(port: 0)
+        try await server.stop()
+        let server2 = NIOHTTPServer(kernel: kernel)
+        let boundPort = try await server2.start(port: port)
+        XCTAssertEqual(boundPort, port)
+        try await server2.stop()
+    }
+
+    /// The server should handle multiple simultaneous requests.
+    func testServerHandlesConcurrentRequests() async throws {
+        let kernel = HTTPKernel { _ in HTTPResponse(status: 200, body: Data("ok".utf8)) }
+        let server = NIOHTTPServer(kernel: kernel)
+        let port = try await server.start(port: 0)
+        let url = URL(string: "http://127.0.0.1:\(port)/")!
+        async let first = URLSession.shared.data(from: url)
+        async let second = URLSession.shared.data(from: url)
+        let (d1, r1) = try await first
+        let (d2, r2) = try await second
+        XCTAssertEqual((r1 as? HTTPURLResponse)?.statusCode, 200)
+        XCTAssertEqual((r2 as? HTTPURLResponse)?.statusCode, 200)
+        XCTAssertEqual(String(data: d1, encoding: .utf8), "ok")
+        XCTAssertEqual(String(data: d2, encoding: .utf8), "ok")
+        try await server.stop()
+    }
 }
 
 // © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Tests/PublishingFrontendTests/HetznerDNSModelsTests.swift
+++ b/Tests/PublishingFrontendTests/HetznerDNSModelsTests.swift
@@ -1,0 +1,34 @@
+import XCTest
+@testable import PublishingFrontend
+
+final class HetznerDNSModelsTests: XCTestCase {
+    /// Encoding and decoding round-trip for `BulkRecordsCreateRequest` retains records.
+    func testBulkRecordsCreateRequestCodable() throws {
+        let record = RecordCreate(name: "a", ttl: 60, type: "TXT", value: "b", zone_id: "z")
+        let request = BulkRecordsCreateRequest(records: [record])
+        let data = try JSONEncoder().encode(request)
+        let decoded = try JSONDecoder().decode(BulkRecordsCreateRequest.self, from: data)
+        XCTAssertEqual(decoded.records.first?.name, "a")
+    }
+
+    /// Decoding `validateZoneFileResponse` extracts parsed record counts.
+    func testValidateZoneFileResponseDecodes() throws {
+        let json = """
+        {"parsed_records":1,"valid_records":[{"created":"","id":"1","modified":"","name":"","ttl":1,"type":"A","value":"1.1.1.1","zone_id":"z"}]}
+        """.data(using: .utf8)!
+        let response = try JSONDecoder().decode(validateZoneFileResponse.self, from: json)
+        XCTAssertEqual(response.parsed_records, 1)
+        XCTAssertEqual(response.valid_records.count, 1)
+    }
+
+    /// Decoding `Zone` and related responses exercises generated models.
+    func testZoneResponseDecoding() throws {
+        let zone = Zone(created: "c", id: "1", is_secondary_dns: false, legacy_dns_host: "h", legacy_ns: [], modified: "m", name: "n", ns: [], owner: "o", paused: false, permission: "p", project: "pr", records_count: 0, registrar: "reg", status: "s", ttl: 60, txt_verification: [:], verified: "v")
+        let response = ZoneResponse(zone: zone)
+        let data = try JSONEncoder().encode(response)
+        let decoded = try JSONDecoder().decode(ZoneResponse.self, from: data)
+        XCTAssertEqual(decoded.zone.id, "1")
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/docs/README.md
+++ b/docs/README.md
@@ -45,6 +45,7 @@ As modules gain documentation, brief summaries are added here.
 - **APIClient.baseURL**, **session**, and **defaultHeaders** – stored properties document connection details.
 - **HetznerDNSClient.api** – underlying HTTP client property now documented.
 - **ServerGenerator emit helpers** – private functions now describe generated source responsibilities.
+- **BulkRecordsCreateRequest** and **validateZoneFileResponse** – documented models for batch record creation and zone validation feedback.
 
 Documentation coverage will expand alongside test coverage.
 


### PR DESCRIPTION
## Summary
- Document `BulkRecordsCreateRequest` and `validateZoneFileResponse` in Hetzner DNS models
- Add NIOHTTPServer tests for port reuse and concurrent requests
- Add Hetzner DNS model Codable tests
- Update docs and coverage metrics

## Testing
- `swift test --enable-code-coverage`
- `/root/.local/share/mise/installs/swift/6.1/usr/bin/llvm-cov report .build/x86_64-unknown-linux-gnu/debug/FountainCoachPackageTests.xctest --instr-profile=.build/x86_64-unknown-linux-gnu/debug/codecov/default.profdata`


------
https://chatgpt.com/codex/tasks/task_e_688de6c120e8832597cd61a53c6addec