### PR TITLE
Document HTTP request properties and add tests

### DIFF
--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -5,20 +5,20 @@
 Running `swift test --enable-code-coverage` and analysing with `llvm-cov` produced the following totals:
 
 ```
-TOTAL                                          31637   26666    15.71%   14179 11543    18.59%   99084 81812    17.43%
+TOTAL                                          31652   26674    15.73%   14194 11547    18.65%   99114 81834    17.43%
 ```
 
-The repository contains **99,084** executable lines, with **17,272** lines covered (approx. **17.43%** line coverage).
+The repository contains **99,114** executable lines, with **17,280** lines covered (approx. **17.43%** line coverage).
 
 ### Repository source coverage
 
 Ignoring third-party packages under `.build/checkouts`, the totals are:
 
 ```
-TOTAL                                           749     348    53.54%     296     88    70.27%    1680     689    58.99%
+TOTAL                                           590     289    51.02%     173     56    67.63%    1362     541    60.28%
 ```
 
-Within repository sources there are **1,680** lines, with **991** covered, giving **58.99%** line coverage.
+Within repository sources there are **1,362** lines, with **821** covered, giving **60.28%** line coverage.
 
 Coverage results are recalculated after each test run to monitor progress. The project strives for ever more comprehensive test suites across all modules. Recent additions include unit tests for ``APIClient``. New tests now verify ``URLSessionHTTPClient`` behavior and the ``Supervisor`` process termination logic.
 Additional tests now cover ``OpenAPISpec.swiftType`` and the ``camelCased`` string helper. A new ``GatewayServerTests`` suite raises total tests to **27**.
@@ -46,6 +46,7 @@ The new ``BulkRecordsUpdateRequestCodable`` and ``PrimaryServersResponseDecodes`
 The new ``CertificateManager`` start and stop tests raise the total test count to **77**.
 The new server 404 and non-GET tests raise the total test count to **79**.
 The new ``PrimaryServerCreateCodable``, ``RecordResponseDecodes``, and ``ZoneCreateRequestCodable`` tests raise the total test count to **82**.
+The new ``HTTPRequestTests`` verifying defaults and mutation raise the total test count to **84**.
 
 ---
 © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainCodex/IntegrationRuntime/HTTPRequest.swift
+++ b/Sources/FountainCodex/IntegrationRuntime/HTTPRequest.swift
@@ -6,9 +6,13 @@ public struct NoBody: Codable {}
 /// Represents an HTTP request flowing through ``HTTPKernel`` powered servers.
 /// Stores the HTTP method, path, headers and optional body data.
 public struct HTTPRequest: Sendable {
+    /// HTTP verb such as `GET` or `POST`.
     public let method: String
+    /// Requested path without scheme or host.
     public let path: String
+    /// HTTP headers associated with the request.
     public var headers: [String: String]
+    /// Optional message body data.
     public var body: Data
 
     /// Creates a new request instance.

--- a/Sources/FountainCodex/IntegrationRuntime/HTTPResponse.swift
+++ b/Sources/FountainCodex/IntegrationRuntime/HTTPResponse.swift
@@ -3,8 +3,11 @@ import Foundation
 /// Standard HTTP response returned by ``HTTPKernel`` handlers.
 /// Provides mutable status, headers and response body.
 public struct HTTPResponse: Sendable {
+    /// HTTP status code sent back to the client.
     public var status: Int
+    /// Headers included with the response.
     public var headers: [String: String]
+    /// Raw payload returned as the message body.
     public var body: Data
 
     /// Creates a new response value.

--- a/Tests/IntegrationRuntimeTests/CertificateManagerTests.swift
+++ b/Tests/IntegrationRuntimeTests/CertificateManagerTests.swift
@@ -52,6 +52,8 @@ final class CertificateManagerTests: XCTestCase {
         manager.start()
         sleep(1)
         manager.stop()
+        // Allow any in-flight executions to finish before measuring.
+        sleep(1)
         let first = try String(contentsOf: logURL, encoding: .utf8).split(separator: "\n").count
         sleep(1)
         let second = try String(contentsOf: logURL, encoding: .utf8).split(separator: "\n").count

--- a/Tests/IntegrationRuntimeTests/HTTPRequestTests.swift
+++ b/Tests/IntegrationRuntimeTests/HTTPRequestTests.swift
@@ -1,0 +1,24 @@
+import XCTest
+@testable import FountainCodex
+
+final class HTTPRequestTests: XCTestCase {
+    /// Verifies default initializer values for ``HTTPRequest``.
+    func testRequestDefaults() {
+        let req = HTTPRequest(method: "GET", path: "/")
+        XCTAssertEqual(req.method, "GET")
+        XCTAssertEqual(req.path, "/")
+        XCTAssertTrue(req.headers.isEmpty)
+        XCTAssertEqual(req.body.count, 0)
+    }
+
+    /// Confirms headers and body are mutable.
+    func testRequestMutation() {
+        var req = HTTPRequest(method: "POST", path: "/data")
+        req.headers["X-Test"] = "ok"
+        req.body = Data("hi".utf8)
+        XCTAssertEqual(req.headers["X-Test"], "ok")
+        XCTAssertEqual(String(data: req.body, encoding: .utf8), "hi")
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/docs/README.md
+++ b/docs/README.md
@@ -54,6 +54,8 @@ As modules gain documentation, brief summaries are added here.
 - **BulkRecordsUpdateRequest**, **BulkRecordsUpdateResponse**, **RecordUpdate**, and **PrimaryServer** – documented models covering batch record updates and primary server metadata.
 - **PrimaryServerCreate**, **PrimaryServerResponse**, **PrimaryServersResponse**, **Record**, **RecordCreate**, **RecordResponse**, **RecordsResponse**, **Zone**, **ZoneCreateRequest**, **ZoneResponse**, **ZoneUpdateRequest**, and **ZonesResponse** – additional Hetzner DNS models now fully documented.
 - **CertificateManager.start**, **stop**, and **triggerNow** – document timer scheduling, cancellation semantics, and on-demand execution.
+- **HTTPRequest.method**, **path**, **headers**, and **body** – properties now describe their respective roles.
+- **HTTPResponse.status**, **headers**, and **body** – properties now clarify response components.
 
 Documentation coverage will expand alongside test coverage.
 


### PR DESCRIPTION
## Summary
- document HTTP request and response properties for the integration runtime
- add new HTTPRequest tests and stabilize certificate manager timing
- update coverage metrics and documentation progress

## Testing
- `swift test -c release --enable-code-coverage`


------
https://chatgpt.com/codex/tasks/task_e_688ed62fdf308325b681b52505ac2ae6