### PR TITLE
Document services and expand tests

### DIFF
--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -5,10 +5,10 @@
 Running `swift test --enable-code-coverage` and analysing with `llvm-cov` produced the following totals:
 
 ```
-TOTAL                                          31933   26509    16.99%   14429 11479    20.44%   99736 81244    18.54%
+TOTAL                                          31943   26508    17.01%   14439 11479    20.50%   99754 81242    18.56%
 ```
 
-The repository contains **99,736** executable lines, with **18,492** lines covered (approx. **18.54%** line coverage).
+The repository contains **99,754** executable lines, with **18,512** lines covered (approx. **18.56%** line coverage).
 
 ### Repository source coverage
 
@@ -77,6 +77,8 @@ The new ``DeletePrimaryServerRequestTests`` raise the total test count to **105*
 - The new ``SchemaProperty`` dictionary and fallback tests raise the total test count to **127**.
 - The new ``URLSessionHTTPClient`` empty-body and multi-header tests raise the total test count to **129**.
 - The new ``SpecLoader`` empty-file and invalid UTF-8 tests raise the total test count to **131**.
+
+- The new ``ServiceInitializerStoresArguments``, ``PublishingConfigCustomValues``, and ``TodosNotEqualWithDifferentName`` tests raise the total test count to **133**.
 
 ---
 © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/FountainAiLauncher/Sources/FountainAiLauncher/main.swift
+++ b/FountainAiLauncher/Sources/FountainAiLauncher/main.swift
@@ -1,5 +1,6 @@
 import Foundation
 
+/// Services launched by the supervisor at application start.
 let services: [Service] = [
     Service(name: "Awareness Service", binaryPath: "/usr/local/bin/awareness-service", port: 8001, healthPath: "/metrics"),
     Service(name: "Bootstrap Service", binaryPath: "/usr/local/bin/bootstrap-service", port: 8002, healthPath: "/metrics"),

--- a/FountainAiLauncher/Tests/FountainAiLauncherTests/FountainAiLauncherTests.swift
+++ b/FountainAiLauncher/Tests/FountainAiLauncherTests/FountainAiLauncherTests.swift
@@ -19,6 +19,16 @@ final class FountainAiLauncherTests: XCTestCase {
         process.waitUntilExit()
         XCTAssertFalse(process.isRunning)
     }
+
+    /// Verifies the ``Service`` initializer assigns all properties correctly.
+    func testServiceInitializerStoresArguments() {
+        let service = Service(name: "Demo", binaryPath: "/bin/echo", arguments: ["hi"], port: 42, healthPath: "/health")
+        XCTAssertEqual(service.name, "Demo")
+        XCTAssertEqual(service.binaryPath, "/bin/echo")
+        XCTAssertEqual(service.arguments, ["hi"])
+        XCTAssertEqual(service.port, 42)
+        XCTAssertEqual(service.healthPath, "/health")
+    }
 }
 
 // © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Tests/FountainCoreTests/FountainCoreTests.swift
+++ b/Tests/FountainCoreTests/FountainCoreTests.swift
@@ -39,6 +39,13 @@ final class FountainCoreTests: XCTestCase {
         XCTAssertNotEqual(a, b)
     }
 
+    /// Ensures differing names result in inequality even with identical IDs.
+    func testTodosNotEqualWithDifferentName() {
+        let a = Todo(id: 1, name: "A")
+        let b = Todo(id: 1, name: "B")
+        XCTAssertNotEqual(a, b)
+    }
+
     func testTodoEncodingProducesExpectedJSON() throws {
         let todo = Todo(id: 7, name: "Seven")
         let encoder = JSONEncoder()

--- a/Tests/PublishingFrontendTests/PublishingFrontendTests.swift
+++ b/Tests/PublishingFrontendTests/PublishingFrontendTests.swift
@@ -49,6 +49,13 @@ final class PublishingFrontendTests: XCTestCase {
         XCTAssertEqual(config.rootPath, "./Public")
     }
 
+    /// Verifies custom initializer values are stored.
+    func testPublishingConfigCustomValues() throws {
+        let config = PublishingConfig(port: 123, rootPath: "/tmp/Docs")
+        XCTAssertEqual(config.port, 123)
+        XCTAssertEqual(config.rootPath, "/tmp/Docs")
+    }
+
     /// Ensures loading the configuration without a file fails.
     func testLoadPublishingConfigFailsForMissingFile() {
         let dir = FileManager.default.temporaryDirectory.appendingPathComponent("nocfg", isDirectory: true)

--- a/docs/README.md
+++ b/docs/README.md
@@ -77,6 +77,7 @@ As modules gain documentation, brief summaries are added here.
 - **OpenAPISpec.Parameter.swiftName** and **swiftType** – document parameter name sanitization and schema type defaults.
 - **ListZonesParameters.name**, **searchName**, **page**, and **perPage** – document zone filtering and pagination options.
 - **OpenAPISpec.Schema.Property.swiftType** – inline comments clarify array and object mappings and default behavior.
+- **services array** – startup service list in `FountainAiLauncher` now documented.
 
 Documentation coverage will expand alongside test coverage.
 


### PR DESCRIPTION
## Summary
- document startup service list in main launcher
- exercise service initializer and configuration helpers
- refresh coverage report and counts

## Testing
- `./Scripts/run-tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68907deea698832599442dc1adc78901