### PR TITLE
Document PublishingFrontend internals and expand tests

### DIFF
--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -5,10 +5,10 @@
 Running `swift test --enable-code-coverage` and analysing with `llvm-cov` produced the following totals:
 
 ```
-TOTAL                                          31652   26674    15.73%   14194 11547    18.65%   99114 81834    17.43%
+TOTAL                                          31667   26647    15.85%   14204 11535    18.79%   99150 81688    17.61%
 ```
 
-The repository contains **99,114** executable lines, with **17,280** lines covered (approx. **17.43%** line coverage).
+The repository contains **99,150** executable lines, with **17,462** lines covered (approx. **17.61%** line coverage).
 
 ### Repository source coverage
 
@@ -47,6 +47,8 @@ The new ``CertificateManager`` start and stop tests raise the total test count t
 The new server 404 and non-GET tests raise the total test count to **79**.
 The new ``PrimaryServerCreateCodable``, ``RecordResponseDecodes``, and ``ZoneCreateRequestCodable`` tests raise the total test count to **82**.
 The new ``HTTPRequestTests`` verifying defaults and mutation raise the total test count to **84**.
+
+The new ``TodoDecodingFailsForMissingID``, ``LoadPublishingConfigFailsForMissingFile``, and ``ServerSetsContentTypeHeader`` tests raise the total test count to **87**.
 
 ---
 © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/PublishingFrontend/PublishingFrontend.swift
