### PR TITLE
Document parameter helpers and add tests

### DIFF
--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -5,20 +5,20 @@
 Running `swift test --enable-code-coverage` and analysing with `llvm-cov` produced the following totals:
 
 ```
-TOTAL                                          31820   26516    16.67%   14336 11481    19.91%   99477 81241    18.33%
+TOTAL                                          31830   26522    16.68%   14346 11483    19.96%   99499 81247    18.34%
 ```
 
-The repository contains **99,477** executable lines, with **18,236** lines covered (approx. **18.33%** line coverage).
+The repository contains **99,499** executable lines, with **18,252** lines covered (approx. **18.34%** line coverage).
 
 ### Repository source coverage
 
 Ignoring third-party packages under `.build/checkouts` and test targets, the totals are:
 
 ```
-TOTAL                                           782     319    59.21%     329     72    78.12%    1722     638    62.95%
+TOTAL                                           590     256    56.61%     173     37    78.61%    1369     483    64.72%
 ```
 
-Within repository sources there are **1,722** lines, with **1,084** covered, giving **62.95%** line coverage.
+Within repository sources there are **1,369** lines, with **886** covered, giving **64.72%** line coverage.
 
 Coverage results are recalculated after each test run to monitor progress. The project strives for ever more comprehensive test suites across all modules. Recent additions include unit tests for ``APIClient``. New tests now verify ``URLSessionHTTPClient`` behavior and the ``Supervisor`` process termination logic.
 Additional tests now cover ``OpenAPISpec.swiftType`` and the ``camelCased`` string helper. A new ``GatewayServerTests`` suite raises total tests to **27**.
@@ -69,6 +69,8 @@ The new ``DeletePrimaryServerRequestTests`` raise the total test count to **105*
 - The new ``CamelCasedEmptyString`` and ``CamelCasedMultipleUnderscores`` tests raise the total test count to **113**.
 
 - The new ``HTTPResponseStatusMutation`` and ``HTTPResponseBodyMutation`` tests raise the total test count to **115**.
+
+- The new ``OpenAPIParameter`` name and type tests raise the total test count to **117**.
 
 ---
 © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainCodex/Parser/OpenAPISpec.swift
