### PR TITLE
Document Hetzner DNS models and expand tests

### DIFF
--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -5,20 +5,20 @@
 Running `swift test --enable-code-coverage` and analysing with `llvm-cov` produced the following totals:
 
 ```
-TOTAL                                          31612   26644    15.72%   14159 11532    18.55%   99044 81679    17.53%
+TOTAL                                          31637   26666    15.71%   14179 11543    18.59%   99084 81812    17.43%
 ```
 
-The repository contains **99,044** executable lines, with **17,365** lines covered (approx. **17.53%** line coverage).
+The repository contains **99,084** executable lines, with **17,272** lines covered (approx. **17.43%** line coverage).
 
 ### Repository source coverage
 
 Ignoring third-party packages under `.build/checkouts`, the totals are:
 
 ```
-TOTAL                                           590     289    51.02%     173     56    67.63%    1362     541    60.28%
+TOTAL                                           749     348    53.54%     296     88    70.27%    1680     689    58.99%
 ```
 
-Within repository sources there are **1,362** lines, with **821** covered, giving **60.28%** line coverage.
+Within repository sources there are **1,680** lines, with **991** covered, giving **58.99%** line coverage.
 
 Coverage results are recalculated after each test run to monitor progress. The project strives for ever more comprehensive test suites across all modules. Recent additions include unit tests for ``APIClient``. New tests now verify ``URLSessionHTTPClient`` behavior and the ``Supervisor`` process termination logic.
 Additional tests now cover ``OpenAPISpec.swiftType`` and the ``camelCased`` string helper. A new ``GatewayServerTests`` suite raises total tests to **27**.
