### PR TITLE
Document APIRequest and test Route53 errors

### DIFF
--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -5,20 +5,20 @@
 Running `swift test --enable-code-coverage` and analysing with `llvm-cov` produced the following totals:
 
 ```
-TOTAL                                          31548   26662    15.49%   14123 11536    18.32%   98920  81706    17.40%
+TOTAL                                          31568   26664    15.53%   14135 11536    18.39%   98950  81708    17.42%
 ```
 
-The repository contains **98,920** executable lines, with **17,214** lines covered (approx. **17.40%** line coverage).
+The repository contains **98,950** executable lines, with **17,242** lines covered (approx. **17.42%** line coverage).
 
 ### Repository source coverage
 
 Ignoring third-party packages under `.build/checkouts`, the totals are:
 
 ```
-TOTAL                                          1170     368    68.55%     591    93    84.26%    2573     707    72.52%
+TOTAL                                          1190     370    68.91%     603    93    84.58%    2603     709    72.76%
 ```
 
-Within repository sources there are **2,573** lines, with **1,866** covered, giving **72.52%** line coverage.
+Within repository sources there are **2,603** lines, with **1,894** covered, giving **72.76%** line coverage.
 
 Coverage results are recalculated after each test run to monitor progress. The project strives for ever more comprehensive test suites across all modules. Recent additions include unit tests for ``APIClient``. New tests now verify ``URLSessionHTTPClient`` behavior and the ``Supervisor`` process termination logic.
 Additional tests now cover ``OpenAPISpec.swiftType`` and the ``camelCased`` string helper. A new ``GatewayServerTests`` suite raises total tests to **27**.
@@ -40,6 +40,7 @@ The new ``NIOHTTPServer`` port reuse and concurrency tests and Hetzner DNS model
 The new ``importZoneFile`` and ``exportZoneFile`` request tests raise the total test count to **66**.
 The new ``getZone`` and ``listPrimaryServers`` request tests raise the total test count to **69**.
 The new ``PublishingFrontendPlugin`` pass-through and non-GET tests raise the total test count to **71**.
+The new ``Route53Client`` error detail tests raise the total test count to **73**.
 
 ---
 © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/PublishingFrontend/HetznerDNSClient/APIRequest.swift
+++ b/Sources/PublishingFrontend/HetznerDNSClient/APIRequest.swift
@@ -3,10 +3,22 @@ import Foundation
 /// Empty body type used for requests without a payload.
 public struct NoBody: Codable {}
 
+/// Protocol describing an HTTP API request.
+/// Conformers provide the HTTP method, endpoint path,
+/// and optional encodable body type for the request.
+/// The expected server response type is given by ``Response``.
 public protocol APIRequest {
+    /// Encodable payload sent with the request.
+    /// Defaults to ``NoBody`` for endpoints without bodies.
     associatedtype Body: Encodable = NoBody
+    /// Decodable type returned from the server.
     associatedtype Response: Decodable
+    /// HTTP method such as ``GET`` or ``POST``.
     var method: String { get }
+    /// Path relative to the API's base URL.
     var path: String { get }
+    /// Optional body encoded as JSON for the request.
     var body: Body? { get }
 }
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Tests/DNSTests/DNSClientTests.swift
+++ b/Tests/DNSTests/DNSClientTests.swift
@@ -41,6 +41,28 @@ final class DNSClientTests: XCTestCase {
             // expected
         }
     }
+
+    func testRoute53ListZonesErrorDetails() async throws {
+        let client = Route53Client()
+        do {
+            _ = try await client.listZones()
+            XCTFail("expected failure")
+        } catch let error as NSError {
+            XCTAssertEqual(error.domain, "Route53")
+            XCTAssertEqual(error.code, 501)
+        }
+    }
+
+    func testRoute53DeleteRecordErrorDetails() async throws {
+        let client = Route53Client()
+        do {
+            try await client.deleteRecord(id: "1")
+            XCTFail("expected failure")
+        } catch let error as NSError {
+            XCTAssertEqual(error.domain, "Route53")
+            XCTAssertEqual(error.code, 501)
+        }
+    }
 }
 
 // © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,7 @@ As modules gain documentation, brief summaries are added here.
 - **CreateRecord** – documented request wrapper for adding DNS records.
 - **HTTPRequest** and **HTTPResponse** – request/response models now fully documented.
 - **NoBody** – placeholder type for empty request bodies is now documented.
+- **APIRequest** – protocol now documents HTTP method, path, and body fields.
 - **APIClient** – initializer and URLSession extension now documented for clarity.
 - **URLSessionHTTPClientTests** – updated for Linux compatibility ensuring network client coverage.
 - **OpenAPISpec.swiftType** – documented helper converting schemas to Swift types.


### PR DESCRIPTION
## Summary
- document APIRequest protocol fields and use
- record APIRequest progress in docs
- verify Route53Client throws expected domain and code

## Testing
- `swift build -c release -Xswiftc -O -Xswiftc -warnings-as-errors`
- `swift test -c release --enable-code-coverage`
- `llvm-profdata-19 merge -sparse .build/release/codecov/*.profraw -o .build/release/codecov/merged.profdata`
- `llvm-cov-19 report .build/release/FountainCoachPackageTests.xctest -instr-profile .build/release/codecov/merged.profdata`
- `llvm-cov-19 report .build/release/FountainCoachPackageTests.xctest -instr-profile .build/release/codecov/merged.profdata -ignore-filename-regex='\.build/checkouts'`


------
https://chatgpt.com/codex/tasks/task_e_688dfb1b65a483259b24ddc84d0d0646