### PR TITLE
Document DNS client methods and test response mutability

### DIFF
--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -5,20 +5,20 @@
 Running `swift test --enable-code-coverage` and analysing with `llvm-cov` produced the following totals:
 
 ```
-TOTAL                                          31812   26510    16.67%   14328 11480    19.88%   99461 81210    18.35%
+TOTAL                                          31820   26516    16.67%   14336 11481    19.91%   99477 81241    18.33%
 ```
 
-The repository contains **99,461** executable lines, with **18,251** lines covered (approx. **18.35%** line coverage).
+The repository contains **99,477** executable lines, with **18,236** lines covered (approx. **18.33%** line coverage).
 
 ### Repository source coverage
 
-Ignoring third-party packages under `.build/checkouts`, the totals are:
+Ignoring third-party packages under `.build/checkouts` and test targets, the totals are:
 
 ```
-TOTAL                                           590     260    55.93%     173     40    76.88%    1369     490    64.21%
+TOTAL                                           782     319    59.21%     329     72    78.12%    1722     638    62.95%
 ```
 
-Within repository sources there are **1,369** lines, with **879** covered, giving **64.21%** line coverage.
+Within repository sources there are **1,722** lines, with **1,084** covered, giving **62.95%** line coverage.
 
 Coverage results are recalculated after each test run to monitor progress. The project strives for ever more comprehensive test suites across all modules. Recent additions include unit tests for ``APIClient``. New tests now verify ``URLSessionHTTPClient`` behavior and the ``Supervisor`` process termination logic.
 Additional tests now cover ``OpenAPISpec.swiftType`` and the ``camelCased`` string helper. A new ``GatewayServerTests`` suite raises total tests to **27**.
@@ -67,6 +67,8 @@ The new ``DeletePrimaryServerRequestTests`` raise the total test count to **105*
 - The new ``GatewayServer`` unknown-path and plugin-order tests raise the total test count to **111**.
 
 - The new ``CamelCasedEmptyString`` and ``CamelCasedMultipleUnderscores`` tests raise the total test count to **113**.
+
+- The new ``HTTPResponseStatusMutation`` and ``HTTPResponseBodyMutation`` tests raise the total test count to **115**.
 
 ---
 © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/PublishingFrontend/DNSProvider.swift
+++ b/Sources/PublishingFrontend/DNSProvider.swift
@@ -36,12 +36,25 @@ public struct HetznerDNSClient: DNSProvider {
     }
 
     /// Adds an ``A`` or ``TXT`` record to the zone.
+    /// - Parameters:
+    ///   - zone: Target zone identifier the record belongs to.
+    ///   - name: Record name without the zone suffix.
+    ///   - type: DNS record type such as `"A"` or `"TXT"`.
+    ///   - value: DNS record value to store.
+    /// - Throws: Rethrows networking errors from ``APIClient``.
     public func createRecord(zone: String, name: String, type: String, value: String) async throws {
         let body = RecordCreate(name: name, ttl: 60, type: type, value: value, zone_id: zone)
         _ = try await api.send(CreateRecord(body: body))
     }
 
     /// Updates a DNS record's value.
+    /// - Parameters:
+    ///   - id: Identifier of the record to update.
+    ///   - zone: Zone containing the record.
+    ///   - name: Record name without the zone suffix.
+    ///   - type: DNS record type such as `"A"` or `"TXT"`.
+    ///   - value: New DNS record value.
+    /// - Throws: Rethrows networking errors from ``APIClient``.
     public func updateRecord(id: String, zone: String, name: String, type: String, value: String) async throws {
         let params = UpdateRecordParameters(recordid: id)
         let body = RecordCreate(name: name, ttl: 60, type: type, value: value, zone_id: zone)
@@ -49,6 +62,8 @@ public struct HetznerDNSClient: DNSProvider {
     }
 
     /// Removes a DNS record from the zone.
+    /// - Parameter id: Identifier of the record to delete.
+    /// - Throws: Rethrows networking errors from ``APIClient``.
     public func deleteRecord(id: String) async throws {
         let params = DeleteRecordParameters(recordid: id)
         _ = try await api.send(DeleteRecord(parameters: params))

--- a/Tests/IntegrationRuntimeTests/HTTPResponseDefaultsTests.swift
+++ b/Tests/IntegrationRuntimeTests/HTTPResponseDefaultsTests.swift
@@ -33,6 +33,20 @@ final class HTTPResponseDefaultsTests: XCTestCase {
         response.headers["X-Test"] = "1"
         XCTAssertEqual(response.headers["X-Test"], "1")
     }
+
+    /// Ensures the status code can be changed after initialization.
+    func testResponseStatusMutation() {
+        var response = HTTPResponse()
+        response.status = 418
+        XCTAssertEqual(response.status, 418)
+    }
+
+    /// Confirms the response body is mutable.
+    func testResponseBodyMutation() {
+        var response = HTTPResponse()
+        response.body = Data("hi".utf8)
+        XCTAssertEqual(String(data: response.body, encoding: .utf8), "hi")
+    }
 }
 
 // © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/docs/README.md
+++ b/docs/README.md
@@ -63,6 +63,7 @@ As modules gain documentation, brief summaries are added here.
 - **CertificateManager.start**, **stop**, and **triggerNow** – document timer scheduling, cancellation semantics, and on-demand execution.
 - **HTTPRequest.method**, **path**, **headers**, and **body** – properties now describe their respective roles.
 - **HTTPResponse.status**, **headers**, and **body** – properties now clarify response components.
+- **HetznerDNSClient.createRecord**, **updateRecord**, and **deleteRecord** – methods now detail parameters for zone, record name, type, and value.
 - **HTTPKernel.handle** – now documents error propagation from routing closures.
 - **run-tests.sh** – helper script bundling release build and coverage test steps.
 - **PublishingFrontendPlugin.respond** – documents parameters and emitted `Content-Type` header when serving files.


### PR DESCRIPTION
## Summary
- document parameters and error behavior for HetznerDNSClient record management calls
- add tests covering HTTPResponse status and body mutation
- update coverage metrics and documentation progress

## Testing
- `Scripts/run-tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_689014c190848325b922499fd8ca8c25