+++ b/Sources/PublishingFrontend/PublishingFrontend.swift
@@ -23,8 +23,11 @@ public struct PublishingConfig: Codable {
 
 /// Lightweight HTTP server for serving generated documentation.
 public final class PublishingFrontend {
+    /// Underlying HTTP server handling requests.
     private let server: NIOHTTPServer
+    /// Event loop group driving asynchronous operations.
     private let group: EventLoopGroup
+    /// Runtime configuration specifying port and root path.
     private let config: PublishingConfig
 
     /// Creates a new server instance with the given configuration.

--- a/Tests/FountainCoreTests/FountainCoreTests.swift
+++ b/Tests/FountainCoreTests/FountainCoreTests.swift
@@ -26,6 +26,12 @@ final class FountainCoreTests: XCTestCase {
         let json = #"{"id":1}"#.data(using: .utf8)!
         XCTAssertThrowsError(try JSONDecoder().decode(Todo.self, from: json))
     }
+
+    /// Ensures decoding fails when the `id` field is absent.
+    func testTodoDecodingFailsForMissingID() {
+        let json = #"{"name":"Task"}"#.data(using: .utf8)!
+        XCTAssertThrowsError(try JSONDecoder().decode(Todo.self, from: json))
+    }
 }
 
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -51,6 +51,7 @@ As modules gain documentation, brief summaries are added here.
 - **ServerGenerator emit helpers** – private functions now describe generated source responsibilities.
 - **BulkRecordsCreateRequest** and **validateZoneFileResponse** – documented models for batch record creation and zone validation feedback.
 - **PublishingFrontendPlugin.rootPath** – documented property describing the static file directory.
+- **PublishingFrontend.server**, **group**, and **config** – internal properties now describe server instance, event loop management, and runtime configuration.
 - **BulkRecordsUpdateRequest**, **BulkRecordsUpdateResponse**, **RecordUpdate**, and **PrimaryServer** – documented models covering batch record updates and primary server metadata.
 - **PrimaryServerCreate**, **PrimaryServerResponse**, **PrimaryServersResponse**, **Record**, **RecordCreate**, **RecordResponse**, **RecordsResponse**, **Zone**, **ZoneCreateRequest**, **ZoneResponse**, **ZoneUpdateRequest**, and **ZonesResponse** – additional Hetzner DNS models now fully documented.
 - **CertificateManager.start**, **stop**, and **triggerNow** – document timer scheduling, cancellation semantics, and on-demand execution.

--- a/logs/build-20250803050638.log
+++ b/logs/build-20250803050638.log
@@ -1,0 +1,447 @@
+[0/1] Planning build
+Building for production...
+[0/12] Write sources
+[5/18] Write swift-version--4EAD98957C2213E4.txt
+[7/23] Compiling _NIOBase64 Base64.swift
+[8/24] Compiling _NIODataStructures Heap.swift
+[9/25] Compiling InternalCollectionsUtilities FixedWidthInteger+roundUpToPowerOfTwo.swift
+[10/26] Compiling RealModule AlgebraicField.swift
+[11/26] Compiling FountainCore Models.swift
+[12/28] Compiling Logging Locks.swift
+[13/28] Compiling NIOConcurrencyHelpers NIOAtomic.swift
+[14/30] Compiling DequeModule Deque+Codable.swift
+[15/30] Compiling Atomics OptionalRawRepresentable.swift
+[16/31] Compiling FountainCoreTests FountainCoreTests.swift
+[17/31] Compiling Algorithms AdjacentPairs.swift
+[18/31] Compiling Yams AliasDereferencingStrategy.swift
+[19/31] Compiling NIOCore AddressedEnvelope.swift
+[20/33] Compiling NIOEmbedded AsyncTestingChannel.swift
+[21/33] Compiling NIOPosix BSDSocketAPICommon.swift
+[22/34] Compiling NIO Exports.swift
+[23/38] Compiling NIOFoundationCompat ByteBuffer-foundation.swift
+[24/38] Compiling NIOTLS ApplicationProtocolNegotiationHandler.swift
+[25/40] Compiling NIOSOCKS SOCKSClientHandler.swift
+[26/40] Compiling NIOTransportServices AcceptHandler.swift
+[27/40] Compiling NIOHTTP1 ByteCollectionUtils.swift
+[28/42] Compiling NIOSSL AndroidCABundle.swift
+[29/42] Compiling NIOHTTPCompression HTTPCompression.swift
+[30/42] Compiling NIOHPACK DynamicHeaderTable.swift
+[31/43] Compiling NIOHTTP2 ConnectionStateMachine.swift
+[32/44] Compiling AsyncHTTPClient AnyAsyncSequence.swift
+[33/45] Compiling FountainCodex ClientGenerator.swift
+[34/48] Compiling clientgen_service main.swift
+[34/48] Write Objects.LinkFileList
+[36/48] Compiling ClientGeneratorTests ClientGeneratorTests.swift
+/workspace/codex-deployer/Tests/ClientGeneratorTests/SpecValidatorTests.swift:6:13: warning: variable 'op' was never mutated; consider changing to 'let' constant
+ 4 | final class SpecValidatorTests: XCTestCase {
+ 5 |     func testDuplicateOperationIdThrows() throws {
+ 6 |         var op = OpenAPISpec.Operation(operationId: "op", parameters: nil, requestBody: nil, responses: nil, security: nil)
+   |             `- warning: variable 'op' was never mutated; consider changing to 'let' constant
+ 7 |         let item = OpenAPISpec.PathItem(get: op, post: nil, put: nil, delete: nil)
+ 8 |         var spec = OpenAPISpec(title: "API", servers: nil, components: nil, paths: [
+
+/workspace/codex-deployer/Tests/ClientGeneratorTests/SpecValidatorTests.swift:8:13: warning: variable 'spec' was never mutated; consider changing to 'let' constant
+ 6 |         var op = OpenAPISpec.Operation(operationId: "op", parameters: nil, requestBody: nil, responses: nil, security: nil)
+ 7 |         let item = OpenAPISpec.PathItem(get: op, post: nil, put: nil, delete: nil)
+ 8 |         var spec = OpenAPISpec(title: "API", servers: nil, components: nil, paths: [
+   |             `- warning: variable 'spec' was never mutated; consider changing to 'let' constant
+ 9 |             "/a": item,
+10 |             "/b": item
+
+/workspace/codex-deployer/Tests/ClientGeneratorTests/SpecValidatorTests.swift:18:13: warning: variable 'paramSchema' was never mutated; consider changing to 'let' constant
+16 | 
+17 |     func testUnresolvedSchemaReferenceThrows() throws {
+18 |         var paramSchema = OpenAPISpec.Schema()
+   |             `- warning: variable 'paramSchema' was never mutated; consider changing to 'let' constant
+19 |         paramSchema.ref = "#/components/schemas/Missing"
+20 |         let param = OpenAPISpec.Parameter(name: "id", location: "path", required: true, schema: paramSchema)
+
+/workspace/codex-deployer/Tests/ClientGeneratorTests/SpecValidatorTests.swift:21:13: warning: variable 'op' was never mutated; consider changing to 'let' constant
+19 |         paramSchema.ref = "#/components/schemas/Missing"
+20 |         let param = OpenAPISpec.Parameter(name: "id", location: "path", required: true, schema: paramSchema)
+21 |         var op = OpenAPISpec.Operation(operationId: "get", parameters: [param], requestBody: nil, responses: nil, security: nil)
+   |             `- warning: variable 'op' was never mutated; consider changing to 'let' constant
+22 |         let item = OpenAPISpec.PathItem(get: op, post: nil, put: nil, delete: nil)
+23 |         let components = OpenAPISpec.Components(schemas: [:], securitySchemes: nil)
+
+/workspace/codex-deployer/Tests/ClientGeneratorTests/SpecValidatorTests.swift:24:13: warning: variable 'spec' was never mutated; consider changing to 'let' constant
+22 |         let item = OpenAPISpec.PathItem(get: op, post: nil, put: nil, delete: nil)
+23 |         let components = OpenAPISpec.Components(schemas: [:], securitySchemes: nil)
+24 |         var spec = OpenAPISpec(title: "API", servers: nil, components: components, paths: ["/item/{id}": item])
+   |             `- warning: variable 'spec' was never mutated; consider changing to 'let' constant
+25 |         XCTAssertThrowsError(try SpecValidator.validate(spec)) { error in
+26 |             XCTAssertTrue("\(error)".contains("unresolved reference"))
+[36/48] Linking clientgen-service
+[38/48] Compiling PublishingFrontend DNSProvider.swift
+[39/52] Compiling publishing_frontend main.swift
+[39/52] Write Objects.LinkFileList
+[41/52] Compiling gateway_server CertificateManager.swift
+[41/52] Write Objects.LinkFileList
+[43/52] Compiling DNSTests APIClientTests.swift
+[44/52] Compiling PublishingFrontendTests HetznerDNSModelsTests.swift
+/workspace/codex-deployer/Tests/PublishingFrontendTests/PublishingFrontendTests.swift:39:37: warning: result of call to 'changeCurrentDirectoryPath' is unused
+ 37 |         try yaml.write(to: fileURL, atomically: true, encoding: .utf8)
+ 38 |         let cwd = FileManager.default.currentDirectoryPath
+ 39 |         defer { FileManager.default.changeCurrentDirectoryPath(cwd) }
+    |                                     `- warning: result of call to 'changeCurrentDirectoryPath' is unused
+ 40 |         FileManager.default.changeCurrentDirectoryPath(dir.path)
+ 41 |         let config = try loadPublishingConfig()
+
+/workspace/codex-deployer/Tests/PublishingFrontendTests/PublishingFrontendTests.swift:40:29: warning: result of call to 'changeCurrentDirectoryPath' is unused
+ 38 |         let cwd = FileManager.default.currentDirectoryPath
+ 39 |         defer { FileManager.default.changeCurrentDirectoryPath(cwd) }
+ 40 |         FileManager.default.changeCurrentDirectoryPath(dir.path)
+    |                             `- warning: result of call to 'changeCurrentDirectoryPath' is unused
+ 41 |         let config = try loadPublishingConfig()
+ 42 |         XCTAssertEqual(config.port, 1234)
+
+/workspace/codex-deployer/Tests/PublishingFrontendTests/PublishingFrontendTests.swift:58:37: warning: result of call to 'changeCurrentDirectoryPath' is unused
+ 56 |         try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+ 57 |         let cwd = FileManager.default.currentDirectoryPath
+ 58 |         defer { FileManager.default.changeCurrentDirectoryPath(cwd) }
+    |                                     `- warning: result of call to 'changeCurrentDirectoryPath' is unused
+ 59 |         FileManager.default.changeCurrentDirectoryPath(dir.path)
+ 60 |         XCTAssertThrowsError(try loadPublishingConfig())
+
+/workspace/codex-deployer/Tests/PublishingFrontendTests/PublishingFrontendTests.swift:59:29: warning: result of call to 'changeCurrentDirectoryPath' is unused
+ 57 |         let cwd = FileManager.default.currentDirectoryPath
+ 58 |         defer { FileManager.default.changeCurrentDirectoryPath(cwd) }
+ 59 |         FileManager.default.changeCurrentDirectoryPath(dir.path)
+    |                             `- warning: result of call to 'changeCurrentDirectoryPath' is unused
+ 60 |         XCTAssertThrowsError(try loadPublishingConfig())
+ 61 |     }
+[44/52] Linking publishing-frontend
+[45/52] Linking gateway-server
+[47/53] Compiling IntegrationRuntimeTests AsyncHTTPClientDriverTests.swift
+[47/53] /workspace/codex-deployer/.build/x86_64-unknown-linux-gnu/release/FountainCoachPackageDiscoveredTests.derived/all-discovered-tests.swift
+[48/53] Write sources
+[50/54] Compiling FountainCoachPackageDiscoveredTests ClientGeneratorTests.swift
+[50/54] /workspace/codex-deployer/.build/x86_64-unknown-linux-gnu/release/FountainCoachPackageTests.derived/runner.swift
+[51/54] Write sources
+[53/55] Compiling FountainCoachPackageTests runner.swift
+[53/55] Write Objects.LinkFileList
+[54/55] Linking FountainCoachPackageTests.xctest
+Build complete! (126.27s)
+Test Suite 'All tests' started at 2025-08-03 05:08:45.928
+Test Suite 'release.xctest' started at 2025-08-03 05:08:45.948
+Test Suite 'APIClientTests' started at 2025-08-03 05:08:45.948
+Test Case 'APIClientTests.testBearerInitializerSetsHeader' started at 2025-08-03 05:08:45.948
+Test Case 'APIClientTests.testBearerInitializerSetsHeader' passed (0.005 seconds)
+Test Case 'APIClientTests.testRawDataResponse' started at 2025-08-03 05:08:45.954
+Test Case 'APIClientTests.testRawDataResponse' passed (0.002 seconds)
+Test Case 'APIClientTests.testSendDecodesResponse' started at 2025-08-03 05:08:45.955
+Test Case 'APIClientTests.testSendDecodesResponse' passed (0.001 seconds)
+Test Suite 'APIClientTests' passed at 2025-08-03 05:08:45.956
+	 Executed 3 tests, with 0 failures (0 unexpected) in 0.008 (0.008) seconds
+Test Suite 'CreatePrimaryServerRequestTests' started at 2025-08-03 05:08:45.956
+Test Case 'CreatePrimaryServerRequestTests.testMethodIsPOST' started at 2025-08-03 05:08:45.956
+Test Case 'CreatePrimaryServerRequestTests.testMethodIsPOST' passed (0.0 seconds)
+Test Case 'CreatePrimaryServerRequestTests.testPathIsCorrect' started at 2025-08-03 05:08:45.957
+Test Case 'CreatePrimaryServerRequestTests.testPathIsCorrect' passed (0.0 seconds)
+Test Suite 'CreatePrimaryServerRequestTests' passed at 2025-08-03 05:08:45.957
+	 Executed 2 tests, with 0 failures (0 unexpected) in 0.0 (0.0) seconds
+Test Suite 'DNSClientTests' started at 2025-08-03 05:08:45.957
+Test Case 'DNSClientTests.testRoute53CreateRecordStub' started at 2025-08-03 05:08:45.957
+Test Case 'DNSClientTests.testRoute53CreateRecordStub' passed (0.0 seconds)
+Test Case 'DNSClientTests.testRoute53DeleteRecordErrorDetails' started at 2025-08-03 05:08:45.957
+Test Case 'DNSClientTests.testRoute53DeleteRecordErrorDetails' passed (0.101 seconds)
+Test Case 'DNSClientTests.testRoute53DeleteRecordStub' started at 2025-08-03 05:08:46.058
+Test Case 'DNSClientTests.testRoute53DeleteRecordStub' passed (0.0 seconds)
+Test Case 'DNSClientTests.testRoute53ListZonesErrorDetails' started at 2025-08-03 05:08:46.058
+Test Case 'DNSClientTests.testRoute53ListZonesErrorDetails' passed (0.0 seconds)
+Test Case 'DNSClientTests.testRoute53Stub' started at 2025-08-03 05:08:46.059
+Test Case 'DNSClientTests.testRoute53Stub' passed (0.0 seconds)
+Test Case 'DNSClientTests.testRoute53UpdateRecordStub' started at 2025-08-03 05:08:46.059
+Test Case 'DNSClientTests.testRoute53UpdateRecordStub' passed (0.0 seconds)
+Test Suite 'DNSClientTests' passed at 2025-08-03 05:08:46.059
+	 Executed 6 tests, with 0 failures (0 unexpected) in 0.102 (0.102) seconds
+Test Suite 'DeleteZoneRequestTests' started at 2025-08-03 05:08:46.059
+Test Case 'DeleteZoneRequestTests.testPathBuilderEncodesZoneId' started at 2025-08-03 05:08:46.059
+Test Case 'DeleteZoneRequestTests.testPathBuilderEncodesZoneId' passed (0.001 seconds)
+Test Suite 'DeleteZoneRequestTests' passed at 2025-08-03 05:08:46.060
+	 Executed 1 test, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
+Test Suite 'GetPrimaryServerRequestTests' started at 2025-08-03 05:08:46.060
+Test Case 'GetPrimaryServerRequestTests.testMethodIsGET' started at 2025-08-03 05:08:46.060
+Test Case 'GetPrimaryServerRequestTests.testMethodIsGET' passed (0.0 seconds)
+Test Case 'GetPrimaryServerRequestTests.testPathBuilderReplacesId' started at 2025-08-03 05:08:46.061
+Test Case 'GetPrimaryServerRequestTests.testPathBuilderReplacesId' passed (0.0 seconds)
+Test Suite 'GetPrimaryServerRequestTests' passed at 2025-08-03 05:08:46.061
+	 Executed 2 tests, with 0 failures (0 unexpected) in 0.0 (0.0) seconds
+Test Suite 'GetRecordRequestTests' started at 2025-08-03 05:08:46.061
+Test Case 'GetRecordRequestTests.testPathBuilderReplacesRecordId' started at 2025-08-03 05:08:46.061
+Test Case 'GetRecordRequestTests.testPathBuilderReplacesRecordId' passed (0.0 seconds)
+Test Suite 'GetRecordRequestTests' passed at 2025-08-03 05:08:46.061
+	 Executed 1 test, with 0 failures (0 unexpected) in 0.0 (0.0) seconds
+Test Suite 'GetZoneRequestTests' started at 2025-08-03 05:08:46.061
+Test Case 'GetZoneRequestTests.testPathBuilderReplacesZoneId' started at 2025-08-03 05:08:46.061
+Test Case 'GetZoneRequestTests.testPathBuilderReplacesZoneId' passed (0.0 seconds)
+Test Suite 'GetZoneRequestTests' passed at 2025-08-03 05:08:46.061
+	 Executed 1 test, with 0 failures (0 unexpected) in 0.0 (0.0) seconds
+Test Suite 'HetznerDNSClientTests' started at 2025-08-03 05:08:46.061
+Test Case 'HetznerDNSClientTests.testCreateRecordRequest' started at 2025-08-03 05:08:46.061
+Test Case 'HetznerDNSClientTests.testCreateRecordRequest' passed (0.002 seconds)
+Test Case 'HetznerDNSClientTests.testCreateRecordSetsContentTypeHeader' started at 2025-08-03 05:08:46.063
+Test Case 'HetznerDNSClientTests.testCreateRecordSetsContentTypeHeader' passed (0.0 seconds)
+Test Case 'HetznerDNSClientTests.testDeleteRecordRequest' started at 2025-08-03 05:08:46.064
+Test Case 'HetznerDNSClientTests.testDeleteRecordRequest' passed (0.0 seconds)
+Test Case 'HetznerDNSClientTests.testListZonesPathBuilder' started at 2025-08-03 05:08:46.064
+Test Case 'HetznerDNSClientTests.testListZonesPathBuilder' passed (0.0 seconds)
+Test Case 'HetznerDNSClientTests.testUpdateRecordRequest' started at 2025-08-03 05:08:46.064
+Test Case 'HetznerDNSClientTests.testUpdateRecordRequest' passed (0.0 seconds)
+Test Suite 'HetznerDNSClientTests' passed at 2025-08-03 05:08:46.065
+	 Executed 5 tests, with 0 failures (0 unexpected) in 0.003 (0.003) seconds
+Test Suite 'ListPrimaryServersRequestTests' started at 2025-08-03 05:08:46.065
+Test Case 'ListPrimaryServersRequestTests.testPathBuilderAddsZoneIdQueryWhenProvided' started at 2025-08-03 05:08:46.065
+Test Case 'ListPrimaryServersRequestTests.testPathBuilderAddsZoneIdQueryWhenProvided' passed (0.0 seconds)
+Test Case 'ListPrimaryServersRequestTests.testPathBuilderWithoutZoneIdHasNoQuery' started at 2025-08-03 05:08:46.065
+Test Case 'ListPrimaryServersRequestTests.testPathBuilderWithoutZoneIdHasNoQuery' passed (0.0 seconds)
+Test Suite 'ListPrimaryServersRequestTests' passed at 2025-08-03 05:08:46.065
+	 Executed 2 tests, with 0 failures (0 unexpected) in 0.0 (0.0) seconds
+Test Suite 'ListRecordsRequestTests' started at 2025-08-03 05:08:46.065
+Test Case 'ListRecordsRequestTests.testPathBuilderEncodesQuery' started at 2025-08-03 05:08:46.065
+Test Case 'ListRecordsRequestTests.testPathBuilderEncodesQuery' passed (0.0 seconds)
+Test Suite 'ListRecordsRequestTests' passed at 2025-08-03 05:08:46.065
+	 Executed 1 test, with 0 failures (0 unexpected) in 0.0 (0.0) seconds
+Test Suite 'FountainCoreTests' started at 2025-08-03 05:08:46.065
+Test Case 'FountainCoreTests.testTodoDecoding' started at 2025-08-03 05:08:46.065
+Test Case 'FountainCoreTests.testTodoDecoding' passed (0.0 seconds)
+Test Case 'FountainCoreTests.testTodoDecodingFailsForMissingID' started at 2025-08-03 05:08:46.066
+Test Case 'FountainCoreTests.testTodoDecodingFailsForMissingID' passed (0.0 seconds)
+Test Case 'FountainCoreTests.testTodoDecodingFailsForMissingName' started at 2025-08-03 05:08:46.066
+Test Case 'FountainCoreTests.testTodoDecodingFailsForMissingName' passed (0.101 seconds)
+Test Case 'FountainCoreTests.testTodoEncodingRoundTrip' started at 2025-08-03 05:08:46.166
+Test Case 'FountainCoreTests.testTodoEncodingRoundTrip' passed (0.0 seconds)
+Test Case 'FountainCoreTests.testTodoEquality' started at 2025-08-03 05:08:46.167
+Test Case 'FountainCoreTests.testTodoEquality' passed (0.0 seconds)
+Test Suite 'FountainCoreTests' passed at 2025-08-03 05:08:46.167
+	 Executed 5 tests, with 0 failures (0 unexpected) in 0.102 (0.102) seconds
+Test Suite 'ClientGeneratorTests' started at 2025-08-03 05:08:46.167
+Test Case 'ClientGeneratorTests.testClientFilesGenerated' started at 2025-08-03 05:08:46.167
+Test Case 'ClientGeneratorTests.testClientFilesGenerated' passed (0.007 seconds)
+Test Suite 'ClientGeneratorTests' passed at 2025-08-03 05:08:46.174
+	 Executed 1 test, with 0 failures (0 unexpected) in 0.007 (0.007) seconds
+Test Suite 'OpenAPISwiftTypeTests' started at 2025-08-03 05:08:46.174
+Test Case 'OpenAPISwiftTypeTests.testSchemaPropertySwiftType' started at 2025-08-03 05:08:46.174
+Test Case 'OpenAPISwiftTypeTests.testSchemaPropertySwiftType' passed (0.0 seconds)
+Test Case 'OpenAPISwiftTypeTests.testSchemaRefSwiftType' started at 2025-08-03 05:08:46.174
+Test Case 'OpenAPISwiftTypeTests.testSchemaRefSwiftType' passed (0.001 seconds)
+Test Suite 'OpenAPISwiftTypeTests' passed at 2025-08-03 05:08:46.175
+	 Executed 2 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
+Test Suite 'SecurityRequirementTests' started at 2025-08-03 05:08:46.175
+Test Case 'SecurityRequirementTests.testDecodesSchemesFromJSON' started at 2025-08-03 05:08:46.175
+Test Case 'SecurityRequirementTests.testDecodesSchemesFromJSON' passed (0.101 seconds)
+Test Case 'SecurityRequirementTests.testEncodesSchemesToJSON' started at 2025-08-03 05:08:46.276
+Test Case 'SecurityRequirementTests.testEncodesSchemesToJSON' passed (0.001 seconds)
+Test Suite 'SecurityRequirementTests' passed at 2025-08-03 05:08:46.278
+	 Executed 2 tests, with 0 failures (0 unexpected) in 0.102 (0.102) seconds
+Test Suite 'SpecLoaderTests' started at 2025-08-03 05:08:46.278
+Test Case 'SpecLoaderTests.testLoadsJSONRemovingCopyright' started at 2025-08-03 05:08:46.278
+Test Case 'SpecLoaderTests.testLoadsJSONRemovingCopyright' passed (0.002 seconds)
+Test Case 'SpecLoaderTests.testLoadsYAMLAndNormalizesInfoTitle' started at 2025-08-03 05:08:46.280
+Test Case 'SpecLoaderTests.testLoadsYAMLAndNormalizesInfoTitle' passed (0.006 seconds)
+Test Suite 'SpecLoaderTests' passed at 2025-08-03 05:08:46.286
+	 Executed 2 tests, with 0 failures (0 unexpected) in 0.008 (0.008) seconds
+Test Suite 'SpecValidatorTests' started at 2025-08-03 05:08:46.286
+Test Case 'SpecValidatorTests.testDuplicateOperationIdThrows' started at 2025-08-03 05:08:46.286
+Test Case 'SpecValidatorTests.testDuplicateOperationIdThrows' passed (0.0 seconds)
+Test Case 'SpecValidatorTests.testUnresolvedSchemaReferenceThrows' started at 2025-08-03 05:08:46.286
+Test Case 'SpecValidatorTests.testUnresolvedSchemaReferenceThrows' passed (0.0 seconds)
+Test Suite 'SpecValidatorTests' passed at 2025-08-03 05:08:46.286
+	 Executed 2 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
+Test Suite 'StringExtensionTests' started at 2025-08-03 05:08:46.286
+Test Case 'StringExtensionTests.testCamelCased' started at 2025-08-03 05:08:46.286
+Test Case 'StringExtensionTests.testCamelCased' passed (0.0 seconds)
+Test Suite 'StringExtensionTests' passed at 2025-08-03 05:08:46.287
+	 Executed 1 test, with 0 failures (0 unexpected) in 0.0 (0.0) seconds
+Test Suite 'AsyncHTTPClientDriverTests' started at 2025-08-03 05:08:46.287
+Test Case 'AsyncHTTPClientDriverTests.testExecutePerformsRequest' started at 2025-08-03 05:08:46.287
+Test Case 'AsyncHTTPClientDriverTests.testExecutePerformsRequest' passed (0.014 seconds)
+Test Suite 'AsyncHTTPClientDriverTests' passed at 2025-08-03 05:08:46.301
+	 Executed 1 test, with 0 failures (0 unexpected) in 0.014 (0.014) seconds
+Test Suite 'CertificateManagerTests' started at 2025-08-03 05:08:46.301
+Test Case 'CertificateManagerTests.testStartSchedulesRepeatedRuns' started at 2025-08-03 05:08:46.301
+Test Case 'CertificateManagerTests.testStartSchedulesRepeatedRuns' passed (1.002 seconds)
+Test Case 'CertificateManagerTests.testStopCancelsFutureRuns' started at 2025-08-03 05:08:47.303
+Test Case 'CertificateManagerTests.testStopCancelsFutureRuns' passed (3.004 seconds)
+Test Case 'CertificateManagerTests.testTriggerNowRunsScript' started at 2025-08-03 05:08:50.308
+Test Case 'CertificateManagerTests.testTriggerNowRunsScript' passed (1.003 seconds)
+Test Suite 'CertificateManagerTests' passed at 2025-08-03 05:08:51.311
+	 Executed 3 tests, with 0 failures (0 unexpected) in 5.01 (5.01) seconds
+Test Suite 'GatewayPluginDefaultTests' started at 2025-08-03 05:08:51.311
+Test Case 'GatewayPluginDefaultTests.testDefaultImplementationsPassThrough' started at 2025-08-03 05:08:51.311
+Test Case 'GatewayPluginDefaultTests.testDefaultImplementationsPassThrough' passed (0.0 seconds)
+Test Suite 'GatewayPluginDefaultTests' passed at 2025-08-03 05:08:51.311
+	 Executed 1 test, with 0 failures (0 unexpected) in 0.0 (0.0) seconds
+Test Suite 'GatewayServerTests' started at 2025-08-03 05:08:51.311
+Test Case 'GatewayServerTests.testHealthEndpointResponds' started at 2025-08-03 05:08:51.311
+Test Case 'GatewayServerTests.testHealthEndpointResponds' passed (0.109 seconds)
+Test Case 'GatewayServerTests.testMetricsEndpointResponds' started at 2025-08-03 05:08:51.420
+Test Case 'GatewayServerTests.testMetricsEndpointResponds' passed (0.104 seconds)
+Test Case 'GatewayServerTests.testPluginCanRewriteRequestAndResponse' started at 2025-08-03 05:08:51.524
+Test Case 'GatewayServerTests.testPluginCanRewriteRequestAndResponse' passed (0.204 seconds)
+Test Suite 'GatewayServerTests' passed at 2025-08-03 05:08:51.728
+	 Executed 3 tests, with 0 failures (0 unexpected) in 0.416 (0.416) seconds
+Test Suite 'HTTPKernelTests' started at 2025-08-03 05:08:51.728
+Test Case 'HTTPKernelTests.testKernelRoutesRequest' started at 2025-08-03 05:08:51.728
+Test Case 'HTTPKernelTests.testKernelRoutesRequest' passed (0.0 seconds)
+Test Suite 'HTTPKernelTests' passed at 2025-08-03 05:08:51.728
+	 Executed 1 test, with 0 failures (0 unexpected) in 0.0 (0.0) seconds
+Test Suite 'HTTPRequestTests' started at 2025-08-03 05:08:51.728
+Test Case 'HTTPRequestTests.testRequestDefaults' started at 2025-08-03 05:08:51.728
+Test Case 'HTTPRequestTests.testRequestDefaults' passed (0.0 seconds)
+Test Case 'HTTPRequestTests.testRequestMutation' started at 2025-08-03 05:08:51.729
+Test Case 'HTTPRequestTests.testRequestMutation' passed (0.0 seconds)
+Test Suite 'HTTPRequestTests' passed at 2025-08-03 05:08:51.729
+	 Executed 2 tests, with 0 failures (0 unexpected) in 0.0 (0.0) seconds
+Test Suite 'HTTPResponseDefaultsTests' started at 2025-08-03 05:08:51.729
+Test Case 'HTTPResponseDefaultsTests.testNoBodyCodable' started at 2025-08-03 05:08:51.729
+Test Case 'HTTPResponseDefaultsTests.testNoBodyCodable' passed (0.001 seconds)
+Test Case 'HTTPResponseDefaultsTests.testResponseDefaults' started at 2025-08-03 05:08:51.730
+Test Case 'HTTPResponseDefaultsTests.testResponseDefaults' passed (0.0 seconds)
+Test Suite 'HTTPResponseDefaultsTests' passed at 2025-08-03 05:08:51.730
+	 Executed 2 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
+Test Suite 'LoggingPluginTests' started at 2025-08-03 05:08:51.730
+Test Case 'LoggingPluginTests.testLoggingPluginPassThrough' started at 2025-08-03 05:08:51.730
+-> GET /
+<- 200 for /
+Test Case 'LoggingPluginTests.testLoggingPluginPassThrough' passed (0.0 seconds)
+Test Suite 'LoggingPluginTests' passed at 2025-08-03 05:08:51.730
+	 Executed 1 test, with 0 failures (0 unexpected) in 0.0 (0.0) seconds
+Test Suite 'NIOHTTPServerTests' started at 2025-08-03 05:08:51.730
+Test Case 'NIOHTTPServerTests.testServerHandlesConcurrentRequests' started at 2025-08-03 05:08:51.731
+Test Case 'NIOHTTPServerTests.testServerHandlesConcurrentRequests' passed (0.003 seconds)
+Test Case 'NIOHTTPServerTests.testServerReleasesPortOnStop' started at 2025-08-03 05:08:51.734
+Test Case 'NIOHTTPServerTests.testServerReleasesPortOnStop' passed (0.001 seconds)
+Test Case 'NIOHTTPServerTests.testServerResponds' started at 2025-08-03 05:08:51.735
+Test Case 'NIOHTTPServerTests.testServerResponds' passed (0.002 seconds)
+Test Suite 'NIOHTTPServerTests' passed at 2025-08-03 05:08:51.737
+	 Executed 3 tests, with 0 failures (0 unexpected) in 0.007 (0.007) seconds
+Test Suite 'PublishingFrontendPluginTests' started at 2025-08-03 05:08:51.737
+Test Case 'PublishingFrontendPluginTests.testPluginIgnoresNonGETRequests' started at 2025-08-03 05:08:51.737
+Test Case 'PublishingFrontendPluginTests.testPluginIgnoresNonGETRequests' passed (0.203 seconds)
+Test Case 'PublishingFrontendPluginTests.testPluginPassThroughWhenFileMissing' started at 2025-08-03 05:08:51.941
+Test Case 'PublishingFrontendPluginTests.testPluginPassThroughWhenFileMissing' passed (0.001 seconds)
+Test Case 'PublishingFrontendPluginTests.testPluginServesFile' started at 2025-08-03 05:08:51.941
+Test Case 'PublishingFrontendPluginTests.testPluginServesFile' passed (0.006 seconds)
+Test Suite 'PublishingFrontendPluginTests' passed at 2025-08-03 05:08:51.948
+	 Executed 3 tests, with 0 failures (0 unexpected) in 0.21 (0.21) seconds
+Test Suite 'URLSessionHTTPClientTests' started at 2025-08-03 05:08:51.948
+Test Case 'URLSessionHTTPClientTests.testExecutePerformsRequest' started at 2025-08-03 05:08:51.948
+Test Case 'URLSessionHTTPClientTests.testExecutePerformsRequest' passed (0.002 seconds)
+Test Suite 'URLSessionHTTPClientTests' passed at 2025-08-03 05:08:51.950
+	 Executed 1 test, with 0 failures (0 unexpected) in 0.002 (0.002) seconds
+Test Suite 'HetznerDNSModelsTests' started at 2025-08-03 05:08:51.950
+Test Case 'HetznerDNSModelsTests.testBulkRecordsCreateRequestCodable' started at 2025-08-03 05:08:51.950
+Test Case 'HetznerDNSModelsTests.testBulkRecordsCreateRequestCodable' passed (0.001 seconds)
+Test Case 'HetznerDNSModelsTests.testBulkRecordsUpdateRequestCodable' started at 2025-08-03 05:08:51.951
+Test Case 'HetznerDNSModelsTests.testBulkRecordsUpdateRequestCodable' passed (0.001 seconds)
+Test Case 'HetznerDNSModelsTests.testPrimaryServerCreateCodable' started at 2025-08-03 05:08:51.951
+Test Case 'HetznerDNSModelsTests.testPrimaryServerCreateCodable' passed (0.0 seconds)
+Test Case 'HetznerDNSModelsTests.testPrimaryServersResponseDecodes' started at 2025-08-03 05:08:51.952
+Test Case 'HetznerDNSModelsTests.testPrimaryServersResponseDecodes' passed (0.0 seconds)
+Test Case 'HetznerDNSModelsTests.testRecordResponseDecodes' started at 2025-08-03 05:08:51.952
+Test Case 'HetznerDNSModelsTests.testRecordResponseDecodes' passed (0.0 seconds)
+Test Case 'HetznerDNSModelsTests.testValidateZoneFileResponseDecodes' started at 2025-08-03 05:08:51.952
+Test Case 'HetznerDNSModelsTests.testValidateZoneFileResponseDecodes' passed (0.0 seconds)
+Test Case 'HetznerDNSModelsTests.testZoneCreateRequestCodable' started at 2025-08-03 05:08:51.953
+Test Case 'HetznerDNSModelsTests.testZoneCreateRequestCodable' passed (0.0 seconds)
+Test Case 'HetznerDNSModelsTests.testZoneResponseDecoding' started at 2025-08-03 05:08:51.953
+Test Case 'HetznerDNSModelsTests.testZoneResponseDecoding' passed (0.101 seconds)
+Test Suite 'HetznerDNSModelsTests' passed at 2025-08-03 05:08:52.054
+	 Executed 8 tests, with 0 failures (0 unexpected) in 0.104 (0.104) seconds
+Test Suite 'HetznerDNSRequestTests' started at 2025-08-03 05:08:52.054
+Test Case 'HetznerDNSRequestTests.testExportZoneFileMethodIsGet' started at 2025-08-03 05:08:52.054
+Test Case 'HetznerDNSRequestTests.testExportZoneFileMethodIsGet' passed (0.0 seconds)
+Test Case 'HetznerDNSRequestTests.testExportZoneFilePathIncludesZoneID' started at 2025-08-03 05:08:52.055
+Test Case 'HetznerDNSRequestTests.testExportZoneFilePathIncludesZoneID' passed (0.0 seconds)
+Test Case 'HetznerDNSRequestTests.testImportZoneFileMethodIsPost' started at 2025-08-03 05:08:52.055
+Test Case 'HetznerDNSRequestTests.testImportZoneFileMethodIsPost' passed (0.0 seconds)
+Test Case 'HetznerDNSRequestTests.testImportZoneFilePathIncludesZoneID' started at 2025-08-03 05:08:52.055
+Test Case 'HetznerDNSRequestTests.testImportZoneFilePathIncludesZoneID' passed (0.0 seconds)
+Test Case 'HetznerDNSRequestTests.testUpdatePrimaryServerMethodIsPut' started at 2025-08-03 05:08:52.055
+Test Case 'HetznerDNSRequestTests.testUpdatePrimaryServerMethodIsPut' passed (0.0 seconds)
+Test Case 'HetznerDNSRequestTests.testUpdatePrimaryServerPathIncludesID' started at 2025-08-03 05:08:52.055
+Test Case 'HetznerDNSRequestTests.testUpdatePrimaryServerPathIncludesID' passed (0.0 seconds)
+Test Case 'HetznerDNSRequestTests.testValidateZoneFileMethodIsPost' started at 2025-08-03 05:08:52.056
+Test Case 'HetznerDNSRequestTests.testValidateZoneFileMethodIsPost' passed (0.0 seconds)
+Test Case 'HetznerDNSRequestTests.testValidateZoneFilePath' started at 2025-08-03 05:08:52.056
+Test Case 'HetznerDNSRequestTests.testValidateZoneFilePath' passed (0.0 seconds)
+Test Suite 'HetznerDNSRequestTests' passed at 2025-08-03 05:08:52.056
+	 Executed 8 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
+Test Suite 'PublishingFrontendTests' started at 2025-08-03 05:08:52.056
+Test Case 'PublishingFrontendTests.testLoadPublishingConfigFailsForMissingFile' started at 2025-08-03 05:08:52.056
+Test Case 'PublishingFrontendTests.testLoadPublishingConfigFailsForMissingFile' passed (0.001 seconds)
+Test Case 'PublishingFrontendTests.testLoadPublishingConfigParsesYaml' started at 2025-08-03 05:08:52.056
+Test Case 'PublishingFrontendTests.testLoadPublishingConfigParsesYaml' passed (0.003 seconds)
+Test Case 'PublishingFrontendTests.testPublishingConfigDefaultValues' started at 2025-08-03 05:08:52.060
+Test Case 'PublishingFrontendTests.testPublishingConfigDefaultValues' passed (0.0 seconds)
+Test Case 'PublishingFrontendTests.testServerRejectsNonGetRequests' started at 2025-08-03 05:08:52.060
+Test Case 'PublishingFrontendTests.testServerRejectsNonGetRequests' passed (0.002 seconds)
+Test Case 'PublishingFrontendTests.testServerReturns404ForMissingFile' started at 2025-08-03 05:08:52.062
+Test Case 'PublishingFrontendTests.testServerReturns404ForMissingFile' passed (0.002 seconds)
+Test Case 'PublishingFrontendTests.testServerServesIndex' started at 2025-08-03 05:08:52.064
+Test Case 'PublishingFrontendTests.testServerServesIndex' passed (0.009 seconds)
+Test Case 'PublishingFrontendTests.testServerSetsContentTypeHeader' started at 2025-08-03 05:08:52.073
+Test Case 'PublishingFrontendTests.testServerSetsContentTypeHeader' passed (0.003 seconds)
+Test Suite 'PublishingFrontendTests' passed at 2025-08-03 05:08:52.076
+	 Executed 7 tests, with 0 failures (0 unexpected) in 0.02 (0.02) seconds
+Test Suite 'Route53ClientTests' started at 2025-08-03 05:08:52.076
+Test Case 'Route53ClientTests.testCreateRecordThrows' started at 2025-08-03 05:08:52.076
+Test Case 'Route53ClientTests.testCreateRecordThrows' passed (0.0 seconds)
+Test Case 'Route53ClientTests.testDeleteRecordThrows' started at 2025-08-03 05:08:52.077
+Test Case 'Route53ClientTests.testDeleteRecordThrows' passed (0.0 seconds)
+Test Case 'Route53ClientTests.testListZonesThrows' started at 2025-08-03 05:08:52.077
+Test Case 'Route53ClientTests.testListZonesThrows' passed (0.0 seconds)
+Test Case 'Route53ClientTests.testUpdateRecordThrows' started at 2025-08-03 05:08:52.077
+Test Case 'Route53ClientTests.testUpdateRecordThrows' passed (0.0 seconds)
+Test Suite 'Route53ClientTests' passed at 2025-08-03 05:08:52.077
+	 Executed 4 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
+Test Suite 'release.xctest' passed at 2025-08-03 05:08:52.077
+	 Executed 87 tests, with 0 failures (0 unexpected) in 6.125 (6.125) seconds
+Test Suite 'All tests' passed at 2025-08-03 05:08:52.077
+	 Executed 87 tests, with 0 failures (0 unexpected) in 6.125 (6.125) seconds
+◇ Test run started.
+↳ Testing Library Version: 6.1 (43b6f88e2f2712e)
+↳ Target Platform: x86_64-unknown-linux-gnu
+✔ Test run with 0 tests passed after 0.001 seconds.
+[0/1] Planning build
+Building for production...
+[0/7] Write swift-version--4EAD98957C2213E4.txt
+[2/12] Compiling _NIOBase64 Base64.swift
+[3/13] Compiling _NIODataStructures Heap.swift
+[4/13] Compiling NIOConcurrencyHelpers NIOAtomic.swift
+[5/15] Compiling InternalCollectionsUtilities FixedWidthInteger+roundUpToPowerOfTwo.swift
+[6/15] Compiling FountainCore Models.swift
+[7/17] Compiling RealModule AlgebraicField.swift
+[8/18] Compiling Logging Locks.swift
+[9/18] Compiling DequeModule Deque+Codable.swift
+[10/18] Compiling Atomics OptionalRawRepresentable.swift
+[11/19] Compiling Algorithms AdjacentPairs.swift
+[12/19] Compiling Yams AliasDereferencingStrategy.swift
+[13/19] Compiling NIOCore AddressedEnvelope.swift
+[14/21] Compiling NIOEmbedded AsyncTestingChannel.swift
+[15/21] Compiling NIOPosix BSDSocketAPICommon.swift
+[16/22] Compiling NIO Exports.swift
+[17/26] Compiling NIOFoundationCompat ByteBuffer-foundation.swift
+[18/26] Compiling NIOTLS ApplicationProtocolNegotiationHandler.swift
+[19/28] Compiling NIOSOCKS SOCKSClientHandler.swift
+[20/28] Compiling NIOTransportServices AcceptHandler.swift
+[21/28] Compiling NIOHTTP1 ByteCollectionUtils.swift
+[22/30] Compiling NIOSSL AndroidCABundle.swift
+[23/30] Compiling NIOHTTPCompression HTTPCompression.swift
+[24/30] Compiling NIOHPACK DynamicHeaderTable.swift
+[25/31] Compiling NIOHTTP2 ConnectionStateMachine.swift
+[26/32] Compiling AsyncHTTPClient AnyAsyncSequence.swift
+[27/33] Compiling FountainCodex ClientGenerator.swift
+[28/35] Compiling clientgen_service main.swift
+[28/35] Write Objects.LinkFileList
+[29/35] Linking clientgen-service
+[31/35] Compiling PublishingFrontend DNSProvider.swift
+[32/37] Compiling publishing_frontend main.swift
+[32/37] Write Objects.LinkFileList
+[34/37] Compiling gateway_server CertificateManager.swift
+[34/37] Write Objects.LinkFileList
+[35/37] Linking publishing-frontend
+[36/37] Linking gateway-server
+Build complete! (110.57s)
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- document internal `PublishingFrontend` server, event loop, and config properties
- add tests for missing publishing config file, HTML content type header, and missing Todo ID decoding
- refresh coverage report with latest totals (87 tests)

## Testing
- `swift build -c release -Xswiftc -O -Xswiftc -warnings-as-errors`
- `swift test -c release --enable-code-coverage`


------
https://chatgpt.com/codex/tasks/task_e_688eec53bc5483259955ac2c4158d545