+++ b/Sources/FountainCodex/Parser/OpenAPISpec.swift
@@ -254,12 +254,12 @@ extension OpenAPISpec.Schema {
 }
 
 extension OpenAPISpec.Parameter {
-    /// Swift identifier-safe name for the parameter.
+    /// Swift identifier-safe name for the parameter, replacing hyphens with underscores.
     public var swiftName: String {
         name.replacingOccurrences(of: "-", with: "_")
     }
 
-    /// Swift type inferred from the associated schema, defaulting to `String`.
+    /// Swift type inferred from the associated schema, defaulting to `String` when unspecified.
     public var swiftType: String {
         schema?.swiftType ?? "String"
     }

--- a/Sources/FountainCodex/Parser/SpecLoader.swift
+++ b/Sources/FountainCodex/Parser/SpecLoader.swift
@@ -4,6 +4,7 @@ import Yams
 /// Parses an OpenAPI specification from JSON or YAML.
 public enum SpecLoader {
     /// Reads and validates a specification file.
+    /// Strips copyright lines prefixed with "©" before decoding.
     /// - Parameter url: Location of the spec on disk.
     /// - Returns: Parsed ``OpenAPISpec`` instance.
     public static func load(from url: URL) throws -> OpenAPISpec {

--- a/Tests/ClientGeneratorTests/OpenAPIParameterTests.swift
+++ b/Tests/ClientGeneratorTests/OpenAPIParameterTests.swift
@@ -1,0 +1,23 @@
+import XCTest
+@testable import FountainCodex
+
+final class OpenAPIParameterTests: XCTestCase {
+    /// Ensures hyphens are converted to underscores for Swift identifiers.
+    func testSwiftNameReplacesHyphenWithUnderscore() {
+        let param = OpenAPISpec.Parameter(name: "x-id", location: "query")
+        XCTAssertEqual(param.swiftName, "x_id")
+    }
+
+    /// Verifies schema-based type inference and defaulting to `String`.
+    func testSwiftTypeUsesSchemaOrDefaultsToString() {
+        var param = OpenAPISpec.Parameter(name: "count", location: "query")
+        let schema = OpenAPISpec.Schema()
+        schema.type = "integer"
+        param.schema = schema
+        XCTAssertEqual(param.swiftType, "Int")
+        param.schema = nil
+        XCTAssertEqual(param.swiftType, "String")
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/docs/README.md
+++ b/docs/README.md
@@ -69,6 +69,8 @@ As modules gain documentation, brief summaries are added here.
 - **PublishingFrontendPlugin.respond** – documents parameters and emitted `Content-Type` header when serving files.
 - **bulkUpdateRecords.method** and **path**, **updateZone.method** and **path** – request properties now describe HTTP verbs and endpoint resolution.
 - **GatewayServer.plugins** – documents plugin execution order for request preparation and response processing.
+- **SpecLoader.load** – documents removal of copyright lines before decoding.
+- **OpenAPISpec.Parameter.swiftName** and **swiftType** – document parameter name sanitization and schema type defaults.
 
 Documentation coverage will expand alongside test coverage.
 

--- a/logs/build-20250804065736.log
+++ b/logs/build-20250804065736.log
@@ -1,0 +1,613 @@
+Fetching https://github.com/jpsim/Yams.git
+Fetching https://github.com/swift-server/async-http-client.git
+Fetching https://github.com/apple/swift-nio.git
+[1/10997] Fetching yams
+[2/25056] Fetching yams, async-http-client
+[11566/102201] Fetching yams, async-http-client, swift-nio
+Fetched https://github.com/swift-server/async-http-client.git from cache (1.95s)
+[62685/88142] Fetching yams, swift-nio
+Fetched https://github.com/jpsim/Yams.git from cache (2.00s)
+[52459/77145] Fetching swift-nio
+Fetched https://github.com/apple/swift-nio.git from cache (5.52s)
+Computing version for https://github.com/jpsim/Yams.git
+Computed https://github.com/jpsim/Yams.git at 5.4.0 (8.90s)
+Computing version for https://github.com/swift-server/async-http-client.git
+Computed https://github.com/swift-server/async-http-client.git at 1.26.1 (0.86s)
+Fetching https://github.com/apple/swift-algorithms.git
+Fetching https://github.com/apple/swift-log.git
+Fetching https://github.com/apple/swift-atomics.git
+[1/3880] Fetching swift-log
+[234/5688] Fetching swift-log, swift-atomics
+[2732/11647] Fetching swift-log, swift-atomics, swift-algorithms
+Fetched https://github.com/apple/swift-atomics.git from cache (0.70s)
+Fetched https://github.com/apple/swift-log.git from cache (0.71s)
+Fetching https://github.com/apple/swift-nio-transport-services.git
+Fetching https://github.com/apple/swift-nio-extras.git
+Fetched https://github.com/apple/swift-algorithms.git from cache (0.84s)
+Fetching https://github.com/apple/swift-nio-http2.git
+[1/6123] Fetching swift-nio-extras
+[6124/8824] Fetching swift-nio-extras, swift-nio-transport-services
+[6665/20485] Fetching swift-nio-extras, swift-nio-transport-services, swift-nio-http2
+Fetched https://github.com/apple/swift-nio-extras.git from cache (0.56s)
+[4610/14362] Fetching swift-nio-transport-services, swift-nio-http2
+Fetching https://github.com/apple/swift-nio-ssl.git
+Fetched https://github.com/apple/swift-nio-transport-services.git from cache (0.65s)
+[2683/11661] Fetching swift-nio-http2
+[11662/26646] Fetching swift-nio-http2, swift-nio-ssl
+Fetched https://github.com/apple/swift-nio-http2.git from cache (1.23s)
+[2398/14985] Fetching swift-nio-ssl
+Fetched https://github.com/apple/swift-nio-ssl.git from cache (2.09s)
+Computing version for https://github.com/apple/swift-nio-transport-services.git
+Computed https://github.com/apple/swift-nio-transport-services.git at 1.25.0 (4.25s)
+Computing version for https://github.com/apple/swift-nio.git
+Computed https://github.com/apple/swift-nio.git at 2.85.0 (1.07s)
+Fetching https://github.com/apple/swift-collections.git
+Fetching https://github.com/apple/swift-system.git
+[1/16927] Fetching swift-collections
+[679/21758] Fetching swift-collections, swift-system
+Fetched https://github.com/apple/swift-system.git from cache (0.70s)
+[4402/16927] Fetching swift-collections
+Fetched https://github.com/apple/swift-collections.git from cache (1.55s)
+Computing version for https://github.com/apple/swift-atomics.git
+Computed https://github.com/apple/swift-atomics.git at 1.3.0 (2.40s)
+Computing version for https://github.com/apple/swift-nio-http2.git
+Computed https://github.com/apple/swift-nio-http2.git at 1.38.0 (0.87s)
+Computing version for https://github.com/apple/swift-algorithms.git
+Computed https://github.com/apple/swift-algorithms.git at 1.2.1 (0.94s)
+Fetching https://github.com/apple/swift-numerics.git
+[1/5769] Fetching swift-numerics
+Fetched https://github.com/apple/swift-numerics.git from cache (0.68s)
+Computing version for https://github.com/apple/swift-nio-ssl.git
+Computed https://github.com/apple/swift-nio-ssl.git at 2.33.0 (1.69s)
+Computing version for https://github.com/apple/swift-numerics.git
+Computed https://github.com/apple/swift-numerics.git at 1.0.3 (0.90s)
+Computing version for https://github.com/apple/swift-log.git
+Computed https://github.com/apple/swift-log.git at 1.6.4 (0.79s)
+Computing version for https://github.com/apple/swift-nio-extras.git
+Computed https://github.com/apple/swift-nio-extras.git at 1.29.0 (0.90s)
+Fetching https://github.com/swift-server/swift-service-lifecycle.git
+Fetching https://github.com/apple/swift-asn1.git
+Fetching https://github.com/apple/swift-async-algorithms.git
+[1/5012] Fetching swift-async-algorithms
+[1004/6641] Fetching swift-async-algorithms, swift-asn1
+[4793/9074] Fetching swift-async-algorithms, swift-asn1, swift-service-lifecycle
+Fetched https://github.com/swift-server/swift-service-lifecycle.git from cache (0.60s)
+Fetched https://github.com/apple/swift-async-algorithms.git from cache (0.60s)
+Fetched https://github.com/apple/swift-asn1.git from cache (0.60s)
+Fetching https://github.com/apple/swift-http-structured-headers.git
+Fetching https://github.com/apple/swift-http-types.git
+Fetching https://github.com/apple/swift-certificates.git
+[1/917] Fetching swift-http-types
+[918/7377] Fetching swift-http-types, swift-certificates
+[919/8553] Fetching swift-http-types, swift-certificates, swift-http-structured-headers
+Fetched https://github.com/apple/swift-http-types.git from cache (0.54s)
+Fetched https://github.com/apple/swift-http-structured-headers.git from cache (0.55s)
+Fetched https://github.com/apple/swift-certificates.git from cache (0.63s)
+Computing version for https://github.com/swift-server/swift-service-lifecycle.git
+Computed https://github.com/swift-server/swift-service-lifecycle.git at 2.8.0 (2.09s)
+Computing version for https://github.com/apple/swift-async-algorithms.git
+Computed https://github.com/apple/swift-async-algorithms.git at 1.0.4 (0.89s)
+Computing version for https://github.com/apple/swift-asn1.git
+Computed https://github.com/apple/swift-asn1.git at 1.4.0 (0.88s)
+Computing version for https://github.com/apple/swift-certificates.git
+Computed https://github.com/apple/swift-certificates.git at 1.11.0 (1.01s)
+Fetching https://github.com/apple/swift-crypto.git
+[1/15933] Fetching swift-crypto
+Fetched https://github.com/apple/swift-crypto.git from cache (2.02s)
+Computing version for https://github.com/apple/swift-http-types.git
+Computed https://github.com/apple/swift-http-types.git at 1.4.0 (2.89s)
+Computing version for https://github.com/apple/swift-http-structured-headers.git
+Computed https://github.com/apple/swift-http-structured-headers.git at 1.3.0 (0.77s)
+Computing version for https://github.com/apple/swift-system.git
+Computed https://github.com/apple/swift-system.git at 1.6.2 (0.87s)
+Computing version for https://github.com/apple/swift-crypto.git
+Computed https://github.com/apple/swift-crypto.git at 3.13.3 (2.05s)
+Computing version for https://github.com/apple/swift-collections.git
+Computed https://github.com/apple/swift-collections.git at 1.2.1 (0.97s)
+Creating working copy for https://github.com/apple/swift-system.git
+Working copy of https://github.com/apple/swift-system.git resolved at 1.6.2
+Creating working copy for https://github.com/jpsim/Yams.git
+Working copy of https://github.com/jpsim/Yams.git resolved at 5.4.0
+Creating working copy for https://github.com/swift-server/swift-service-lifecycle.git
+Working copy of https://github.com/swift-server/swift-service-lifecycle.git resolved at 2.8.0
+Creating working copy for https://github.com/apple/swift-collections.git
+Working copy of https://github.com/apple/swift-collections.git resolved at 1.2.1
+Creating working copy for https://github.com/apple/swift-http-structured-headers.git
+Working copy of https://github.com/apple/swift-http-structured-headers.git resolved at 1.3.0
+Creating working copy for https://github.com/apple/swift-log.git
+Working copy of https://github.com/apple/swift-log.git resolved at 1.6.4
+Creating working copy for https://github.com/apple/swift-async-algorithms.git
+Working copy of https://github.com/apple/swift-async-algorithms.git resolved at 1.0.4
+Creating working copy for https://github.com/apple/swift-numerics.git
+Working copy of https://github.com/apple/swift-numerics.git resolved at 1.0.3
+Creating working copy for https://github.com/apple/swift-crypto.git
+Working copy of https://github.com/apple/swift-crypto.git resolved at 3.13.3
+Creating working copy for https://github.com/apple/swift-atomics.git
+Working copy of https://github.com/apple/swift-atomics.git resolved at 1.3.0
+Creating working copy for https://github.com/apple/swift-nio.git
+Working copy of https://github.com/apple/swift-nio.git resolved at 2.85.0
+Creating working copy for https://github.com/swift-server/async-http-client.git
+Working copy of https://github.com/swift-server/async-http-client.git resolved at 1.26.1
+Creating working copy for https://github.com/apple/swift-nio-extras.git
+Working copy of https://github.com/apple/swift-nio-extras.git resolved at 1.29.0
+Creating working copy for https://github.com/apple/swift-algorithms.git
+Working copy of https://github.com/apple/swift-algorithms.git resolved at 1.2.1
+Creating working copy for https://github.com/apple/swift-certificates.git
+Working copy of https://github.com/apple/swift-certificates.git resolved at 1.11.0
+Creating working copy for https://github.com/apple/swift-nio-http2.git
+Working copy of https://github.com/apple/swift-nio-http2.git resolved at 1.38.0
+Creating working copy for https://github.com/apple/swift-http-types.git
+Working copy of https://github.com/apple/swift-http-types.git resolved at 1.4.0
+Creating working copy for https://github.com/apple/swift-nio-transport-services.git
+Working copy of https://github.com/apple/swift-nio-transport-services.git resolved at 1.25.0
+Creating working copy for https://github.com/apple/swift-nio-ssl.git
+Working copy of https://github.com/apple/swift-nio-ssl.git resolved at 2.33.0
+Creating working copy for https://github.com/apple/swift-asn1.git
+Working copy of https://github.com/apple/swift-asn1.git resolved at 1.4.0
+Building for production...
+[0/459] Write sources
+[10/459] Compiling _NumericsShims _NumericsShims.c
+[10/459] Write sources
+[13/459] Compiling _AtomicsShims.c
+[14/459] Write sources
+[29/459] Compiling sha256-586-linux.S
+[30/459] Compiling sha256-armv4-linux.S
+[31/459] Compiling writer.c
+[32/459] Compiling reader.c
+[33/459] Compiling parser.c
+[34/459] Write swift-version--4EAD98957C2213E4.txt
+[34/459] Compiling x_spki.cc
+[36/459] Compiling CNIOWindows shim.c
+[37/459] Compiling CNIOWindows WSAStartup.c
+[38/459] Compiling api.c
+[39/461] Compiling emitter.c
+[40/463] Compiling scanner.c
+[42/464] Compiling _NIOBase64 Base64.swift
+[43/465] Compiling RealModule AlgebraicField.swift
+[44/466] Compiling _NIODataStructures Heap.swift
+[45/466] Compiling FountainCore Models.swift
+[45/466] Compiling CNIOWASI CNIOWASI.c
+[46/466] Compiling CNIOPosix event_loop_id.c
+[47/466] Compiling CNIOLinux liburing_shims.c
+[48/466] Compiling CNIOLinux shim.c
+[50/466] Compiling InternalCollectionsUtilities FixedWidthInteger+roundUpToPowerOfTwo.swift
+[50/466] Compiling CNIOLLHTTP c_nio_http.c
+[51/466] Compiling CNIOExtrasZlib empty.c
+[52/466] Compiling CNIOLLHTTP c_nio_api.c
+[53/467] Compiling CNIODarwin shim.c
+[54/467] Compiling CNIOBoringSSLShims shims.c
+[55/467] Compiling fiat_p256_adx_sqr.S
+[56/467] Compiling fiat_p256_adx_mul.S
+[57/467] Compiling fiat_curve25519_adx_square.S
+[58/467] Compiling CNIOLLHTTP c_nio_llhttp.c
+[59/467] Compiling fiat_curve25519_adx_mul.S
+[61/467] Compiling Logging Locks.swift
+[62/467] Compiling DequeModule Deque+Codable.swift
+[62/467] Compiling tls_method.cc
+[63/467] Compiling tls_record.cc
+[64/467] Compiling tls13_server.cc
+[65/467] Compiling tls13_enc.cc
+[66/467] Compiling tls13_both.cc
+[67/467] Compiling tls13_client.cc
+[68/467] Compiling t1_enc.cc
+[69/467] Compiling ssl_transcript.cc
+[70/467] Compiling ssl_versions.cc
+[71/467] Compiling ssl_stat.cc
+[72/467] Compiling ssl_x509.cc
+[73/467] Compiling ssl_privkey.cc
+[74/467] Compiling ssl_session.cc
+[75/467] Compiling ssl_key_share.cc
+[76/467] Compiling ssl_file.cc
+[77/467] Compiling ssl_lib.cc
+[78/467] Compiling ssl_credential.cc
+[79/467] Compiling ssl_cipher.cc
+[80/467] Compiling ssl_buffer.cc
+[81/467] Compiling ssl_cert.cc
+[82/467] Compiling ssl_asn1.cc
+[83/467] Compiling ssl_aead_ctx.cc
+[84/467] Compiling s3_lib.cc
+[85/467] Compiling s3_pkt.cc
+[86/467] Compiling s3_both.cc
+[88/467] Compiling Yams AliasDereferencingStrategy.swift
+[88/467] Compiling handshake_server.cc
+[89/467] Compiling handshake.cc
+[90/467] Compiling handshake_client.cc
+[91/467] Compiling handoff.cc
+[92/467] Compiling encrypted_client_hello.cc
+[93/467] Compiling dtls_record.cc
+[94/467] Compiling dtls_method.cc
+[95/467] Compiling extensions.cc
+[96/467] Compiling d1_srtp.cc
+[97/467] Compiling md5-x86_64-linux.S
+[98/467] Compiling md5-x86_64-apple.S
+[99/467] Compiling md5-586-linux.S
+[100/467] Compiling bio_ssl.cc
+[101/467] Compiling md5-586-apple.S
+[102/467] Compiling chacha20_poly1305_x86_64-linux.S
+[103/467] Compiling err_data.cc
+[104/467] Compiling d1_pkt.cc
+[105/467] Compiling chacha20_poly1305_x86_64-apple.S
+[106/467] Compiling chacha20_poly1305_armv8-win.S
+[107/467] Compiling chacha20_poly1305_armv8-linux.S
+[108/467] Compiling chacha20_poly1305_armv8-apple.S
+[109/467] Compiling d1_lib.cc
+[110/467] Compiling chacha-x86_64-linux.S
+[111/467] Compiling chacha-x86_64-apple.S
+[112/467] Compiling chacha-x86-linux.S
+[113/467] Compiling chacha-x86-apple.S
+[114/467] Compiling chacha-armv8-win.S
+[115/467] Compiling chacha-armv8-linux.S
+[116/467] Compiling chacha-armv8-apple.S
+[117/467] Compiling chacha-armv4-linux.S
+[118/467] Compiling aes128gcmsiv-x86_64-linux.S
+[119/467] Compiling aes128gcmsiv-x86_64-apple.S
+[120/467] Compiling x86_64-mont5-linux.S
+[121/467] Compiling d1_both.cc
+[122/467] Compiling x86_64-mont5-apple.S
+[123/467] Compiling x86_64-mont-linux.S
+[124/467] Compiling x86_64-mont-apple.S
+[125/467] Compiling x86-mont-apple.S
+[126/467] Compiling x86-mont-linux.S
+[127/467] Compiling vpaes-x86_64-linux.S
+[128/467] Compiling vpaes-x86_64-apple.S
+[129/467] Compiling vpaes-x86-apple.S
+[130/467] Compiling vpaes-x86-linux.S
+[131/467] Compiling vpaes-armv8-win.S
+[132/467] Compiling vpaes-armv8-linux.S
+[133/467] Compiling vpaes-armv8-apple.S
+[134/467] Compiling vpaes-armv7-linux.S
+[135/467] Compiling sha512-x86_64-apple.S
+[136/467] Compiling sha512-x86_64-linux.S
+[137/467] Compiling sha512-armv8-win.S
+[138/467] Compiling sha512-armv8-linux.S
+[139/467] Compiling sha512-armv8-apple.S
+[140/467] Compiling sha512-armv4-linux.S
+[141/467] Compiling sha512-586-linux.S
+[142/467] Compiling sha512-586-apple.S
+[143/467] Compiling sha256-x86_64-apple.S
+[144/467] Compiling sha256-x86_64-linux.S
+[145/467] Compiling sha256-armv8-win.S
+[146/467] Compiling sha256-armv8-linux.S
+[147/467] Compiling sha256-armv8-apple.S
+[148/467] Compiling sha256-586-apple.S
+[149/467] Compiling sha1-x86_64-linux.S
+[150/467] Compiling sha1-x86_64-apple.S
+[151/467] Compiling sha1-armv8-win.S
+[152/467] Compiling sha1-armv8-linux.S
+[153/467] Compiling sha1-armv8-apple.S
+[154/467] Compiling sha1-armv4-large-linux.S
+[155/467] Compiling sha1-586-linux.S
+[156/467] Compiling sha1-586-apple.S
+[157/467] Compiling rsaz-avx2-linux.S
+[158/467] Compiling rsaz-avx2-apple.S
+[159/467] Compiling rdrand-x86_64-linux.S
+[160/467] Compiling rdrand-x86_64-apple.S
+[161/467] Compiling p256_beeu-x86_64-asm-apple.S
+[162/467] Compiling p256_beeu-x86_64-asm-linux.S
+[163/467] Compiling p256_beeu-armv8-asm-win.S
+[164/467] Compiling p256_beeu-armv8-asm-linux.S
+[165/467] Compiling p256_beeu-armv8-asm-apple.S
+[166/467] Compiling p256-x86_64-asm-apple.S
+[167/467] Compiling p256-x86_64-asm-linux.S
+[168/467] Compiling p256-armv8-asm-win.S
+[169/467] Compiling p256-armv8-asm-linux.S
+[170/467] Compiling p256-armv8-asm-apple.S
+[171/467] Compiling ghashv8-armv8-win.S
+[172/467] Compiling ghashv8-armv8-linux.S
+[173/467] Compiling ghashv8-armv7-linux.S
+[174/467] Compiling ghashv8-armv8-apple.S
+[175/467] Compiling ghash-x86_64-linux.S
+[176/467] Compiling ghash-x86_64-apple.S
+[177/467] Compiling ghash-x86-linux.S
+[178/467] Compiling ghash-ssse3-x86_64-linux.S
+[179/467] Compiling ghash-x86-apple.S
+[180/467] Compiling ghash-ssse3-x86_64-apple.S
+[181/467] Compiling ghash-ssse3-x86-linux.S
+[182/467] Compiling ghash-ssse3-x86-apple.S
+[183/467] Compiling ghash-neon-armv8-win.S
+[184/467] Compiling ghash-neon-armv8-apple.S
+[185/467] Compiling ghash-neon-armv8-linux.S
+[186/467] Compiling ghash-armv4-linux.S
+[187/467] Compiling co-586-linux.S
+[188/467] Compiling co-586-apple.S
+[189/467] Compiling bsaes-armv7-linux.S
+[190/467] Compiling bn-armv8-win.S
+[191/467] Compiling bn-armv8-linux.S
+[192/467] Compiling bn-armv8-apple.S
+[193/467] Compiling bn-586-linux.S
+[194/467] Compiling armv8-mont-win.S
+[195/467] Compiling bn-586-apple.S
+[196/467] Compiling armv8-mont-apple.S
+[197/467] Compiling armv8-mont-linux.S
+[198/467] Compiling armv4-mont-linux.S
+[199/467] Compiling aesv8-gcm-armv8-win.S
+[200/467] Compiling aesv8-gcm-armv8-linux.S
+[201/467] Compiling aesv8-gcm-armv8-apple.S
+[202/467] Compiling aesv8-armv8-win.S
+[203/467] Compiling aesv8-armv8-linux.S
+[204/467] Compiling aesv8-armv8-apple.S
+[205/467] Compiling aesv8-armv7-linux.S
+[206/467] Compiling aesni-x86_64-apple.S
+[207/467] Compiling aesni-x86_64-linux.S
+[208/467] Compiling aesni-x86-linux.S
+[209/467] Compiling aesni-x86-apple.S
+[210/467] Compiling aesni-gcm-x86_64-linux.S
+[211/467] Compiling aesni-gcm-x86_64-apple.S
+[212/467] Compiling aes-gcm-avx2-x86_64-linux.S
+[213/467] Compiling aes-gcm-avx2-x86_64-apple.S
+[214/467] Compiling aes-gcm-avx10-x86_64-apple.S
+[215/467] Compiling aes-gcm-avx10-x86_64-linux.S
+[216/467] Compiling x_val.cc
+[217/467] Compiling x_x509a.cc
+[218/467] Compiling x_sig.cc
+[219/467] Compiling x_req.cc
+[220/467] Compiling x_x509.cc
+[221/467] Compiling x_pubkey.cc
+[222/467] Compiling x_exten.cc
+[223/467] Compiling x_name.cc
+[224/467] Compiling x_crl.cc
+[225/467] Compiling x_attrib.cc
+[226/467] Compiling x_algor.cc
+[227/467] Compiling x509spki.cc
+[228/467] Compiling x509rset.cc
+[229/467] Compiling x_all.cc
+[230/467] Compiling x509name.cc
+[231/467] Compiling x509cset.cc
+[232/467] Compiling x509_vpm.cc
+[233/467] Compiling x509_txt.cc
+[234/467] Compiling x509_v3.cc
+[235/467] Compiling x509_vfy.cc
+[236/467] Compiling x509_trs.cc
+[237/467] Compiling x509_set.cc
+[238/467] Compiling x509_req.cc
+[239/467] Compiling x509_obj.cc
+[240/467] Compiling x509_lu.cc
+[241/467] Compiling x509_ext.cc
+[242/467] Compiling x509_def.cc
+[243/467] Compiling x509_d2.cc
+[244/467] Compiling x509_cmp.cc
+[245/467] Compiling x509_att.cc
+[246/467] Compiling x509.cc
+[247/467] Compiling v3_skey.cc
+[248/467] Compiling v3_utl.cc
+[249/467] Compiling v3_purp.cc
+[250/467] Compiling v3_prn.cc
+[251/467] Compiling v3_pmaps.cc
+[252/467] Compiling v3_pcons.cc
+[253/467] Compiling v3_ocsp.cc
+[254/467] Compiling v3_ncons.cc
+[255/467] Compiling v3_lib.cc
+[256/467] Compiling v3_int.cc
+[257/467] Compiling v3_info.cc
+[258/467] Compiling v3_ia5.cc
+[259/467] Compiling v3_genn.cc
+[260/467] Compiling v3_enum.cc
+[261/467] Compiling v3_extku.cc
+[262/467] Compiling v3_crld.cc
+[263/467] Compiling v3_cpols.cc
+[264/467] Compiling v3_bitst.cc
+[265/467] Compiling v3_conf.cc
+[266/467] Compiling v3_bcons.cc
+[267/467] Compiling v3_alt.cc
+[268/467] Compiling v3_akeya.cc
+[269/467] Compiling t_x509a.cc
+[270/467] Compiling v3_akey.cc
+[271/467] Compiling t_x509.cc
+[272/467] Compiling t_crl.cc
+[273/467] Compiling t_req.cc
+[274/467] Compiling name_print.cc
+[275/467] Compiling rsa_pss.cc
+[276/467] Compiling i2d_pr.cc
+[277/467] Compiling policy.cc
+[278/467] Compiling by_file.cc
+[279/467] Compiling by_dir.cc
+[280/467] Compiling algorithm.cc
+[281/467] Compiling a_verify.cc
+[282/467] Compiling asn1_gen.cc
+[283/467] Compiling a_sign.cc
+[284/467] Compiling thread_win.cc
+[285/467] Compiling a_digest.cc
+[286/467] Compiling trust_token.cc
+[287/467] Compiling voprf.cc
+[288/467] Compiling pmbtoken.cc
+[289/467] Compiling thread.cc
+[290/467] Compiling thread_none.cc
+[291/467] Compiling thread_pthread.cc
+[292/467] Compiling stack.cc
+[293/467] Compiling slhdsa.cc
+[294/467] Compiling siphash.cc
+[295/467] Compiling sha512.cc
+[296/467] Compiling spake2plus.cc
+[297/467] Compiling sha256.cc
+[298/467] Compiling sha1.cc
+[299/467] Compiling rsa_extra.cc
+[300/467] Compiling rsa_print.cc
+[301/467] Compiling rsa_crypt.cc
+[302/467] Compiling refcount.cc
+[303/467] Compiling rc4.cc
+[304/467] Compiling rsa_asn1.cc
+[305/467] Compiling windows.cc
+[306/467] Compiling trusty.cc
+[307/467] Compiling rand.cc
+[308/467] Compiling urandom.cc
+[309/467] Compiling passive.cc
+[310/467] Compiling ios.cc
+[311/467] Compiling getentropy.cc
+[312/467] Compiling deterministic.cc
+[313/467] Compiling forkunsafe.cc
+[314/467] Compiling fork_detect.cc
+[315/467] Compiling poly1305_arm_asm.S
+[316/467] Compiling pool.cc
+[317/467] Compiling poly1305.cc
+[318/467] Compiling poly1305_arm.cc
+[319/467] Compiling poly1305_vec.cc
+[320/467] Compiling pkcs7.cc
+[321/467] Compiling pkcs8.cc
+[322/467] Compiling pkcs8_x509.cc
+[323/467] Compiling p5_pbev2.cc
+[324/467] Compiling pkcs7_x509.cc
+[325/467] Compiling pem_xaux.cc
+[326/467] Compiling pem_x509.cc
+[327/467] Compiling pem_pkey.cc
+[328/467] Compiling pem_oth.cc
+[329/467] Compiling pem_pk8.cc
+[330/467] Compiling obj_xref.cc
+[331/467] Compiling pem_info.cc
+[332/467] Compiling pem_lib.cc
+[333/467] Compiling pem_all.cc
+[333/467] Compiling obj.cc
+[335/467] Compiling mlkem.cc
+[336/467] Compiling mldsa.cc
+[337/467] Compiling md5.cc
+[338/467] Compiling md4.cc
+[339/467] Compiling mem.cc
+[340/467] Compiling lhash.cc
+[341/467] Compiling fips_shared_support.cc
+[342/467] Compiling poly_rq_mul.S
+[343/467] Compiling ex_data.cc
+[344/467] Compiling kyber.cc
+[345/467] Compiling hpke.cc
+[346/467] Compiling sign.cc
+[347/467] Compiling hrss.cc
+[348/467] Compiling scrypt.cc
+[349/467] Compiling print.cc
+[350/467] Compiling pbkdf.cc
+[351/467] Compiling p_x25519.cc
+[352/467] Compiling p_x25519_asn1.cc
+[353/467] Compiling p_rsa_asn1.cc
+[354/467] Compiling p_rsa.cc
+[355/467] Compiling p_hkdf.cc
+[356/467] Compiling p_ed25519_asn1.cc
+[357/467] Compiling p_ed25519.cc
+[358/467] Compiling p_ec_asn1.cc
+[359/467] Compiling p_ec.cc
+[360/467] Compiling p_dsa_asn1.cc
+[361/467] Compiling p_dh_asn1.cc
+[362/467] Compiling p_dh.cc
+[363/467] Compiling evp_ctx.cc
+[364/467] Compiling evp.cc
+[365/467] Compiling evp_asn1.cc
+[366/467] Compiling engine.cc
+[367/467] Compiling err.cc
+[368/467] Compiling ecdsa_asn1.cc
+[369/467] Compiling ecdh.cc
+[370/467] Compiling ec_derive.cc
+[371/467] Compiling hash_to_curve.cc
+[372/467] Compiling dsa_asn1.cc
+[373/467] Compiling ec_asn1.cc
+[374/467] Compiling dsa.cc
+[375/467] Compiling digest_extra.cc
+[376/467] Compiling params.cc
+[377/467] Compiling dh_asn1.cc
+[378/467] Compiling spake25519.cc
+[379/467] Compiling x25519-asm-arm.S
+[380/467] Compiling des.cc
+[381/467] Compiling crypto.cc
+[382/467] Compiling cpu_intel.cc
+[383/467] Compiling cpu_arm_linux.cc
+[384/467] Compiling cpu_arm_freebsd.cc
+[385/467] Compiling curve25519_64_adx.cc
+[386/467] Compiling curve25519.cc
+[387/467] Compiling cpu_aarch64_win.cc
+[388/467] Compiling cpu_aarch64_openbsd.cc
+[389/467] Compiling cpu_aarch64_sysreg.cc
+[390/467] Compiling cpu_aarch64_linux.cc
+[391/467] Compiling cpu_aarch64_fuchsia.cc
+[392/467] Compiling cpu_aarch64_apple.cc
+[393/467] Compiling conf.cc
+[394/467] Compiling tls_cbc.cc
+[395/467] Compiling get_cipher.cc
+[396/467] Compiling e_tls.cc
+[397/467] Compiling e_rc4.cc
+[398/467] Compiling e_null.cc
+[399/467] Compiling e_rc2.cc
+[400/467] Compiling e_des.cc
+[401/467] Compiling e_chacha20poly1305.cc
+[402/467] Compiling derive_key.cc
+[403/467] Compiling e_aesctrhmac.cc
+[404/467] Compiling e_aesgcmsiv.cc
+[405/467] Compiling chacha.cc
+[406/467] Compiling unicode.cc
+[407/467] Compiling ber.cc
+[408/467] Compiling cbb.cc
+[409/467] Compiling cbs.cc
+[410/467] Compiling asn1_compat.cc
+[411/467] Compiling buf.cc
+[412/467] Compiling bn_asn1.cc
+[413/467] Compiling blake2.cc
+[414/467] Compiling convert.cc
+[415/467] Compiling socket.cc
+[416/467] Compiling socket_helper.cc
+[417/467] Compiling printf.cc
+[418/467] Compiling pair.cc
+[419/467] Compiling hexdump.cc
+[420/467] Compiling file.cc
+[421/467] Compiling fd.cc
+[422/467] Compiling errno.cc
+[423/467] Compiling bio_mem.cc
+[424/467] Compiling connect.cc
+[425/467] Compiling base64.cc
+[426/467] Compiling bio.cc
+[427/467] Compiling tasn_typ.cc
+[428/467] Compiling tasn_utl.cc
+[429/467] Compiling tasn_fre.cc
+[430/467] Compiling tasn_new.cc
+[431/467] Compiling tasn_enc.cc
+[432/467] Compiling posix_time.cc
+[433/467] Compiling f_string.cc
+[434/467] Compiling tasn_dec.cc
+[435/467] Compiling f_int.cc
+[436/467] Compiling asn_pack.cc
+[437/467] Compiling asn1_par.cc
+[438/467] Compiling a_utctm.cc
+[439/467] Compiling asn1_lib.cc
+[440/467] Compiling a_type.cc
+[441/467] Compiling a_time.cc
+[442/467] Compiling a_octet.cc
+[442/467] Compiling a_strnid.cc
+[444/467] Compiling a_strex.cc
+[445/467] Compiling a_object.cc
+[446/467] Compiling a_i2d_fp.cc
+[447/467] Compiling a_mbstr.cc
+[448/467] Compiling a_int.cc
+[449/467] Compiling a_gentm.cc
+[450/467] Compiling a_dup.cc
+[451/467] Compiling a_d2i_fp.cc
+[452/467] Compiling a_bool.cc
+[453/467] Compiling CAsyncHTTPClient CAsyncHTTPClient.c
+[454/467] Write sources
+[456/467] Compiling a_bitstr.cc
+[456/467] Write sources
+[458/469] Compiling c-nioatomics.c
+[459/469] Compiling c-atomics.c
+[460/470] Compiling bcm.cc
+[462/470] Compiling NIOConcurrencyHelpers NIOAtomic.swift
+[463/470] Compiling Atomics OptionalRawRepresentable.swift
+[464/471] Compiling Algorithms AdjacentPairs.swift
+[465/471] Compiling NIOCore AddressedEnvelope.swift
+[466/473] Compiling NIOEmbedded AsyncTestingChannel.swift
+[467/473] Compiling NIOPosix BSDSocketAPICommon.swift
+[468/474] Compiling NIO Exports.swift
+[469/478] Compiling NIOTLS ApplicationProtocolNegotiationHandler.swift
+[470/479] Compiling NIOSOCKS SOCKSClientHandler.swift
+[471/479] Compiling NIOFoundationCompat ByteBuffer-foundation.swift
+[472/480] Compiling NIOTransportServices AcceptHandler.swift
+[473/480] Compiling NIOHTTP1 ByteCollectionUtils.swift
+[474/482] Compiling NIOSSL AndroidCABundle.swift
+[475/482] Compiling NIOHTTPCompression HTTPCompression.swift
+[476/482] Compiling NIOHPACK DynamicHeaderTable.swift
+[477/483] Compiling NIOHTTP2 ConnectionStateMachine.swift
+[478/484] Compiling AsyncHTTPClient AnyAsyncSequence.swift
+[479/485] Compiling FountainCodex ClientGenerator.swift
+[480/487] Compiling clientgen_service main.swift
+[480/487] Write Objects.LinkFileList
+[481/487] Linking clientgen-service
+[483/487] Compiling PublishingFrontend DNSProvider.swift
+[484/489] Compiling publishing_frontend main.swift
+[484/489] Write Objects.LinkFileList
+[486/489] Compiling gateway_server CertificateManager.swift
+[486/489] Write Objects.LinkFileList
+[487/489] Linking publishing-frontend
+[488/489] Linking gateway-server
+Build complete! (286.86s)
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/logs/test-20250804065736.log
+++ b/logs/test-20250804065736.log
@@ -1,0 +1,434 @@
+[0/1] Planning build
+Building for production...
+[0/12] Write sources
+[5/18] Write swift-version--4EAD98957C2213E4.txt
+[7/23] Compiling _NIOBase64 Base64.swift
+[8/24] Compiling RealModule AlgebraicField.swift
+[9/24] Compiling _NIODataStructures Heap.swift
+[10/25] Compiling NIOConcurrencyHelpers NIOAtomic.swift
+[11/27] Compiling FountainCore Models.swift
+[12/28] Compiling InternalCollectionsUtilities FixedWidthInteger+roundUpToPowerOfTwo.swift
+[13/29] Compiling Logging Locks.swift
+[14/30] Compiling Atomics OptionalRawRepresentable.swift
+[15/30] Compiling DequeModule Deque+Codable.swift
+[16/31] Compiling FountainCoreTests FountainCoreTests.swift
+[17/31] Compiling Algorithms AdjacentPairs.swift
+[18/31] Compiling Yams AliasDereferencingStrategy.swift
+[19/31] Compiling NIOCore AddressedEnvelope.swift
+[20/33] Compiling NIOEmbedded AsyncTestingChannel.swift
+[21/33] Compiling NIOPosix BSDSocketAPICommon.swift
+[22/34] Compiling NIO Exports.swift
+[23/38] Compiling NIOFoundationCompat ByteBuffer-foundation.swift
+[24/38] Compiling NIOTLS ApplicationProtocolNegotiationHandler.swift
+[25/40] Compiling NIOSOCKS SOCKSClientHandler.swift
+[26/40] Compiling NIOTransportServices AcceptHandler.swift
+[27/40] Compiling NIOHTTP1 ByteCollectionUtils.swift
+[28/42] Compiling NIOSSL AndroidCABundle.swift
+[29/42] Compiling NIOHTTPCompression HTTPCompression.swift
+[30/42] Compiling NIOHPACK DynamicHeaderTable.swift
+[31/43] Compiling NIOHTTP2 ConnectionStateMachine.swift
+[32/44] Compiling AsyncHTTPClient AnyAsyncSequence.swift
+[33/45] Compiling FountainCodex ClientGenerator.swift
+[34/48] Compiling clientgen_service main.swift
+[34/48] Write Objects.LinkFileList
+[36/48] Compiling ClientGeneratorTests ClientGeneratorTests.swift
+[36/48] Linking clientgen-service
+[38/48] Compiling PublishingFrontend DNSProvider.swift
+[39/52] Compiling publishing_frontend main.swift
+[39/52] Write Objects.LinkFileList
+[41/52] Compiling gateway_server CertificateManager.swift
+[41/52] Write Objects.LinkFileList
+[43/52] Compiling PublishingFrontendTests HetznerDNSModelsTests.swift
+/workspace/codex-deployer/Tests/PublishingFrontendTests/PublishingFrontendTests.swift:39:37: warning: result of call to 'changeCurrentDirectoryPath' is unused
+ 37 |         try yaml.write(to: fileURL, atomically: true, encoding: .utf8)
+ 38 |         let cwd = FileManager.default.currentDirectoryPath
+ 39 |         defer { FileManager.default.changeCurrentDirectoryPath(cwd) }
+    |                                     `- warning: result of call to 'changeCurrentDirectoryPath' is unused
+ 40 |         FileManager.default.changeCurrentDirectoryPath(dir.path)
+ 41 |         let config = try loadPublishingConfig()
+
+/workspace/codex-deployer/Tests/PublishingFrontendTests/PublishingFrontendTests.swift:40:29: warning: result of call to 'changeCurrentDirectoryPath' is unused
+ 38 |         let cwd = FileManager.default.currentDirectoryPath
+ 39 |         defer { FileManager.default.changeCurrentDirectoryPath(cwd) }
+ 40 |         FileManager.default.changeCurrentDirectoryPath(dir.path)
+    |                             `- warning: result of call to 'changeCurrentDirectoryPath' is unused
+ 41 |         let config = try loadPublishingConfig()
+ 42 |         XCTAssertEqual(config.port, 1234)
+
+/workspace/codex-deployer/Tests/PublishingFrontendTests/PublishingFrontendTests.swift:58:37: warning: result of call to 'changeCurrentDirectoryPath' is unused
+ 56 |         try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+ 57 |         let cwd = FileManager.default.currentDirectoryPath
+ 58 |         defer { FileManager.default.changeCurrentDirectoryPath(cwd) }
+    |                                     `- warning: result of call to 'changeCurrentDirectoryPath' is unused
+ 59 |         FileManager.default.changeCurrentDirectoryPath(dir.path)
+ 60 |         XCTAssertThrowsError(try loadPublishingConfig())
+
+/workspace/codex-deployer/Tests/PublishingFrontendTests/PublishingFrontendTests.swift:59:29: warning: result of call to 'changeCurrentDirectoryPath' is unused
+ 57 |         let cwd = FileManager.default.currentDirectoryPath
+ 58 |         defer { FileManager.default.changeCurrentDirectoryPath(cwd) }
+ 59 |         FileManager.default.changeCurrentDirectoryPath(dir.path)
+    |                             `- warning: result of call to 'changeCurrentDirectoryPath' is unused
+ 60 |         XCTAssertThrowsError(try loadPublishingConfig())
+ 61 |     }
+[44/52] Compiling DNSTests APIClientTests.swift
+[44/52] Linking publishing-frontend
+[45/52] Linking gateway-server
+[47/53] Compiling IntegrationRuntimeTests AsyncHTTPClientDriverTests.swift
+[47/53] /workspace/codex-deployer/.build/x86_64-unknown-linux-gnu/release/FountainCoachPackageDiscoveredTests.derived/all-discovered-tests.swift
+[48/53] Write sources
+[50/54] Compiling FountainCoachPackageDiscoveredTests ClientGeneratorTests.swift
+[50/54] /workspace/codex-deployer/.build/x86_64-unknown-linux-gnu/release/FountainCoachPackageTests.derived/runner.swift
+[51/54] Write sources
+[53/55] Compiling FountainCoachPackageTests runner.swift
+[53/55] Write Objects.LinkFileList
+[54/55] Linking FountainCoachPackageTests.xctest
+Build complete! (172.95s)
+Test Suite 'All tests' started at 2025-08-04 07:05:19.846
+Test Suite 'release.xctest' started at 2025-08-04 07:05:19.862
+Test Suite 'ClientGeneratorTests' started at 2025-08-04 07:05:19.862
+Test Case 'ClientGeneratorTests.testClientFilesGenerated' started at 2025-08-04 07:05:19.862
+Test Case 'ClientGeneratorTests.testClientFilesGenerated' passed (0.013 seconds)
+Test Suite 'ClientGeneratorTests' passed at 2025-08-04 07:05:19.876
+	 Executed 1 test, with 0 failures (0 unexpected) in 0.013 (0.013) seconds
+Test Suite 'OpenAPIParameterTests' started at 2025-08-04 07:05:19.876
+Test Case 'OpenAPIParameterTests.testSwiftNameReplacesHyphenWithUnderscore' started at 2025-08-04 07:05:19.876
+Test Case 'OpenAPIParameterTests.testSwiftNameReplacesHyphenWithUnderscore' passed (0.001 seconds)
+Test Case 'OpenAPIParameterTests.testSwiftTypeUsesSchemaOrDefaultsToString' started at 2025-08-04 07:05:19.877
+Test Case 'OpenAPIParameterTests.testSwiftTypeUsesSchemaOrDefaultsToString' passed (0.0 seconds)
+Test Suite 'OpenAPIParameterTests' passed at 2025-08-04 07:05:19.877
+	 Executed 2 tests, with 0 failures (0 unexpected) in 0.002 (0.002) seconds
+Test Suite 'OpenAPISwiftTypeTests' started at 2025-08-04 07:05:19.877
+Test Case 'OpenAPISwiftTypeTests.testSchemaPropertySwiftType' started at 2025-08-04 07:05:19.877
+Test Case 'OpenAPISwiftTypeTests.testSchemaPropertySwiftType' passed (0.0 seconds)
+Test Case 'OpenAPISwiftTypeTests.testSchemaRefSwiftType' started at 2025-08-04 07:05:19.878
+Test Case 'OpenAPISwiftTypeTests.testSchemaRefSwiftType' passed (0.0 seconds)
+Test Suite 'OpenAPISwiftTypeTests' passed at 2025-08-04 07:05:19.878
+	 Executed 2 tests, with 0 failures (0 unexpected) in 0.0 (0.0) seconds
+Test Suite 'SecurityRequirementTests' started at 2025-08-04 07:05:19.878
+Test Case 'SecurityRequirementTests.testDecodesSchemesFromJSON' started at 2025-08-04 07:05:19.878
+Test Case 'SecurityRequirementTests.testDecodesSchemesFromJSON' passed (0.001 seconds)
+Test Case 'SecurityRequirementTests.testEncodesSchemesToJSON' started at 2025-08-04 07:05:19.879
+Test Case 'SecurityRequirementTests.testEncodesSchemesToJSON' passed (0.001 seconds)
+Test Suite 'SecurityRequirementTests' passed at 2025-08-04 07:05:19.880
+	 Executed 2 tests, with 0 failures (0 unexpected) in 0.002 (0.002) seconds
+Test Suite 'SpecLoaderTests' started at 2025-08-04 07:05:19.880
+Test Case 'SpecLoaderTests.testLoadsJSONRemovingCopyright' started at 2025-08-04 07:05:19.880
+Test Case 'SpecLoaderTests.testLoadsJSONRemovingCopyright' passed (0.002 seconds)
+Test Case 'SpecLoaderTests.testLoadsYAMLAndNormalizesInfoTitle' started at 2025-08-04 07:05:19.882
+Test Case 'SpecLoaderTests.testLoadsYAMLAndNormalizesInfoTitle' passed (0.007 seconds)
+Test Suite 'SpecLoaderTests' passed at 2025-08-04 07:05:19.889
+	 Executed 2 tests, with 0 failures (0 unexpected) in 0.008 (0.008) seconds
+Test Suite 'SpecValidatorTests' started at 2025-08-04 07:05:19.889
+Test Case 'SpecValidatorTests.testDuplicateOperationIdThrows' started at 2025-08-04 07:05:19.889
+Test Case 'SpecValidatorTests.testDuplicateOperationIdThrows' passed (0.001 seconds)
+Test Case 'SpecValidatorTests.testMissingPathParameterThrows' started at 2025-08-04 07:05:19.889
+Test Case 'SpecValidatorTests.testMissingPathParameterThrows' passed (0.0 seconds)
+Test Case 'SpecValidatorTests.testPathParameterMustBeRequired' started at 2025-08-04 07:05:19.889
+Test Case 'SpecValidatorTests.testPathParameterMustBeRequired' passed (0.0 seconds)
+Test Case 'SpecValidatorTests.testUnknownSecuritySchemeThrows' started at 2025-08-04 07:05:19.890
+Test Case 'SpecValidatorTests.testUnknownSecuritySchemeThrows' passed (0.0 seconds)
+Test Case 'SpecValidatorTests.testUnresolvedSchemaReferenceThrows' started at 2025-08-04 07:05:19.890
+Test Case 'SpecValidatorTests.testUnresolvedSchemaReferenceThrows' passed (0.0 seconds)
+Test Suite 'SpecValidatorTests' passed at 2025-08-04 07:05:19.890
+	 Executed 5 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
+Test Suite 'StringExtensionTests' started at 2025-08-04 07:05:19.890
+Test Case 'StringExtensionTests.testCamelCased' started at 2025-08-04 07:05:19.890
+Test Case 'StringExtensionTests.testCamelCased' passed (0.0 seconds)
+Test Case 'StringExtensionTests.testCamelCasedEmptyString' started at 2025-08-04 07:05:19.891
+Test Case 'StringExtensionTests.testCamelCasedEmptyString' passed (0.0 seconds)
+Test Case 'StringExtensionTests.testCamelCasedMultipleUnderscores' started at 2025-08-04 07:05:19.891
+Test Case 'StringExtensionTests.testCamelCasedMultipleUnderscores' passed (0.0 seconds)
+Test Suite 'StringExtensionTests' passed at 2025-08-04 07:05:19.891
+	 Executed 3 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
+Test Suite 'AsyncHTTPClientDriverTests' started at 2025-08-04 07:05:19.891
+Test Case 'AsyncHTTPClientDriverTests.testExecutePerformsRequest' started at 2025-08-04 07:05:19.891
+Test Case 'AsyncHTTPClientDriverTests.testExecutePerformsRequest' passed (0.019 seconds)
+Test Case 'AsyncHTTPClientDriverTests.testExecuteSendsBody' started at 2025-08-04 07:05:19.910
+Test Case 'AsyncHTTPClientDriverTests.testExecuteSendsBody' passed (0.003 seconds)
+Test Suite 'AsyncHTTPClientDriverTests' passed at 2025-08-04 07:05:19.913
+	 Executed 2 tests, with 0 failures (0 unexpected) in 0.022 (0.022) seconds
+Test Suite 'CertificateManagerTests' started at 2025-08-04 07:05:19.913
+Test Case 'CertificateManagerTests.testStartSchedulesRepeatedRuns' started at 2025-08-04 07:05:19.913
+Test Case 'CertificateManagerTests.testStartSchedulesRepeatedRuns' passed (1.002 seconds)
+Test Case 'CertificateManagerTests.testStopCancelsFutureRuns' started at 2025-08-04 07:05:20.915
+Test Case 'CertificateManagerTests.testStopCancelsFutureRuns' passed (3.003 seconds)
+Test Case 'CertificateManagerTests.testTriggerNowRunsScript' started at 2025-08-04 07:05:23.918
+Test Case 'CertificateManagerTests.testTriggerNowRunsScript' passed (1.048 seconds)
+Test Suite 'CertificateManagerTests' passed at 2025-08-04 07:05:24.966
+	 Executed 3 tests, with 0 failures (0 unexpected) in 5.053 (5.053) seconds
+Test Suite 'GatewayPluginTests' started at 2025-08-04 07:05:24.966
+Test Case 'GatewayPluginTests.testDefaultPrepareReturnsSameRequest' started at 2025-08-04 07:05:24.966
+Test Case 'GatewayPluginTests.testDefaultPrepareReturnsSameRequest' passed (0.0 seconds)
+Test Case 'GatewayPluginTests.testDefaultRespondReturnsSameResponse' started at 2025-08-04 07:05:24.967
+Test Case 'GatewayPluginTests.testDefaultRespondReturnsSameResponse' passed (0.0 seconds)
+Test Suite 'GatewayPluginTests' passed at 2025-08-04 07:05:24.967
+	 Executed 2 tests, with 0 failures (0 unexpected) in 0.0 (0.0) seconds
+Test Suite 'GatewayServerTests' started at 2025-08-04 07:05:24.967
+Test Case 'GatewayServerTests.testHealthEndpointResponds' started at 2025-08-04 07:05:24.967
+Test Case 'GatewayServerTests.testHealthEndpointResponds' passed (0.113 seconds)
+Test Case 'GatewayServerTests.testMetricsEndpointResponds' started at 2025-08-04 07:05:25.080
+Test Case 'GatewayServerTests.testMetricsEndpointResponds' passed (0.104 seconds)
+Test Case 'GatewayServerTests.testPluginCanRewriteRequestAndResponse' started at 2025-08-04 07:05:25.183
+Test Case 'GatewayServerTests.testPluginCanRewriteRequestAndResponse' passed (0.103 seconds)
+Test Case 'GatewayServerTests.testPluginsRespondInReverseOrder' started at 2025-08-04 07:05:25.287
+Test Case 'GatewayServerTests.testPluginsRespondInReverseOrder' passed (0.104 seconds)
+Test Case 'GatewayServerTests.testUnknownPathReturns404' started at 2025-08-04 07:05:25.391
+Test Case 'GatewayServerTests.testUnknownPathReturns404' passed (0.104 seconds)
+Test Suite 'GatewayServerTests' passed at 2025-08-04 07:05:25.495
+	 Executed 5 tests, with 0 failures (0 unexpected) in 0.528 (0.528) seconds
+Test Suite 'HTTPKernelTests' started at 2025-08-04 07:05:25.495
+Test Case 'HTTPKernelTests.testKernelPropagatesErrors' started at 2025-08-04 07:05:25.495
+Test Case 'HTTPKernelTests.testKernelPropagatesErrors' passed (0.0 seconds)
+Test Case 'HTTPKernelTests.testKernelRoutesRequest' started at 2025-08-04 07:05:25.495
+Test Case 'HTTPKernelTests.testKernelRoutesRequest' passed (0.0 seconds)
+Test Suite 'HTTPKernelTests' passed at 2025-08-04 07:05:25.496
+	 Executed 2 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
+Test Suite 'HTTPRequestTests' started at 2025-08-04 07:05:25.496
+Test Case 'HTTPRequestTests.testRequestDefaults' started at 2025-08-04 07:05:25.496
+Test Case 'HTTPRequestTests.testRequestDefaults' passed (0.0 seconds)
+Test Case 'HTTPRequestTests.testRequestInitializerStoresValues' started at 2025-08-04 07:05:25.496
+Test Case 'HTTPRequestTests.testRequestInitializerStoresValues' passed (0.0 seconds)
+Test Case 'HTTPRequestTests.testRequestMutation' started at 2025-08-04 07:05:25.496
+Test Case 'HTTPRequestTests.testRequestMutation' passed (0.0 seconds)
+Test Suite 'HTTPRequestTests' passed at 2025-08-04 07:05:25.496
+	 Executed 3 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
+Test Suite 'HTTPResponseDefaultsTests' started at 2025-08-04 07:05:25.496
+Test Case 'HTTPResponseDefaultsTests.testNoBodyCodable' started at 2025-08-04 07:05:25.496
+Test Case 'HTTPResponseDefaultsTests.testNoBodyCodable' passed (0.001 seconds)
+Test Case 'HTTPResponseDefaultsTests.testResponseBodyMutation' started at 2025-08-04 07:05:25.497
+Test Case 'HTTPResponseDefaultsTests.testResponseBodyMutation' passed (0.0 seconds)
+Test Case 'HTTPResponseDefaultsTests.testResponseDefaults' started at 2025-08-04 07:05:25.497
+Test Case 'HTTPResponseDefaultsTests.testResponseDefaults' passed (0.0 seconds)
+Test Case 'HTTPResponseDefaultsTests.testResponseHeadersMutation' started at 2025-08-04 07:05:25.497
+Test Case 'HTTPResponseDefaultsTests.testResponseHeadersMutation' passed (0.0 seconds)
+Test Case 'HTTPResponseDefaultsTests.testResponseInitializerStoresValues' started at 2025-08-04 07:05:25.497
+Test Case 'HTTPResponseDefaultsTests.testResponseInitializerStoresValues' passed (0.0 seconds)
+Test Case 'HTTPResponseDefaultsTests.testResponseStatusMutation' started at 2025-08-04 07:05:25.498
+Test Case 'HTTPResponseDefaultsTests.testResponseStatusMutation' passed (0.0 seconds)
+Test Suite 'HTTPResponseDefaultsTests' passed at 2025-08-04 07:05:25.498
+	 Executed 6 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
+Test Suite 'LoggingPluginTests' started at 2025-08-04 07:05:25.498
+Test Case 'LoggingPluginTests.testLoggingPluginPassThrough' started at 2025-08-04 07:05:25.498
+-> GET /
+<- 200 for /
+Test Case 'LoggingPluginTests.testLoggingPluginPassThrough' passed (0.0 seconds)
+Test Suite 'LoggingPluginTests' passed at 2025-08-04 07:05:25.498
+	 Executed 1 test, with 0 failures (0 unexpected) in 0.0 (0.0) seconds
+Test Suite 'NIOHTTPServerTests' started at 2025-08-04 07:05:25.498
+Test Case 'NIOHTTPServerTests.testServerHandlesConcurrentRequests' started at 2025-08-04 07:05:25.498
+Test Case 'NIOHTTPServerTests.testServerHandlesConcurrentRequests' passed (0.003 seconds)
+Test Case 'NIOHTTPServerTests.testServerReleasesPortOnStop' started at 2025-08-04 07:05:25.501
+Test Case 'NIOHTTPServerTests.testServerReleasesPortOnStop' passed (0.103 seconds)
+Test Case 'NIOHTTPServerTests.testServerResponds' started at 2025-08-04 07:05:25.604
+Test Case 'NIOHTTPServerTests.testServerResponds' passed (0.002 seconds)
+Test Suite 'NIOHTTPServerTests' passed at 2025-08-04 07:05:25.606
+	 Executed 3 tests, with 0 failures (0 unexpected) in 0.108 (0.108) seconds
+Test Suite 'PublishingFrontendPluginTests' started at 2025-08-04 07:05:25.606
+Test Case 'PublishingFrontendPluginTests.testPluginIgnoresNonGETRequests' started at 2025-08-04 07:05:25.606
+Test Case 'PublishingFrontendPluginTests.testPluginIgnoresNonGETRequests' passed (0.003 seconds)
+Test Case 'PublishingFrontendPluginTests.testPluginPassThroughWhenFileMissing' started at 2025-08-04 07:05:25.608
+Test Case 'PublishingFrontendPluginTests.testPluginPassThroughWhenFileMissing' passed (0.0 seconds)
+Test Case 'PublishingFrontendPluginTests.testPluginServesFile' started at 2025-08-04 07:05:25.609
+Test Case 'PublishingFrontendPluginTests.testPluginServesFile' passed (0.001 seconds)
+Test Case 'PublishingFrontendPluginTests.testPluginSetsContentTypeHeader' started at 2025-08-04 07:05:25.610
+Test Case 'PublishingFrontendPluginTests.testPluginSetsContentTypeHeader' passed (0.002 seconds)
+Test Suite 'PublishingFrontendPluginTests' passed at 2025-08-04 07:05:25.612
+	 Executed 4 tests, with 0 failures (0 unexpected) in 0.006 (0.006) seconds
+Test Suite 'URLSessionHTTPClientTests' started at 2025-08-04 07:05:25.612
+Test Case 'URLSessionHTTPClientTests.testExecutePerformsRequest' started at 2025-08-04 07:05:25.612
+Test Case 'URLSessionHTTPClientTests.testExecutePerformsRequest' passed (0.001 seconds)
+Test Suite 'URLSessionHTTPClientTests' passed at 2025-08-04 07:05:25.613
+	 Executed 1 test, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
+Test Suite 'APIClientTests' started at 2025-08-04 07:05:25.613
+Test Case 'APIClientTests.testBearerInitializerSetsHeader' started at 2025-08-04 07:05:25.613
+Test Case 'APIClientTests.testBearerInitializerSetsHeader' passed (0.001 seconds)
+Test Case 'APIClientTests.testRawDataResponse' started at 2025-08-04 07:05:25.614
+Test Case 'APIClientTests.testRawDataResponse' passed (0.001 seconds)
+Test Case 'APIClientTests.testSendDecodesResponse' started at 2025-08-04 07:05:25.615
+Test Case 'APIClientTests.testSendDecodesResponse' passed (0.0 seconds)
+Test Suite 'APIClientTests' passed at 2025-08-04 07:05:25.615
+	 Executed 3 tests, with 0 failures (0 unexpected) in 0.002 (0.002) seconds
+Test Suite 'CreatePrimaryServerRequestTests' started at 2025-08-04 07:05:25.615
+Test Case 'CreatePrimaryServerRequestTests.testMethodIsPOST' started at 2025-08-04 07:05:25.615
+Test Case 'CreatePrimaryServerRequestTests.testMethodIsPOST' passed (0.201 seconds)
+Test Case 'CreatePrimaryServerRequestTests.testPathIsCorrect' started at 2025-08-04 07:05:25.816
+Test Case 'CreatePrimaryServerRequestTests.testPathIsCorrect' passed (0.0 seconds)
+Test Suite 'CreatePrimaryServerRequestTests' passed at 2025-08-04 07:05:25.816
+	 Executed 2 tests, with 0 failures (0 unexpected) in 0.201 (0.201) seconds
+Test Suite 'DNSClientTests' started at 2025-08-04 07:05:25.816
+Test Case 'DNSClientTests.testRoute53CreateRecordStub' started at 2025-08-04 07:05:25.816
+Test Case 'DNSClientTests.testRoute53CreateRecordStub' passed (0.0 seconds)
+Test Case 'DNSClientTests.testRoute53DeleteRecordErrorDetails' started at 2025-08-04 07:05:25.817
+Test Case 'DNSClientTests.testRoute53DeleteRecordErrorDetails' passed (0.001 seconds)
+Test Case 'DNSClientTests.testRoute53DeleteRecordStub' started at 2025-08-04 07:05:25.817
+Test Case 'DNSClientTests.testRoute53DeleteRecordStub' passed (0.0 seconds)
+Test Case 'DNSClientTests.testRoute53ListZonesErrorDetails' started at 2025-08-04 07:05:25.818
+Test Case 'DNSClientTests.testRoute53ListZonesErrorDetails' passed (0.0 seconds)
+Test Case 'DNSClientTests.testRoute53Stub' started at 2025-08-04 07:05:25.818
+Test Case 'DNSClientTests.testRoute53Stub' passed (0.0 seconds)
+Test Case 'DNSClientTests.testRoute53UpdateRecordStub' started at 2025-08-04 07:05:25.818
+Test Case 'DNSClientTests.testRoute53UpdateRecordStub' passed (0.0 seconds)
+Test Suite 'DNSClientTests' passed at 2025-08-04 07:05:25.818
+	 Executed 6 tests, with 0 failures (0 unexpected) in 0.002 (0.002) seconds
+Test Suite 'DeletePrimaryServerRequestTests' started at 2025-08-04 07:05:25.818
+Test Case 'DeletePrimaryServerRequestTests.testMethodIsDELETE' started at 2025-08-04 07:05:25.818
+Test Case 'DeletePrimaryServerRequestTests.testMethodIsDELETE' passed (0.0 seconds)
+Test Case 'DeletePrimaryServerRequestTests.testPathIsCorrect' started at 2025-08-04 07:05:25.819
+Test Case 'DeletePrimaryServerRequestTests.testPathIsCorrect' passed (0.0 seconds)
+Test Suite 'DeletePrimaryServerRequestTests' passed at 2025-08-04 07:05:25.819
+	 Executed 2 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
+Test Suite 'DeleteZoneRequestTests' started at 2025-08-04 07:05:25.819
+Test Case 'DeleteZoneRequestTests.testPathBuilderEncodesZoneId' started at 2025-08-04 07:05:25.819
+Test Case 'DeleteZoneRequestTests.testPathBuilderEncodesZoneId' passed (0.0 seconds)
+Test Suite 'DeleteZoneRequestTests' passed at 2025-08-04 07:05:25.819
+	 Executed 1 test, with 0 failures (0 unexpected) in 0.0 (0.0) seconds
+Test Suite 'GetPrimaryServerRequestTests' started at 2025-08-04 07:05:25.819
+Test Case 'GetPrimaryServerRequestTests.testMethodIsGET' started at 2025-08-04 07:05:25.819
+Test Case 'GetPrimaryServerRequestTests.testMethodIsGET' passed (0.0 seconds)
+Test Case 'GetPrimaryServerRequestTests.testPathBuilderReplacesId' started at 2025-08-04 07:05:25.819
+Test Case 'GetPrimaryServerRequestTests.testPathBuilderReplacesId' passed (0.0 seconds)
+Test Suite 'GetPrimaryServerRequestTests' passed at 2025-08-04 07:05:25.820
+	 Executed 2 tests, with 0 failures (0 unexpected) in 0.0 (0.0) seconds
+Test Suite 'GetRecordRequestTests' started at 2025-08-04 07:05:25.820
+Test Case 'GetRecordRequestTests.testPathBuilderReplacesRecordId' started at 2025-08-04 07:05:25.820
+Test Case 'GetRecordRequestTests.testPathBuilderReplacesRecordId' passed (0.0 seconds)
+Test Suite 'GetRecordRequestTests' passed at 2025-08-04 07:05:25.820
+	 Executed 1 test, with 0 failures (0 unexpected) in 0.0 (0.0) seconds
+Test Suite 'GetZoneRequestTests' started at 2025-08-04 07:05:25.820
+Test Case 'GetZoneRequestTests.testPathBuilderReplacesZoneId' started at 2025-08-04 07:05:25.820
+Test Case 'GetZoneRequestTests.testPathBuilderReplacesZoneId' passed (0.101 seconds)
+Test Suite 'GetZoneRequestTests' passed at 2025-08-04 07:05:25.921
+	 Executed 1 test, with 0 failures (0 unexpected) in 0.101 (0.101) seconds
+Test Suite 'HetznerDNSClientTests' started at 2025-08-04 07:05:25.921
+Test Case 'HetznerDNSClientTests.testCreateRecordRequest' started at 2025-08-04 07:05:25.921
+Test Case 'HetznerDNSClientTests.testCreateRecordRequest' passed (0.002 seconds)
+Test Case 'HetznerDNSClientTests.testCreateRecordSetsContentTypeHeader' started at 2025-08-04 07:05:25.922
+Test Case 'HetznerDNSClientTests.testCreateRecordSetsContentTypeHeader' passed (0.001 seconds)
+Test Case 'HetznerDNSClientTests.testDeleteRecordRequest' started at 2025-08-04 07:05:25.923
+Test Case 'HetznerDNSClientTests.testDeleteRecordRequest' passed (0.0 seconds)
+Test Case 'HetznerDNSClientTests.testListZonesPathBuilder' started at 2025-08-04 07:05:25.923
+Test Case 'HetznerDNSClientTests.testListZonesPathBuilder' passed (0.1 seconds)
+Test Case 'HetznerDNSClientTests.testUpdateRecordRequest' started at 2025-08-04 07:05:26.024
+Test Case 'HetznerDNSClientTests.testUpdateRecordRequest' passed (0.001 seconds)
+Test Suite 'HetznerDNSClientTests' passed at 2025-08-04 07:05:26.025
+	 Executed 5 tests, with 0 failures (0 unexpected) in 0.104 (0.104) seconds
+Test Suite 'ListPrimaryServersRequestTests' started at 2025-08-04 07:05:26.025
+Test Case 'ListPrimaryServersRequestTests.testPathBuilderAddsZoneIdQueryWhenProvided' started at 2025-08-04 07:05:26.025
+Test Case 'ListPrimaryServersRequestTests.testPathBuilderAddsZoneIdQueryWhenProvided' passed (0.0 seconds)
+Test Case 'ListPrimaryServersRequestTests.testPathBuilderWithoutZoneIdHasNoQuery' started at 2025-08-04 07:05:26.025
+Test Case 'ListPrimaryServersRequestTests.testPathBuilderWithoutZoneIdHasNoQuery' passed (0.0 seconds)
+Test Suite 'ListPrimaryServersRequestTests' passed at 2025-08-04 07:05:26.025
+	 Executed 2 tests, with 0 failures (0 unexpected) in 0.0 (0.0) seconds
+Test Suite 'ListRecordsRequestTests' started at 2025-08-04 07:05:26.025
+Test Case 'ListRecordsRequestTests.testPathBuilderEncodesQuery' started at 2025-08-04 07:05:26.025
+Test Case 'ListRecordsRequestTests.testPathBuilderEncodesQuery' passed (0.0 seconds)
+Test Suite 'ListRecordsRequestTests' passed at 2025-08-04 07:05:26.025
+	 Executed 1 test, with 0 failures (0 unexpected) in 0.0 (0.0) seconds
+Test Suite 'FountainCoreTests' started at 2025-08-04 07:05:26.026
+Test Case 'FountainCoreTests.testTodoDecoding' started at 2025-08-04 07:05:26.026
+Test Case 'FountainCoreTests.testTodoDecoding' passed (0.001 seconds)
+Test Case 'FountainCoreTests.testTodoDecodingFailsForMissingID' started at 2025-08-04 07:05:26.026
+Test Case 'FountainCoreTests.testTodoDecodingFailsForMissingID' passed (0.001 seconds)
+Test Case 'FountainCoreTests.testTodoDecodingFailsForMissingName' started at 2025-08-04 07:05:26.027
+Test Case 'FountainCoreTests.testTodoDecodingFailsForMissingName' passed (0.0 seconds)
+Test Case 'FountainCoreTests.testTodoEncodingProducesExpectedJSON' started at 2025-08-04 07:05:26.027
+Test Case 'FountainCoreTests.testTodoEncodingProducesExpectedJSON' passed (0.001 seconds)
+Test Case 'FountainCoreTests.testTodoEncodingRoundTrip' started at 2025-08-04 07:05:26.028
+Test Case 'FountainCoreTests.testTodoEncodingRoundTrip' passed (0.0 seconds)
+Test Case 'FountainCoreTests.testTodoEquality' started at 2025-08-04 07:05:26.028
+Test Case 'FountainCoreTests.testTodoEquality' passed (0.0 seconds)
+Test Case 'FountainCoreTests.testTodosNotEqualWithDifferentID' started at 2025-08-04 07:05:26.029
+Test Case 'FountainCoreTests.testTodosNotEqualWithDifferentID' passed (0.0 seconds)
+Test Suite 'FountainCoreTests' passed at 2025-08-04 07:05:26.029
+	 Executed 7 tests, with 0 failures (0 unexpected) in 0.003 (0.003) seconds
+Test Suite 'HetznerDNSModelsTests' started at 2025-08-04 07:05:26.029
+Test Case 'HetznerDNSModelsTests.testBulkRecordsCreateRequestCodable' started at 2025-08-04 07:05:26.029
+Test Case 'HetznerDNSModelsTests.testBulkRecordsCreateRequestCodable' passed (0.003 seconds)
+Test Case 'HetznerDNSModelsTests.testBulkRecordsUpdateRequestCodable' started at 2025-08-04 07:05:26.032
+Test Case 'HetznerDNSModelsTests.testBulkRecordsUpdateRequestCodable' passed (0.001 seconds)
+Test Case 'HetznerDNSModelsTests.testPrimaryServerCreateCodable' started at 2025-08-04 07:05:26.033
+Test Case 'HetznerDNSModelsTests.testPrimaryServerCreateCodable' passed (0.001 seconds)
+Test Case 'HetznerDNSModelsTests.testPrimaryServersResponseDecodes' started at 2025-08-04 07:05:26.034
+Test Case 'HetznerDNSModelsTests.testPrimaryServersResponseDecodes' passed (0.001 seconds)
+Test Case 'HetznerDNSModelsTests.testRecordResponseDecodes' started at 2025-08-04 07:05:26.034
+Test Case 'HetznerDNSModelsTests.testRecordResponseDecodes' passed (0.0 seconds)
+Test Case 'HetznerDNSModelsTests.testValidateZoneFileResponseDecodes' started at 2025-08-04 07:05:26.035
+Test Case 'HetznerDNSModelsTests.testValidateZoneFileResponseDecodes' passed (0.0 seconds)
+Test Case 'HetznerDNSModelsTests.testZoneCreateRequestCodable' started at 2025-08-04 07:05:26.035
+Test Case 'HetznerDNSModelsTests.testZoneCreateRequestCodable' passed (0.001 seconds)
+Test Case 'HetznerDNSModelsTests.testZoneResponseDecoding' started at 2025-08-04 07:05:26.036
+Test Case 'HetznerDNSModelsTests.testZoneResponseDecoding' passed (0.001 seconds)
+Test Suite 'HetznerDNSModelsTests' passed at 2025-08-04 07:05:26.037
+	 Executed 8 tests, with 0 failures (0 unexpected) in 0.008 (0.008) seconds
+Test Suite 'HetznerDNSRequestTests' started at 2025-08-04 07:05:26.037
+Test Case 'HetznerDNSRequestTests.testBulkCreateRecordsMethodIsPost' started at 2025-08-04 07:05:26.037
+Test Case 'HetznerDNSRequestTests.testBulkCreateRecordsMethodIsPost' passed (0.0 seconds)
+Test Case 'HetznerDNSRequestTests.testBulkCreateRecordsPath' started at 2025-08-04 07:05:26.037
+Test Case 'HetznerDNSRequestTests.testBulkCreateRecordsPath' passed (0.0 seconds)
+Test Case 'HetznerDNSRequestTests.testBulkUpdateRecordsMethodIsPut' started at 2025-08-04 07:05:26.037
+Test Case 'HetznerDNSRequestTests.testBulkUpdateRecordsMethodIsPut' passed (0.0 seconds)
+Test Case 'HetznerDNSRequestTests.testBulkUpdateRecordsPath' started at 2025-08-04 07:05:26.038
+Test Case 'HetznerDNSRequestTests.testBulkUpdateRecordsPath' passed (0.0 seconds)
+Test Case 'HetznerDNSRequestTests.testCreateZoneMethodIsPost' started at 2025-08-04 07:05:26.038
+Test Case 'HetznerDNSRequestTests.testCreateZoneMethodIsPost' passed (0.0 seconds)
+Test Case 'HetznerDNSRequestTests.testCreateZonePath' started at 2025-08-04 07:05:26.038
+Test Case 'HetznerDNSRequestTests.testCreateZonePath' passed (0.0 seconds)
+Test Case 'HetznerDNSRequestTests.testExportZoneFileMethodIsGet' started at 2025-08-04 07:05:26.038
+Test Case 'HetznerDNSRequestTests.testExportZoneFileMethodIsGet' passed (0.0 seconds)
+Test Case 'HetznerDNSRequestTests.testExportZoneFilePathIncludesZoneID' started at 2025-08-04 07:05:26.039
+Test Case 'HetznerDNSRequestTests.testExportZoneFilePathIncludesZoneID' passed (0.0 seconds)
+Test Case 'HetznerDNSRequestTests.testImportZoneFileMethodIsPost' started at 2025-08-04 07:05:26.039
+Test Case 'HetznerDNSRequestTests.testImportZoneFileMethodIsPost' passed (0.0 seconds)
+Test Case 'HetznerDNSRequestTests.testImportZoneFilePathIncludesZoneID' started at 2025-08-04 07:05:26.039
+Test Case 'HetznerDNSRequestTests.testImportZoneFilePathIncludesZoneID' passed (0.0 seconds)
+Test Case 'HetznerDNSRequestTests.testUpdatePrimaryServerMethodIsPut' started at 2025-08-04 07:05:26.040
+Test Case 'HetznerDNSRequestTests.testUpdatePrimaryServerMethodIsPut' passed (0.0 seconds)
+Test Case 'HetznerDNSRequestTests.testUpdatePrimaryServerPathIncludesID' started at 2025-08-04 07:05:26.040
+Test Case 'HetznerDNSRequestTests.testUpdatePrimaryServerPathIncludesID' passed (0.0 seconds)
+Test Case 'HetznerDNSRequestTests.testUpdateZoneMethodIsPut' started at 2025-08-04 07:05:26.040
+Test Case 'HetznerDNSRequestTests.testUpdateZoneMethodIsPut' passed (0.0 seconds)
+Test Case 'HetznerDNSRequestTests.testUpdateZonePathIncludesID' started at 2025-08-04 07:05:26.040
+Test Case 'HetznerDNSRequestTests.testUpdateZonePathIncludesID' passed (0.0 seconds)
+Test Case 'HetznerDNSRequestTests.testValidateZoneFileMethodIsPost' started at 2025-08-04 07:05:26.041
+Test Case 'HetznerDNSRequestTests.testValidateZoneFileMethodIsPost' passed (0.0 seconds)
+Test Case 'HetznerDNSRequestTests.testValidateZoneFilePath' started at 2025-08-04 07:05:26.041
+Test Case 'HetznerDNSRequestTests.testValidateZoneFilePath' passed (0.0 seconds)
+Test Suite 'HetznerDNSRequestTests' passed at 2025-08-04 07:05:26.041
+	 Executed 16 tests, with 0 failures (0 unexpected) in 0.004 (0.004) seconds
+Test Suite 'PublishingFrontendTests' started at 2025-08-04 07:05:26.041
+Test Case 'PublishingFrontendTests.testLoadPublishingConfigFailsForMissingFile' started at 2025-08-04 07:05:26.041
+Test Case 'PublishingFrontendTests.testLoadPublishingConfigFailsForMissingFile' passed (0.0 seconds)
+Test Case 'PublishingFrontendTests.testLoadPublishingConfigParsesYaml' started at 2025-08-04 07:05:26.041
+Test Case 'PublishingFrontendTests.testLoadPublishingConfigParsesYaml' passed (0.004 seconds)
+Test Case 'PublishingFrontendTests.testPublishingConfigDefaultValues' started at 2025-08-04 07:05:26.045
+Test Case 'PublishingFrontendTests.testPublishingConfigDefaultValues' passed (0.0 seconds)
+Test Case 'PublishingFrontendTests.testServerRejectsNonGetRequests' started at 2025-08-04 07:05:26.045
+Test Case 'PublishingFrontendTests.testServerRejectsNonGetRequests' passed (0.005 seconds)
+Test Case 'PublishingFrontendTests.testServerReturns404ForMissingFile' started at 2025-08-04 07:05:26.051
+Test Case 'PublishingFrontendTests.testServerReturns404ForMissingFile' passed (0.004 seconds)
+Test Case 'PublishingFrontendTests.testServerServesIndex' started at 2025-08-04 07:05:26.055
+Test Case 'PublishingFrontendTests.testServerServesIndex' passed (0.005 seconds)
+Test Case 'PublishingFrontendTests.testServerSetsContentTypeHeader' started at 2025-08-04 07:05:26.060
+Test Case 'PublishingFrontendTests.testServerSetsContentTypeHeader' passed (0.005 seconds)
+Test Suite 'PublishingFrontendTests' passed at 2025-08-04 07:05:26.066
+	 Executed 7 tests, with 0 failures (0 unexpected) in 0.024 (0.024) seconds
+Test Suite 'Route53ClientTests' started at 2025-08-04 07:05:26.066
+Test Case 'Route53ClientTests.testCreateRecordThrows' started at 2025-08-04 07:05:26.066
+Test Case 'Route53ClientTests.testCreateRecordThrows' passed (0.0 seconds)
+Test Case 'Route53ClientTests.testDeleteRecordThrows' started at 2025-08-04 07:05:26.066
+Test Case 'Route53ClientTests.testDeleteRecordThrows' passed (0.0 seconds)
+Test Case 'Route53ClientTests.testListZonesThrows' started at 2025-08-04 07:05:26.066
+Test Case 'Route53ClientTests.testListZonesThrows' passed (0.001 seconds)
+Test Case 'Route53ClientTests.testUpdateRecordThrows' started at 2025-08-04 07:05:26.067
+Test Case 'Route53ClientTests.testUpdateRecordThrows' passed (0.0 seconds)
+Test Suite 'Route53ClientTests' passed at 2025-08-04 07:05:26.068
+	 Executed 4 tests, with 0 failures (0 unexpected) in 0.002 (0.002) seconds
+Test Suite 'release.xctest' passed at 2025-08-04 07:05:26.068
+	 Executed 117 tests, with 0 failures (0 unexpected) in 6.201 (6.201) seconds
+Test Suite 'All tests' passed at 2025-08-04 07:05:26.068
+	 Executed 117 tests, with 0 failures (0 unexpected) in 6.201 (6.201) seconds
+◇ Test run started.
+↳ Testing Library Version: 6.1 (43b6f88e2f2712e)
+↳ Target Platform: x86_64-unknown-linux-gnu
+✔ Test run with 0 tests passed after 0.001 seconds.
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- document SpecLoader copyright stripping and parameter helper behavior
- test OpenAPI parameter name sanitization and type inference
- refresh coverage and add documentation progress

## Testing
- `bash Scripts/run-tests.sh`
- `llvm-profdata-19 merge -sparse .build/x86_64-unknown-linux-gnu/release/codecov/*.profraw -o default.profdata`
- `llvm-cov-19 report .build/x86_64-unknown-linux-gnu/release/FountainCoachPackageTests.xctest --instr-profile=default.profdata`
- `llvm-cov-19 report .build/x86_64-unknown-linux-gnu/release/FountainCoachPackageTests.xctest --instr-profile=default.profdata -ignore-filename-regex='\.build|Tests|usr|/swift/'`


------
https://chatgpt.com/codex/tasks/task_e_6890592a06408325a3cefd798ca89b2f