### PR TITLE
Document deletePrimaryServer request and add tests

### DIFF
--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -5,20 +5,20 @@
 Running `swift test --enable-code-coverage` and analysing with `llvm-cov` produced the following totals:
 
 ```
-TOTAL                                          31758   26538    16.44%   14282 11493    19.53%   99347 81296    18.17%
+TOTAL                                          31766   26565    16.37%   14290 11503    19.50%   99364 81455    18.02%
 ```
 
-The repository contains **99,347** executable lines, with **18,051** lines covered (approx. **18.17%** line coverage).
+The repository contains **99,364** executable lines, with **17,909** lines covered (approx. **18.02%** line coverage).
 
 ### Repository source coverage
 
 Ignoring third-party packages under `.build/checkouts`, the totals are:
 
 ```
-TOTAL                                           590     273    53.73%     173     49    71.68%    1366     520    61.93%
+TOTAL                                           590     269    54.41%     173     46    73.41%    1366     508    62.81%
 ```
 
-Within repository sources there are **1,366** lines, with **846** covered, giving **61.93%** line coverage.
+Within repository sources there are **1,366** lines, with **858** covered, giving **62.81%** line coverage.
 
 Coverage results are recalculated after each test run to monitor progress. The project strives for ever more comprehensive test suites across all modules. Recent additions include unit tests for ``APIClient``. New tests now verify ``URLSessionHTTPClient`` behavior and the ``Supervisor`` process termination logic.
 Additional tests now cover ``OpenAPISpec.swiftType`` and the ``camelCased`` string helper. A new ``GatewayServerTests`` suite raises total tests to **27**.
@@ -60,6 +60,8 @@ The new ``TodosNotEqualWithDifferentID`` and ``TodoEncodingProducesExpectedJSON`
 
 The new ``SpecValidator`` missing parameter, required flag, and security scheme tests raise the total test count to **101**.
 The new ``GatewayPlugin`` default behavior tests and ``PublishingFrontendPlugin`` header check raise the total test count to **103**.
+
+The new ``DeletePrimaryServerRequestTests`` raise the total test count to **105**.
 
 ---
 © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/PublishingFrontend/HetznerDNSClient/Requests/deletePrimaryServer.swift
+++ b/Sources/PublishingFrontend/HetznerDNSClient/Requests/deletePrimaryServer.swift
@@ -1,14 +1,22 @@
 import Foundation
 
+/// Parameters for the ``deletePrimaryServer`` request.
 public struct deletePrimaryServerParameters: Codable {
+    /// Identifier of the primary server to remove.
     public let primaryserverid: String
 }
 
+/// Request removing a primary DNS server by identifier.
 public struct deletePrimaryServer: APIRequest {
+    /// This request carries no body.
     public typealias Body = NoBody
+    /// Hetzner's API returns an empty payload.
     public typealias Response = Data
+    /// HTTP method for the request.
     public var method: String { "DELETE" }
+    /// Path parameters identifying the primary server.
     public var parameters: deletePrimaryServerParameters
+    /// API endpoint path interpolating the primary server ID.
     public var path: String {
         var path = "/primary_servers/{PrimaryServerID}"
         let query: [String] = []
@@ -16,11 +24,17 @@ public struct deletePrimaryServer: APIRequest {
         if !query.isEmpty { path += "?" + query.joined(separator: "&") }
         return path
     }
+    /// Optional request body kept for protocol conformance.
     public var body: Body?
 
+    /// Creates a new delete request.
+    /// - Parameters:
+    ///   - parameters: Values interpolated into the endpoint path.
+    ///   - body: Unused placeholder body.
     public init(parameters: deletePrimaryServerParameters, body: Body? = nil) {
         self.parameters = parameters
         self.body = body
     }
 }
+
 // © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Tests/DNSTests/DeletePrimaryServerRequestTests.swift
+++ b/Tests/DNSTests/DeletePrimaryServerRequestTests.swift
@@ -1,0 +1,18 @@
+import XCTest
+@testable import PublishingFrontend
+
+final class DeletePrimaryServerRequestTests: XCTestCase {
+    func testPathIsCorrect() {
+        let params = deletePrimaryServerParameters(primaryserverid: "123")
+        let req = deletePrimaryServer(parameters: params)
+        XCTAssertEqual(req.path, "/primary_servers/123")
+    }
+
+    func testMethodIsDELETE() {
+        let params = deletePrimaryServerParameters(primaryserverid: "abc")
+        let req = deletePrimaryServer(parameters: params)
+        XCTAssertEqual(req.method, "DELETE")
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/docs/README.md
+++ b/docs/README.md
@@ -49,6 +49,7 @@ As modules gain documentation, brief summaries are added here.
 - **FountainOps Todo** – generated model now documents its properties.
 - **createPrimaryServer** and **getPrimaryServer** – request types now document server creation and retrieval.
 - **validateZoneFile** and **updatePrimaryServer** – request types now document zone file validation and primary server updates.
+- **deletePrimaryServer** – request and parameters now document primary server deletion.
 - **GatewayServer** – internal components like the certificate manager and plugin stack are now described.
 - **GatewayServer.start** and **stop** – documentation now explains certificate manager activation and graceful shutdown.
 - **APIClient.baseURL**, **session**, and **defaultHeaders** – stored properties document connection details.


### PR DESCRIPTION
## Summary
- document `deletePrimaryServer` request parameters and behavior
- add DELETE primary server request tests
- update docs and coverage progress tracking

## Testing
- `Scripts/run-tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_688f2795aa00832595866d10f6bf2f95