### PR TITLE
Document certificate manager and add timer tests

### DIFF
--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -5,20 +5,20 @@
 Running `swift test --enable-code-coverage` and analysing with `llvm-cov` produced the following totals:
 
 ```
-TOTAL                                          31579   26658    15.58%   14143 11532    18.46%   98969  81689    17.46%
+TOTAL                                          31596   26664    15.61%   14151 11536    18.48%   99009 81708    17.47%
 ```
 
-The repository contains **98,969** executable lines, with **17,280** lines covered (approx. **17.46%** line coverage).
+The repository contains **99,009** executable lines, with **17,301** lines covered (approx. **17.47%** line coverage).
 
 ### Repository source coverage
 
 Ignoring third-party packages under `.build/checkouts`, the totals are:
 
 ```
-TOTAL                                           590     294    50.17%     173     57    67.05%    1362     545    60.00%
+TOTAL                                           590     294    50.17%     173     57    67.05%    1362     545    59.99%
 ```
 
-Within repository sources there are **1,362** lines, with **817** covered, giving **60.00%** line coverage.
+Within repository sources there are **1,362** lines, with **817** covered, giving **59.99%** line coverage.
 
 Coverage results are recalculated after each test run to monitor progress. The project strives for ever more comprehensive test suites across all modules. Recent additions include unit tests for ``APIClient``. New tests now verify ``URLSessionHTTPClient`` behavior and the ``Supervisor`` process termination logic.
 Additional tests now cover ``OpenAPISpec.swiftType`` and the ``camelCased`` string helper. A new ``GatewayServerTests`` suite raises total tests to **27**.
@@ -42,6 +42,8 @@ The new ``getZone`` and ``listPrimaryServers`` request tests raise the total tes
 The new ``PublishingFrontendPlugin`` pass-through and non-GET tests raise the total test count to **71**.
 The new ``Route53Client`` error detail tests raise the total test count to **73**.
 The new ``BulkRecordsUpdateRequestCodable`` and ``PrimaryServersResponseDecodes`` tests raise the total test count to **75**.
+
+The new ``CertificateManager`` start and stop tests raise the total test count to **77**.
 
 ---
 © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/GatewayApp/CertificateManager.swift
+++ b/Sources/GatewayApp/CertificateManager.swift
@@ -19,6 +19,8 @@ public final class CertificateManager {
     }
 
     /// Starts automatic certificate renewal on a timer.
+    /// Invokes the configured shell script every ``interval`` seconds on a
+    /// background queue until ``stop()`` is called.
     public func start() {
         let timer = DispatchSource.makeTimerSource()
         timer.schedule(deadline: .now(), repeating: interval)
@@ -36,12 +38,14 @@ public final class CertificateManager {
     }
 
     /// Stops the timer and cancels future renewals.
+    /// Safe to call multiple times; subsequent calls have no effect.
     public func stop() {
         timer?.cancel()
         timer = nil
     }
 
-    /// Immediately runs the renewal script once.
+    /// Immediately runs the renewal script once outside the normal schedule.
+    /// Any error is printed to standard output.
     public func triggerNow() {
         let task = Process()
         task.executableURL = URL(fileURLWithPath: scriptPath)

--- a/Tests/IntegrationRuntimeTests/CertificateManagerTests.swift
+++ b/Tests/IntegrationRuntimeTests/CertificateManagerTests.swift
@@ -2,6 +2,7 @@ import XCTest
 @testable import gateway_server
 
 final class CertificateManagerTests: XCTestCase {
+    /// Executes the renewal script immediately when `triggerNow` is invoked.
     func testTriggerNowRunsScript() throws {
         let dir = FileManager.default.temporaryDirectory.appendingPathComponent("cert_test")
         try? FileManager.default.removeItem(at: dir)
@@ -17,6 +18,44 @@ final class CertificateManagerTests: XCTestCase {
         sleep(1)
         let exists = FileManager.default.fileExists(atPath: logURL.path)
         XCTAssertTrue(exists)
+    }
+
+    /// Ensures that calling `start` schedules repeated executions of the script.
+    func testStartSchedulesRepeatedRuns() throws {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent("cert_start")
+        try? FileManager.default.removeItem(at: dir)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let logURL = dir.appendingPathComponent("log.txt")
+        let scriptURL = dir.appendingPathComponent("renew.sh")
+        let script = "#!/bin/sh\necho tick >> \(logURL.path)\n"
+        try script.write(to: scriptURL, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: scriptURL.path)
+        let manager = CertificateManager(scriptPath: scriptURL.path, interval: 0.2)
+        manager.start()
+        sleep(1)
+        manager.stop()
+        let content = try String(contentsOf: logURL, encoding: .utf8)
+        XCTAssertGreaterThan(content.split(separator: "\n").count, 1)
+    }
+
+    /// Verifies `stop` prevents further scheduled executions after cancellation.
+    func testStopCancelsFutureRuns() throws {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent("cert_stop")
+        try? FileManager.default.removeItem(at: dir)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let logURL = dir.appendingPathComponent("log.txt")
+        let scriptURL = dir.appendingPathComponent("renew.sh")
+        let script = "#!/bin/sh\necho ping >> \(logURL.path)\n"
+        try script.write(to: scriptURL, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: scriptURL.path)
+        let manager = CertificateManager(scriptPath: scriptURL.path, interval: 0.2)
+        manager.start()
+        sleep(1)
+        manager.stop()
+        let first = try String(contentsOf: logURL, encoding: .utf8).split(separator: "\n").count
+        sleep(1)
+        let second = try String(contentsOf: logURL, encoding: .utf8).split(separator: "\n").count
+        XCTAssertEqual(first, second)
     }
 }
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -51,6 +51,7 @@ As modules gain documentation, brief summaries are added here.
 - **BulkRecordsCreateRequest** and **validateZoneFileResponse** – documented models for batch record creation and zone validation feedback.
 - **PublishingFrontendPlugin.rootPath** – documented property describing the static file directory.
 - **BulkRecordsUpdateRequest**, **BulkRecordsUpdateResponse**, **RecordUpdate**, and **PrimaryServer** – documented models covering batch record updates and primary server metadata.
+- **CertificateManager.start**, **stop**, and **triggerNow** – document timer scheduling, cancellation semantics, and on-demand execution.
 
 Documentation coverage will expand alongside test coverage.
 


### PR DESCRIPTION
## Summary
- document certificate manager timer lifecycle
- test certificate manager start and stop scheduling
- log new coverage numbers

## Testing
- `swift build -c release -Xswiftc -O -Xswiftc -warnings-as-errors`
- `swift test -c release --enable-code-coverage`
- `llvm-profdata-19 merge -sparse .build/x86_64-unknown-linux-gnu/release/codecov/*.profraw -o coverage.profdata`
- `llvm-cov-19 report .build/x86_64-unknown-linux-gnu/release/FountainCoachPackageTests.xctest --instr-profile=coverage.profdata`


------
https://chatgpt.com/codex/tasks/task_e_688e0cdb7bd883259c8b5bd70a1e7ca4