@@ -45,6 +45,7 @@ The new ``BulkRecordsUpdateRequestCodable`` and ``PrimaryServersResponseDecodes`
 
 The new ``CertificateManager`` start and stop tests raise the total test count to **77**.
 The new server 404 and non-GET tests raise the total test count to **79**.
+The new ``PrimaryServerCreateCodable``, ``RecordResponseDecodes``, and ``ZoneCreateRequestCodable`` tests raise the total test count to **82**.
 
 ---
 © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/PublishingFrontend/HetznerDNSClient/Models.swift
+++ b/Sources/PublishingFrontend/HetznerDNSClient/Models.swift
@@ -62,84 +62,141 @@ public struct PrimaryServer: Codable {
     public let zone_id: String
 }
 
+/// Request payload for creating a new primary DNS server.
 public struct PrimaryServerCreate: Codable {
+    /// IP address of the primary server to register.
     public let address: String
+    /// Port the server listens on.
     public let port: Int
+    /// Identifier of the zone served by the primary server.
     public let zone_id: String
 }
 
+/// Response wrapping a single created primary server.
 public struct PrimaryServerResponse: Codable {
+    /// Newly created or fetched primary server.
     public let primary_server: PrimaryServer
 }
 
+/// Response containing an array of primary servers.
 public struct PrimaryServersResponse: Codable {
+    /// List of available primary servers.
     public let primary_servers: [PrimaryServer]
 }
 
+/// Representation of a DNS record returned by the API.
 public struct Record: Codable {
+    /// Creation timestamp for the record.
     public let created: String
+    /// Unique identifier for the record.
     public let id: String
+    /// Last modification timestamp.
     public let modified: String
+    /// Hostname associated with the record.
     public let name: String
+    /// Time to live value in seconds.
     public let ttl: Int
+    /// DNS record type, such as `A` or `TXT`.
     public let type: String
+    /// Value stored in the record.
     public let value: String
+    /// Identifier of the zone that owns the record.
     public let zone_id: String
 }
 
+/// Request body for creating a single DNS record.
 public struct RecordCreate: Codable {
+    /// Hostname for the new record.
     public let name: String
+    /// Time to live value in seconds.
     public let ttl: Int
+    /// DNS record type, such as `A` or `TXT`.
     public let type: String
+    /// Value to associate with the record.
     public let value: String
+    /// Zone identifier where the record will be created.
     public let zone_id: String
 }
 
+/// Response wrapper containing a single record instance.
 public struct RecordResponse: Codable {
+    /// Record returned by the server.
     public let record: Record
 }
 
+/// Response returning multiple records.
 public struct RecordsResponse: Codable {
+    /// Array of DNS records.
     public let records: [Record]
 }
 
+/// Detailed representation of a DNS zone.
 public struct Zone: Codable {
+    /// Creation timestamp for the zone.
     public let created: String
+    /// Unique identifier for the zone.
     public let id: String
+    /// Flag indicating if the zone uses a secondary DNS setup.
     public let is_secondary_dns: Bool
+    /// Hostname of the legacy DNS server.
     public let legacy_dns_host: String
+    /// Nameserver entries for the legacy setup.
     public let legacy_ns: [String]
+    /// Last modification timestamp.
     public let modified: String
+    /// Zone name such as `example.com`.
     public let name: String
+    /// Nameserver records assigned to the zone.
     public let ns: [String]
+    /// Owner identifier for the zone.
     public let owner: String
+    /// Indicates whether the zone is paused.
     public let paused: Bool
+    /// Permission level of the current account.
     public let permission: String
+    /// Project identifier the zone belongs to.
     public let project: String
+    /// Number of records contained within the zone.
     public let records_count: Int
+    /// Registrar information for the domain.
     public let registrar: String
+    /// Operational status of the zone.
     public let status: String
+    /// Default time to live value for records.
     public let ttl: Int
+    /// TXT records used for verification purposes.
     public let txt_verification: [String: String]
+    /// Timestamp when verification completed.
     public let verified: String
 }
 
+/// Request payload for creating a new DNS zone.
 public struct ZoneCreateRequest: Codable {
+    /// Name of the zone to create.
     public let name: String
+    /// Default time to live value for the zone.
     public let ttl: Int
 }
 
+/// Response wrapper containing a single zone.
 public struct ZoneResponse: Codable {
+    /// Zone returned by the server.
     public let zone: Zone
 }
 
+/// Request payload for updating an existing zone.
 public struct ZoneUpdateRequest: Codable {
+    /// Updated zone name.
     public let name: String
+    /// Updated default time to live value.
     public let ttl: Int
 }
 
+/// Response returning a list of zones with metadata.
 public struct ZonesResponse: Codable {
+    /// Additional response metadata.
     public let meta: [String: String]
+    /// Zones returned by the API.
     public let zones: [Zone]
 }
 

--- a/Tests/PublishingFrontendTests/HetznerDNSModelsTests.swift
+++ b/Tests/PublishingFrontendTests/HetznerDNSModelsTests.swift
@@ -46,6 +46,35 @@ final class HetznerDNSModelsTests: XCTestCase {
         let response = try JSONDecoder().decode(PrimaryServersResponse.self, from: json)
         XCTAssertEqual(response.primary_servers.first?.port, 53)
     }
+
+    /// Encoding and decoding round-trip for `PrimaryServerCreate` preserves data.
+    func testPrimaryServerCreateCodable() throws {
+        let request = PrimaryServerCreate(address: "1.1.1.1", port: 53, zone_id: "z")
+        let data = try JSONEncoder().encode(request)
+        let decoded = try JSONDecoder().decode(PrimaryServerCreate.self, from: data)
+        XCTAssertEqual(decoded.address, "1.1.1.1")
+        XCTAssertEqual(decoded.port, 53)
+        XCTAssertEqual(decoded.zone_id, "z")
+    }
+
+    /// Decoding `RecordResponse` extracts the embedded record details.
+    func testRecordResponseDecodes() throws {
+        let json = """
+        {"record":{"created":"c","id":"1","modified":"m","name":"n","ttl":60,"type":"A","value":"1.1.1.1","zone_id":"z"}}
+        """.data(using: .utf8)!
+        let response = try JSONDecoder().decode(RecordResponse.self, from: json)
+        XCTAssertEqual(response.record.name, "n")
+        XCTAssertEqual(response.record.value, "1.1.1.1")
+    }
+
+    /// Encoding and decoding `ZoneCreateRequest` maintains provided values.
+    func testZoneCreateRequestCodable() throws {
+        let request = ZoneCreateRequest(name: "example.com", ttl: 60)
+        let data = try JSONEncoder().encode(request)
+        let decoded = try JSONDecoder().decode(ZoneCreateRequest.self, from: data)
+        XCTAssertEqual(decoded.name, "example.com")
+        XCTAssertEqual(decoded.ttl, 60)
+    }
 }
 
 // © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/docs/README.md
+++ b/docs/README.md
@@ -52,6 +52,7 @@ As modules gain documentation, brief summaries are added here.
 - **BulkRecordsCreateRequest** and **validateZoneFileResponse** – documented models for batch record creation and zone validation feedback.
 - **PublishingFrontendPlugin.rootPath** – documented property describing the static file directory.
 - **BulkRecordsUpdateRequest**, **BulkRecordsUpdateResponse**, **RecordUpdate**, and **PrimaryServer** – documented models covering batch record updates and primary server metadata.
+- **PrimaryServerCreate**, **PrimaryServerResponse**, **PrimaryServersResponse**, **Record**, **RecordCreate**, **RecordResponse**, **RecordsResponse**, **Zone**, **ZoneCreateRequest**, **ZoneResponse**, **ZoneUpdateRequest**, and **ZonesResponse** – additional Hetzner DNS models now fully documented.
 - **CertificateManager.start**, **stop**, and **triggerNow** – document timer scheduling, cancellation semantics, and on-demand execution.
 
 Documentation coverage will expand alongside test coverage.


### PR DESCRIPTION
## Summary
- document additional Hetzner DNS models
- add encoding/decoding tests for primary server, record response, and zone creation
- refresh coverage report

## Testing
- `swift build -c release -Xswiftc -O -Xswiftc -warnings-as-errors`
- `swift test -c release --enable-code-coverage`


------
https://chatgpt.com/codex/tasks/task_e_688ecf98cf508325b0c8db16bf2a599f