### PR TITLE
Document record request paths and add tests

### DIFF
--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -5,10 +5,10 @@
 Running `swift test --enable-code-coverage` and analysing with `llvm-cov` produced the following totals:
 
 ```
-TOTAL                                          31882   26550    16.72%   14380 11491    20.09%   99602 81426    18.25%
+TOTAL                                          31901   26510    16.90%   14399 11475    20.31%   99641 81230    18.48%
 ```
 
-The repository contains **99,602** executable lines, with **18,176** lines covered (approx. **18.25%** line coverage).
+The repository contains **99,641** executable lines, with **18,411** lines covered (approx. **18.48%** line coverage).
 
 ### Repository source coverage
 
@@ -73,6 +73,7 @@ The new ``DeletePrimaryServerRequestTests`` raise the total test count to **105*
 - The new ``OpenAPIParameter`` name and type tests raise the total test count to **117**.
 - The new ``GatewayServer`` prepare-order and health content-type tests raise the total test count to **119**.
 - The new ``listZones`` identifier retrieval and ``Route53Client`` error detail tests raise the total test count to **122**.
+- The new ``DeleteRecordRequest`` and ``UpdateRecordRequest`` tests raise the total test count to **125**.
 
 ---
 © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/PublishingFrontend/HetznerDNSClient/Requests/DeleteRecord.swift
+++ b/Sources/PublishingFrontend/HetznerDNSClient/Requests/DeleteRecord.swift
@@ -16,7 +16,7 @@ public struct DeleteRecord: APIRequest {
     public var method: String { "DELETE" }
     /// Parameters identifying which record to delete.
     public var parameters: DeleteRecordParameters
-    /// API endpoint path with the record ID substituted.
+    /// API endpoint path where `{RecordID}` is replaced with ``DeleteRecordParameters.recordid``.
     public var path: String {
         var path = "/records/{RecordID}"
         let query: [String] = []

--- a/Sources/PublishingFrontend/HetznerDNSClient/Requests/UpdateRecord.swift
+++ b/Sources/PublishingFrontend/HetznerDNSClient/Requests/UpdateRecord.swift
@@ -18,7 +18,7 @@ public struct UpdateRecord: APIRequest {
     public var method: String { "PUT" }
     /// Parameters describing which record to update.
     public var parameters: UpdateRecordParameters
-    /// Constructed path for the request.
+    /// API endpoint path with `{RecordID}` replaced by ``UpdateRecordParameters.recordid``.
     public var path: String {
         var path = "/records/{RecordID}"
         let query: [String] = []
@@ -26,7 +26,7 @@ public struct UpdateRecord: APIRequest {
         if !query.isEmpty { path += "?" + query.joined(separator: "&") }
         return path
     }
-    /// Request body containing record data.
+    /// Request body containing updated record data.
     public var body: Body?
 
     /// Creates a new request.

--- a/Tests/DNSTests/DeleteRecordRequestTests.swift
+++ b/Tests/DNSTests/DeleteRecordRequestTests.swift
@@ -1,0 +1,15 @@
+import XCTest
+@testable import PublishingFrontend
+
+final class DeleteRecordRequestTests: XCTestCase {
+    /// Builds a delete request and verifies HTTP method and path.
+    func testDeleteRecordBuildsPathAndMethod() {
+        let params = DeleteRecordParameters(recordid: "99")
+        let req = DeleteRecord(parameters: params)
+        XCTAssertEqual(req.method, "DELETE")
+        XCTAssertEqual(req.path, "/records/99")
+        XCTAssertNil(req.body)
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Tests/DNSTests/UpdateRecordRequestTests.swift
+++ b/Tests/DNSTests/UpdateRecordRequestTests.swift
@@ -1,0 +1,24 @@
+import XCTest
+@testable import PublishingFrontend
+
+final class UpdateRecordRequestTests: XCTestCase {
+    /// Builds an update request and verifies the HTTP method and path.
+    func testUpdateRecordBuildsPathAndMethod() {
+        let params = UpdateRecordParameters(recordid: "42")
+        let body = RecordCreate(name: "www", ttl: 60, type: "A", value: "1.2.3.4", zone_id: "z")
+        let req = UpdateRecord(parameters: params, body: body)
+        XCTAssertEqual(req.method, "PUT")
+        XCTAssertEqual(req.path, "/records/42")
+    }
+
+    /// Ensures body data is stored on the request.
+    func testUpdateRecordStoresBody() {
+        let params = UpdateRecordParameters(recordid: "1")
+        let body = RecordCreate(name: "foo", ttl: 120, type: "TXT", value: "bar", zone_id: "z")
+        let req = UpdateRecord(parameters: params, body: body)
+        XCTAssertEqual(req.body?.name, "foo")
+        XCTAssertEqual(req.body?.type, "TXT")
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/docs/README.md
+++ b/docs/README.md
@@ -38,6 +38,7 @@ As modules gain documentation, brief summaries are added here.
 - **SpecValidator.validateSchema** – documents recursive schema reference checks and path placeholder enforcement.
 - **listRecords** and **listPrimaryServers** – request types now include documentation.
 - **bulkUpdateRecords**, **deleteZone**, **updateZone**, **exportZoneFile**, **importZoneFile** – additional DNS client requests documented.
+- **UpdateRecord** and **DeleteRecord** – request types now detail record identifier substitution within their paths.
 - **bulkCreateRecords** and **createZone** – request types now document bulk record creation and zone provisioning.
 - **getRecord** and **updateRecord** – request types now include usage documentation.
 - **getZone** – request type now documents zone retrieval parameters.


### PR DESCRIPTION
## Summary
- document UpdateRecord and DeleteRecord request path substitution
- test UpdateRecord and DeleteRecord request builders
- log updated coverage metrics

## Testing
- `Scripts/run-tests.sh`
- `llvm-cov-19 report .build/release/FountainCoachPackageTests.xctest -instr-profile .build/release/codecov/default.profdata | tail -n 1`
- `llvm-cov-19 report .build/release/FountainCoachPackageTests.xctest -instr-profile .build/release/codecov/default.profdata -ignore-filename-regex='\.build|Tests' | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689064cbd59083258cfd36e6419d41ad