### PR TITLE
Document Route53 parameters and expand SpecValidator tests

### DIFF
--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -5,20 +5,20 @@
 Running `swift test --enable-code-coverage` and analysing with `llvm-cov` produced the following totals:
 
 ```
-TOTAL                                          31959   26475    17.16%   14451 11476    20.59%   99797 81189    18.65%
+TOTAL                                          31974   26506    17.10%   14466 11488    20.59%   99839 81363    18.51%
 ```
 
-The repository contains **99,797** executable lines, with **18,608** lines covered (approx. **18.65%** line coverage).
+The repository contains **99,839** executable lines, with **18,476** lines covered (approx. **18.51%** line coverage).
 
 ### Repository source coverage
 
 Ignoring third-party packages under `.build/checkouts` and test targets, the totals are:
 
 ```
-TOTAL                                           590     213    63.90%     173     31    82.08%    1380     418    69.71%
+TOTAL                                           590     210    64.41%     173     31    82.08%    1380     415    69.93%
 ```
 
-Within repository sources there are **1,380** lines, with **962** covered, giving **69.71%** line coverage.
+Within repository sources there are **1,380** lines, with **965** covered, giving **69.93%** line coverage.
 
 Coverage results are recalculated after each test run to monitor progress. The project strives for ever more comprehensive test suites across all modules. Recent additions include unit tests for ``APIClient``. New tests now verify ``URLSessionHTTPClient`` behavior and the ``Supervisor`` process termination logic.
 Additional tests now cover ``OpenAPISpec.swiftType`` and the ``camelCased`` string helper. A new ``GatewayServerTests`` suite raises total tests to **27**.
@@ -81,6 +81,8 @@ The new ``DeletePrimaryServerRequestTests`` raise the total test count to **105*
 - The new ``ServiceInitializerStoresArguments``, ``PublishingConfigCustomValues``, and ``TodosNotEqualWithDifferentName`` tests raise the total test count to **133**.
 
 - The new ``CamelCasedLeadingUnderscore``, ``CamelCasedNumbers``, and ``EmitRequestGeneratesQueryParameter`` tests raise the total test count to **136**.
+
+- The new ``SpecValidator`` empty title, parameter name, and parameter location tests raise the total test count to **139**.
 
 ---
 © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/PublishingFrontend/DNSProvider.swift
+++ b/Sources/PublishingFrontend/DNSProvider.swift
@@ -75,21 +75,34 @@ public struct Route53Client: DNSProvider {
     /// Creates a new client instance.
     public init() {}
     /// Lists zones available to the AWS Route53 account.
+    /// - Returns: This stub never returns normally.
     /// - Throws: An ``NSError`` with domain `"Route53"` and code `501`.
     public func listZones() async throws -> [String] {
         throw NSError(domain: "Route53", code: 501)
     }
     /// Attempts to create a DNS record within Route53.
+    /// - Parameters:
+    ///   - zone: Hosted zone identifier.
+    ///   - name: Record name without the zone suffix.
+    ///   - type: DNS record type such as `"A"` or `"TXT"`.
+    ///   - value: Content value for the record.
     /// - Throws: An ``NSError`` with domain `"Route53"` and code `501`.
     public func createRecord(zone: String, name: String, type: String, value: String) async throws {
         throw NSError(domain: "Route53", code: 501)
     }
     /// Attempts to update a DNS record within Route53.
+    /// - Parameters:
+    ///   - id: Identifier of the record to update.
+    ///   - zone: Hosted zone containing the record.
+    ///   - name: Record name without the zone suffix.
+    ///   - type: DNS record type such as `"A"` or `"TXT"`.
+    ///   - value: New content to store in the record.
     /// - Throws: An ``NSError`` with domain `"Route53"` and code `501`.
     public func updateRecord(id: String, zone: String, name: String, type: String, value: String) async throws {
         throw NSError(domain: "Route53", code: 501)
     }
     /// Attempts to delete a DNS record in Route53.
+    /// - Parameter id: Identifier of the record to delete.
     /// - Throws: An ``NSError`` with domain `"Route53"` and code `501`.
     public func deleteRecord(id: String) async throws {
         throw NSError(domain: "Route53", code: 501)

--- a/Tests/ClientGeneratorTests/SpecValidatorTests.swift
+++ b/Tests/ClientGeneratorTests/SpecValidatorTests.swift
@@ -59,6 +59,36 @@ final class SpecValidatorTests: XCTestCase {
             XCTAssertTrue("\(error)".contains("unknown security scheme"))
         }
     }
+
+    /// Ensures an empty specification title triggers validation failure.
+    func testEmptyTitleThrows() throws {
+        let spec = OpenAPISpec(title: "   ", servers: nil, components: nil, paths: nil)
+        XCTAssertThrowsError(try SpecValidator.validate(spec)) { error in
+            XCTAssertTrue("\(error)".contains("title cannot be empty"))
+        }
+    }
+
+    /// Ensures parameters must declare a non-empty name.
+    func testEmptyParameterNameThrows() throws {
+        let param = OpenAPISpec.Parameter(name: "  ", location: "query", required: false, schema: nil)
+        let op = OpenAPISpec.Operation(operationId: "get", parameters: [param], requestBody: nil, responses: nil, security: nil)
+        let item = OpenAPISpec.PathItem(get: op, post: nil, put: nil, delete: nil)
+        let spec = OpenAPISpec(title: "API", servers: nil, components: nil, paths: ["/": item])
+        XCTAssertThrowsError(try SpecValidator.validate(spec)) { error in
+            XCTAssertTrue("\(error)".contains("parameter name cannot be empty"))
+        }
+    }
+
+    /// Ensures parameters must declare where they appear in the request.
+    func testEmptyParameterLocationThrows() throws {
+        let param = OpenAPISpec.Parameter(name: "id", location: "   ", required: false, schema: nil)
+        let op = OpenAPISpec.Operation(operationId: "get", parameters: [param], requestBody: nil, responses: nil, security: nil)
+        let item = OpenAPISpec.PathItem(get: op, post: nil, put: nil, delete: nil)
+        let spec = OpenAPISpec(title: "API", servers: nil, components: nil, paths: ["/": item])
+        XCTAssertThrowsError(try SpecValidator.validate(spec)) { error in
+            XCTAssertTrue("\(error)".contains("parameter location cannot be empty"))
+        }
+    }
 }
 
 // © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/docs/README.md
+++ b/docs/README.md
@@ -47,7 +47,7 @@ As modules gain documentation, brief summaries are added here.
 - **PublishingConfig.port** and **rootPath** – documented properties clarifying server binding and static directory.
 - **Todo.id** and **Todo.name** – documented properties clarifying task identifiers and titles.
 - **OpenAPISpec** – root model now documents components, servers, security schemes, and requirements.
-- **Route53Client** – stub methods now describe the unimplemented error responses.
+- **Route53Client** – stub methods now describe the unimplemented error responses and detail parameter roles for record operations.
 - **FountainOps Todo** – generated model now documents its properties.
 - **createPrimaryServer** and **getPrimaryServer** – request types now document server creation and retrieval.
 - **validateZoneFile** and **updatePrimaryServer** – request types now document zone file validation and primary server updates.

--- a/logs/build-20250804104758.log
+++ b/logs/build-20250804104758.log
@@ -1,0 +1,610 @@
+Fetching https://github.com/apple/swift-nio.git
+Fetching https://github.com/jpsim/Yams.git
+Fetching https://github.com/swift-server/async-http-client.git
+[1/10997] Fetching yams
+[2/25062] Fetching yams, async-http-client
+[14714/102251] Fetching yams, async-http-client, swift-nio
+Fetched https://github.com/swift-server/async-http-client.git from cache (1.03s)
+[14098/88186] Fetching yams, swift-nio
+Fetched https://github.com/jpsim/Yams.git from cache (4.54s)
+Fetched https://github.com/apple/swift-nio.git from cache (4.61s)
+Computing version for https://github.com/jpsim/Yams.git
+Computed https://github.com/jpsim/Yams.git at 5.4.0 (7.08s)
+Computing version for https://github.com/swift-server/async-http-client.git
+Computed https://github.com/swift-server/async-http-client.git at 1.26.1 (0.62s)
+Fetching https://github.com/apple/swift-log.git
+Fetching https://github.com/apple/swift-atomics.git
+Fetching https://github.com/apple/swift-algorithms.git
+[1/1808] Fetching swift-atomics
+[1809/5688] Fetching swift-atomics, swift-log
+[2042/11647] Fetching swift-atomics, swift-log, swift-algorithms
+Fetched https://github.com/apple/swift-atomics.git from cache (0.43s)
+[448/9839] Fetching swift-log, swift-algorithms
+Fetching https://github.com/apple/swift-nio-transport-services.git
+Fetched https://github.com/apple/swift-log.git from cache (0.60s)
+Fetching https://github.com/apple/swift-nio-extras.git
+Fetched https://github.com/apple/swift-algorithms.git from cache (0.64s)
+Fetching https://github.com/apple/swift-nio-http2.git
+[1/2701] Fetching swift-nio-transport-services
+Fetched https://github.com/apple/swift-nio-transport-services.git from cache (0.51s)
+Fetching https://github.com/apple/swift-nio-ssl.git
+[1/6123] Fetching swift-nio-extras
+[430/17784] Fetching swift-nio-extras, swift-nio-http2
+Fetched https://github.com/apple/swift-nio-extras.git from cache (0.56s)
+[2916/11661] Fetching swift-nio-http2
+[11662/26646] Fetching swift-nio-http2, swift-nio-ssl
+Fetched https://github.com/apple/swift-nio-http2.git from cache (1.04s)
+[4346/14985] Fetching swift-nio-ssl
+Fetched https://github.com/apple/swift-nio-ssl.git from cache (1.55s)
+Computing version for https://github.com/apple/swift-nio-transport-services.git
+Computed https://github.com/apple/swift-nio-transport-services.git at 1.25.0 (3.09s)
+Computing version for https://github.com/apple/swift-nio.git
+Computed https://github.com/apple/swift-nio.git at 2.85.0 (0.79s)
+Fetching https://github.com/apple/swift-system.git
+Fetching https://github.com/apple/swift-collections.git
+[1/4831] Fetching swift-system
+[1741/21758] Fetching swift-system, swift-collections
+Fetched https://github.com/apple/swift-system.git from cache (1.31s)
+Fetched https://github.com/apple/swift-collections.git from cache (1.32s)
+Computing version for https://github.com/apple/swift-atomics.git
+Computed https://github.com/apple/swift-atomics.git at 1.3.0 (1.93s)
+Computing version for https://github.com/apple/swift-nio-http2.git
+Computed https://github.com/apple/swift-nio-http2.git at 1.38.0 (0.64s)
+Computing version for https://github.com/apple/swift-algorithms.git
+Computed https://github.com/apple/swift-algorithms.git at 1.2.1 (0.68s)
+Fetching https://github.com/apple/swift-numerics.git
+[1/5769] Fetching swift-numerics
+Fetched https://github.com/apple/swift-numerics.git from cache (0.61s)
+Computing version for https://github.com/apple/swift-nio-ssl.git
+Computed https://github.com/apple/swift-nio-ssl.git at 2.33.0 (1.38s)
+Computing version for https://github.com/apple/swift-numerics.git
+Computed https://github.com/apple/swift-numerics.git at 1.0.3 (0.67s)
+Computing version for https://github.com/apple/swift-log.git
+Computed https://github.com/apple/swift-log.git at 1.6.4 (0.59s)
+Computing version for https://github.com/apple/swift-nio-extras.git
+Computed https://github.com/apple/swift-nio-extras.git at 1.29.0 (0.69s)
+Fetching https://github.com/apple/swift-async-algorithms.git
+Fetching https://github.com/swift-server/swift-service-lifecycle.git
+Fetching https://github.com/apple/swift-asn1.git
+[1/2433] Fetching swift-service-lifecycle
+[42/4062] Fetching swift-service-lifecycle, swift-asn1
+[368/9074] Fetching swift-service-lifecycle, swift-asn1, swift-async-algorithms
+Fetched https://github.com/swift-server/swift-service-lifecycle.git from cache (0.57s)
+Fetched https://github.com/apple/swift-asn1.git from cache (0.57s)
+Fetched https://github.com/apple/swift-async-algorithms.git from cache (0.57s)
+Fetching https://github.com/apple/swift-http-structured-headers.git
+Fetching https://github.com/apple/swift-certificates.git
+Fetching https://github.com/apple/swift-http-types.git
+[1/1176] Fetching swift-http-structured-headers
+Fetched https://github.com/apple/swift-http-structured-headers.git from cache (0.34s)
+[1/917] Fetching swift-http-types
+[258/7377] Fetching swift-http-types, swift-certificates
+Fetched https://github.com/apple/swift-http-types.git from cache (0.44s)
+[388/6460] Fetching swift-certificates
+Fetched https://github.com/apple/swift-certificates.git from cache (0.62s)
+Computing version for https://github.com/swift-server/swift-service-lifecycle.git
+Computed https://github.com/swift-server/swift-service-lifecycle.git at 2.8.0 (1.80s)
+Computing version for https://github.com/apple/swift-async-algorithms.git
+Computed https://github.com/apple/swift-async-algorithms.git at 1.0.4 (0.70s)
+Computing version for https://github.com/apple/swift-asn1.git
+Computed https://github.com/apple/swift-asn1.git at 1.4.0 (0.68s)
+Computing version for https://github.com/apple/swift-certificates.git
+Computed https://github.com/apple/swift-certificates.git at 1.11.0 (0.73s)
+Fetching https://github.com/apple/swift-crypto.git
+[1/15933] Fetching swift-crypto
+Fetched https://github.com/apple/swift-crypto.git from cache (1.70s)
+Computing version for https://github.com/apple/swift-http-types.git
+Computed https://github.com/apple/swift-http-types.git at 1.4.0 (2.34s)
+Computing version for https://github.com/apple/swift-http-structured-headers.git
+Computed https://github.com/apple/swift-http-structured-headers.git at 1.3.0 (0.64s)
+Computing version for https://github.com/apple/swift-system.git
+Computed https://github.com/apple/swift-system.git at 1.6.2 (0.66s)
+Computing version for https://github.com/apple/swift-crypto.git
+Computed https://github.com/apple/swift-crypto.git at 3.13.3 (1.42s)
+Computing version for https://github.com/apple/swift-collections.git
+Computed https://github.com/apple/swift-collections.git at 1.2.1 (0.73s)
+Creating working copy for https://github.com/apple/swift-algorithms.git
+Working copy of https://github.com/apple/swift-algorithms.git resolved at 1.2.1
+Creating working copy for https://github.com/swift-server/swift-service-lifecycle.git
+Working copy of https://github.com/swift-server/swift-service-lifecycle.git resolved at 2.8.0
+Creating working copy for https://github.com/apple/swift-http-types.git
+Working copy of https://github.com/apple/swift-http-types.git resolved at 1.4.0
+Creating working copy for https://github.com/apple/swift-atomics.git
+Working copy of https://github.com/apple/swift-atomics.git resolved at 1.3.0
+Creating working copy for https://github.com/apple/swift-nio-ssl.git
+Working copy of https://github.com/apple/swift-nio-ssl.git resolved at 2.33.0
+Creating working copy for https://github.com/apple/swift-asn1.git
+Working copy of https://github.com/apple/swift-asn1.git resolved at 1.4.0
+Creating working copy for https://github.com/apple/swift-system.git
+Working copy of https://github.com/apple/swift-system.git resolved at 1.6.2
+Creating working copy for https://github.com/apple/swift-crypto.git
+Working copy of https://github.com/apple/swift-crypto.git resolved at 3.13.3
+Creating working copy for https://github.com/apple/swift-log.git
+Working copy of https://github.com/apple/swift-log.git resolved at 1.6.4
+Creating working copy for https://github.com/jpsim/Yams.git
+Working copy of https://github.com/jpsim/Yams.git resolved at 5.4.0
+Creating working copy for https://github.com/apple/swift-nio.git
+Working copy of https://github.com/apple/swift-nio.git resolved at 2.85.0
+Creating working copy for https://github.com/apple/swift-nio-extras.git
+Working copy of https://github.com/apple/swift-nio-extras.git resolved at 1.29.0
+Creating working copy for https://github.com/swift-server/async-http-client.git
+Working copy of https://github.com/swift-server/async-http-client.git resolved at 1.26.1
+Creating working copy for https://github.com/apple/swift-numerics.git
+Working copy of https://github.com/apple/swift-numerics.git resolved at 1.0.3
+Creating working copy for https://github.com/apple/swift-nio-http2.git
+Working copy of https://github.com/apple/swift-nio-http2.git resolved at 1.38.0
+Creating working copy for https://github.com/apple/swift-nio-transport-services.git
+Working copy of https://github.com/apple/swift-nio-transport-services.git resolved at 1.25.0
+Creating working copy for https://github.com/apple/swift-http-structured-headers.git
+Working copy of https://github.com/apple/swift-http-structured-headers.git resolved at 1.3.0
+Creating working copy for https://github.com/apple/swift-collections.git
+Working copy of https://github.com/apple/swift-collections.git resolved at 1.2.1
+Creating working copy for https://github.com/apple/swift-async-algorithms.git
+Working copy of https://github.com/apple/swift-async-algorithms.git resolved at 1.0.4
+Creating working copy for https://github.com/apple/swift-certificates.git
+Working copy of https://github.com/apple/swift-certificates.git resolved at 1.11.0
+Building for production...
+[0/459] Write sources
+[27/459] Compiling _NumericsShims _NumericsShims.c
+[28/459] Compiling _AtomicsShims.c
+[29/459] Compiling writer.c
+[30/459] Compiling reader.c
+[31/459] Write swift-version--4EAD98957C2213E4.txt
+[32/459] Compiling CNIOWindows shim.c
+[33/459] Compiling parser.c
+[34/461] Compiling api.c
+[35/462] Compiling emitter.c
+[36/463] Compiling scanner.c
+[38/464] Compiling _NIOBase64 Base64.swift
+[39/465] Compiling RealModule AlgebraicField.swift
+[40/466] Compiling _NIODataStructures Heap.swift
+[40/466] Compiling CNIOWindows WSAStartup.c
+[41/466] Compiling CNIOWASI CNIOWASI.c
+[42/466] Compiling CNIOPosix event_loop_id.c
+[44/466] Compiling FountainCore Models.swift
+[44/466] Compiling CNIOLinux shim.c
+[45/466] Compiling CNIOLinux liburing_shims.c
+[46/466] Compiling CNIOLLHTTP c_nio_http.c
+[48/466] Compiling InternalCollectionsUtilities FixedWidthInteger+roundUpToPowerOfTwo.swift
+[48/466] Compiling CNIOLLHTTP c_nio_api.c
+[49/466] Compiling CNIOExtrasZlib empty.c
+[50/466] Compiling CNIODarwin shim.c
+[51/467] Compiling CNIOBoringSSLShims shims.c
+[52/467] Compiling fiat_p256_adx_sqr.S
+[53/467] Compiling fiat_p256_adx_mul.S
+[54/467] Compiling fiat_curve25519_adx_square.S
+[55/467] Compiling CNIOLLHTTP c_nio_llhttp.c
+[56/467] Compiling fiat_curve25519_adx_mul.S
+[58/467] Compiling Logging Locks.swift
+[58/467] Compiling tls_record.cc
+[60/467] Compiling DequeModule Deque+Codable.swift
+[60/467] Compiling tls_method.cc
+[61/467] Compiling tls13_server.cc
+[62/467] Compiling tls13_enc.cc
+[63/467] Compiling tls13_both.cc
+[64/467] Compiling tls13_client.cc
+[65/467] Compiling t1_enc.cc
+[66/467] Compiling ssl_transcript.cc
+[67/467] Compiling ssl_versions.cc
+[68/467] Compiling ssl_stat.cc
+[69/467] Compiling ssl_x509.cc
+[70/467] Compiling ssl_privkey.cc
+[71/467] Compiling ssl_session.cc
+[72/467] Compiling ssl_key_share.cc
+[73/467] Compiling ssl_lib.cc
+[74/467] Compiling ssl_file.cc
+[75/467] Compiling ssl_credential.cc
+[76/467] Compiling ssl_cipher.cc
+[77/467] Compiling ssl_buffer.cc
+[78/467] Compiling ssl_cert.cc
+[79/467] Compiling ssl_asn1.cc
+[80/467] Compiling ssl_aead_ctx.cc
+[81/467] Compiling s3_pkt.cc
+[82/467] Compiling s3_lib.cc
+[83/467] Compiling s3_both.cc
+[85/467] Compiling Yams AliasDereferencingStrategy.swift
+[85/467] Compiling handshake_server.cc
+[86/467] Compiling handshake.cc
+[87/467] Compiling handshake_client.cc
+[88/467] Compiling handoff.cc
+[89/467] Compiling encrypted_client_hello.cc
+[90/467] Compiling extensions.cc
+[91/467] Compiling dtls_record.cc
+[92/467] Compiling d1_srtp.cc
+[93/467] Compiling dtls_method.cc
+[94/467] Compiling md5-x86_64-linux.S
+[95/467] Compiling md5-x86_64-apple.S
+[96/467] Compiling md5-586-linux.S
+[97/467] Compiling md5-586-apple.S
+[98/467] Compiling d1_pkt.cc
+[99/467] Compiling bio_ssl.cc
+[100/467] Compiling chacha20_poly1305_x86_64-linux.S
+[101/467] Compiling chacha20_poly1305_x86_64-apple.S
+[102/467] Compiling err_data.cc
+[103/467] Compiling chacha20_poly1305_armv8-win.S
+[104/467] Compiling chacha20_poly1305_armv8-apple.S
+[105/467] Compiling chacha20_poly1305_armv8-linux.S
+[106/467] Compiling chacha-x86_64-linux.S
+[107/467] Compiling chacha-x86_64-apple.S
+[108/467] Compiling chacha-x86-linux.S
+[109/467] Compiling chacha-x86-apple.S
+[110/467] Compiling d1_lib.cc
+[111/467] Compiling chacha-armv8-linux.S
+[112/467] Compiling chacha-armv8-apple.S
+[113/467] Compiling chacha-armv8-win.S
+[114/467] Compiling chacha-armv4-linux.S
+[115/467] Compiling aes128gcmsiv-x86_64-linux.S
+[116/467] Compiling aes128gcmsiv-x86_64-apple.S
+[117/467] Compiling x86_64-mont5-linux.S
+[118/467] Compiling x86_64-mont5-apple.S
+[119/467] Compiling x86_64-mont-linux.S
+[120/467] Compiling d1_both.cc
+[121/467] Compiling x86_64-mont-apple.S
+[122/467] Compiling x86-mont-linux.S
+[123/467] Compiling x86-mont-apple.S
+[124/467] Compiling vpaes-x86_64-apple.S
+[125/467] Compiling vpaes-x86_64-linux.S
+[126/467] Compiling vpaes-x86-linux.S
+[127/467] Compiling vpaes-x86-apple.S
+[128/467] Compiling vpaes-armv8-win.S
+[129/467] Compiling vpaes-armv8-linux.S
+[130/467] Compiling vpaes-armv8-apple.S
+[131/467] Compiling vpaes-armv7-linux.S
+[132/467] Compiling sha512-x86_64-linux.S
+[133/467] Compiling sha512-x86_64-apple.S
+[134/467] Compiling sha512-armv8-win.S
+[135/467] Compiling sha512-armv8-linux.S
+[136/467] Compiling sha512-armv8-apple.S
+[137/467] Compiling sha512-armv4-linux.S
+[138/467] Compiling sha512-586-linux.S
+[139/467] Compiling sha512-586-apple.S
+[140/467] Compiling sha256-x86_64-linux.S
+[141/467] Compiling sha256-x86_64-apple.S
+[142/467] Compiling sha256-armv8-win.S
+[143/467] Compiling sha256-armv8-linux.S
+[144/467] Compiling sha1-x86_64-linux.S
+[145/467] Compiling sha256-586-apple.S
+[146/467] Compiling sha256-armv4-linux.S
+[146/467] Compiling sha256-armv8-apple.S
+[147/467] Compiling sha256-586-linux.S
+[149/467] Compiling sha1-armv8-linux.S
+[150/467] Compiling sha1-armv8-apple.S
+[151/467] Compiling sha1-armv4-large-linux.S
+[151/467] Compiling sha1-armv8-win.S
+[153/467] Compiling sha1-x86_64-apple.S
+[154/467] Compiling sha1-586-apple.S
+[154/467] Compiling sha1-586-linux.S
+[156/467] Compiling rsaz-avx2-linux.S
+[157/467] Compiling rsaz-avx2-apple.S
+[158/467] Compiling rdrand-x86_64-linux.S
+[159/467] Compiling p256_beeu-x86_64-asm-apple.S
+[160/467] Compiling rdrand-x86_64-apple.S
+[161/467] Compiling p256_beeu-armv8-asm-win.S
+[162/467] Compiling p256_beeu-x86_64-asm-linux.S
+[163/467] Compiling p256_beeu-armv8-asm-linux.S
+[164/467] Compiling p256_beeu-armv8-asm-apple.S
+[165/467] Compiling p256-x86_64-asm-apple.S
+[166/467] Compiling p256-armv8-asm-win.S
+[167/467] Compiling p256-x86_64-asm-linux.S
+[168/467] Compiling p256-armv8-asm-linux.S
+[169/467] Compiling p256-armv8-asm-apple.S
+[170/467] Compiling ghashv8-armv8-win.S
+[171/467] Compiling ghashv8-armv8-linux.S
+[172/467] Compiling ghashv8-armv8-apple.S
+[173/467] Compiling ghashv8-armv7-linux.S
+[174/467] Compiling ghash-x86_64-linux.S
+[175/467] Compiling ghash-x86-linux.S
+[176/467] Compiling ghash-x86_64-apple.S
+[177/467] Compiling ghash-x86-apple.S
+[178/467] Compiling ghash-ssse3-x86_64-linux.S
+[179/467] Compiling ghash-ssse3-x86_64-apple.S
+[180/467] Compiling ghash-ssse3-x86-linux.S
+[181/467] Compiling ghash-ssse3-x86-apple.S
+[182/467] Compiling ghash-neon-armv8-win.S
+[183/467] Compiling ghash-neon-armv8-linux.S
+[184/467] Compiling ghash-neon-armv8-apple.S
+[185/467] Compiling co-586-linux.S
+[186/467] Compiling ghash-armv4-linux.S
+[187/467] Compiling co-586-apple.S
+[188/467] Compiling bsaes-armv7-linux.S
+[189/467] Compiling bn-armv8-linux.S
+[190/467] Compiling bn-armv8-win.S
+[191/467] Compiling bn-armv8-apple.S
+[192/467] Compiling bn-586-linux.S
+[193/467] Compiling bn-586-apple.S
+[194/467] Compiling armv8-mont-linux.S
+[195/467] Compiling armv8-mont-win.S
+[196/467] Compiling armv8-mont-apple.S
+[197/467] Compiling aesv8-gcm-armv8-win.S
+[198/467] Compiling armv4-mont-linux.S
+[199/467] Compiling aesv8-gcm-armv8-linux.S
+[200/467] Compiling aesv8-gcm-armv8-apple.S
+[201/467] Compiling aesv8-armv8-win.S
+[201/467] Compiling aesv8-armv8-linux.S
+[203/467] Compiling aesv8-armv8-apple.S
+[204/467] Compiling aesv8-armv7-linux.S
+[205/467] Compiling aesni-x86_64-linux.S
+[206/467] Compiling aesni-x86-linux.S
+[207/467] Compiling aesni-x86-apple.S
+[208/467] Compiling aesni-x86_64-apple.S
+[209/467] Compiling aesni-gcm-x86_64-linux.S
+[210/467] Compiling aesni-gcm-x86_64-apple.S
+[211/467] Compiling aes-gcm-avx2-x86_64-apple.S
+[212/467] Compiling aes-gcm-avx2-x86_64-linux.S
+[213/467] Compiling aes-gcm-avx10-x86_64-linux.S
+[214/467] Compiling aes-gcm-avx10-x86_64-apple.S
+[215/467] Compiling x_x509a.cc
+[216/467] Compiling x_spki.cc
+[217/467] Compiling x_val.cc
+[218/467] Compiling x_sig.cc
+[219/467] Compiling x_x509.cc
+[220/467] Compiling x_exten.cc
+[221/467] Compiling x_req.cc
+[222/467] Compiling x_pubkey.cc
+[223/467] Compiling x_name.cc
+[224/467] Compiling x_crl.cc
+[225/467] Compiling x509spki.cc
+[226/467] Compiling x_attrib.cc
+[227/467] Compiling x_algor.cc
+[228/467] Compiling x_all.cc
+[229/467] Compiling x509rset.cc
+[230/467] Compiling x509cset.cc
+[231/467] Compiling x509name.cc
+[232/467] Compiling x509_vpm.cc
+[233/467] Compiling x509_v3.cc
+[234/467] Compiling x509_vfy.cc
+[235/467] Compiling x509_txt.cc
+[236/467] Compiling x509_trs.cc
+[237/467] Compiling x509_set.cc
+[238/467] Compiling x509_req.cc
+[239/467] Compiling x509_obj.cc
+[240/467] Compiling x509_def.cc
+[241/467] Compiling x509_lu.cc
+[242/467] Compiling x509_ext.cc
+[243/467] Compiling x509_d2.cc
+[244/467] Compiling x509_cmp.cc
+[245/467] Compiling x509.cc
+[246/467] Compiling x509_att.cc
+[247/467] Compiling v3_skey.cc
+[248/467] Compiling v3_utl.cc
+[249/467] Compiling v3_purp.cc
+[250/467] Compiling v3_prn.cc
+[251/467] Compiling v3_pmaps.cc
+[252/467] Compiling v3_pcons.cc
+[253/467] Compiling v3_ocsp.cc
+[254/467] Compiling v3_ncons.cc
+[255/467] Compiling v3_lib.cc
+[256/467] Compiling v3_int.cc
+[257/467] Compiling v3_info.cc
+[258/467] Compiling v3_ia5.cc
+[259/467] Compiling v3_genn.cc
+[260/467] Compiling v3_extku.cc
+[261/467] Compiling v3_enum.cc
+[262/467] Compiling v3_crld.cc
+[263/467] Compiling v3_cpols.cc
+[264/467] Compiling v3_conf.cc
+[265/467] Compiling v3_bitst.cc
+[266/467] Compiling v3_bcons.cc
+[267/467] Compiling v3_alt.cc
+[268/467] Compiling v3_akeya.cc
+[269/467] Compiling v3_akey.cc
+[270/467] Compiling t_x509a.cc
+[271/467] Compiling t_x509.cc
+[272/467] Compiling t_crl.cc
+[273/467] Compiling t_req.cc
+[274/467] Compiling i2d_pr.cc
+[275/467] Compiling rsa_pss.cc
+[276/467] Compiling policy.cc
+[277/467] Compiling name_print.cc
+[278/467] Compiling by_file.cc
+[279/467] Compiling by_dir.cc
+[280/467] Compiling asn1_gen.cc
+[281/467] Compiling algorithm.cc
+[282/467] Compiling a_verify.cc
+[283/467] Compiling a_sign.cc
+[284/467] Compiling thread_win.cc
+[285/467] Compiling a_digest.cc
+[286/467] Compiling voprf.cc
+[287/467] Compiling trust_token.cc
+[288/467] Compiling thread.cc
+[289/467] Compiling thread_none.cc
+[290/467] Compiling pmbtoken.cc
+[291/467] Compiling thread_pthread.cc
+[292/467] Compiling stack.cc
+[293/467] Compiling sha512.cc
+[294/467] Compiling slhdsa.cc
+[295/467] Compiling siphash.cc
+[296/467] Compiling spake2plus.cc
+[297/467] Compiling sha256.cc
+[298/467] Compiling sha1.cc
+[299/467] Compiling rsa_extra.cc
+[300/467] Compiling rsa_print.cc
+[301/467] Compiling rsa_asn1.cc
+[302/467] Compiling rsa_crypt.cc
+[303/467] Compiling refcount.cc
+[304/467] Compiling rc4.cc
+[305/467] Compiling windows.cc
+[306/467] Compiling trusty.cc
+[307/467] Compiling ios.cc
+[308/467] Compiling rand.cc
+[308/467] Compiling urandom.cc
+[310/467] Compiling passive.cc
+[311/467] Compiling getentropy.cc
+[312/467] Compiling deterministic.cc
+[313/467] Compiling forkunsafe.cc
+[314/467] Compiling fork_detect.cc
+[315/467] Compiling poly1305_arm_asm.S
+[316/467] Compiling pool.cc
+[317/467] Compiling poly1305.cc
+[318/467] Compiling poly1305_arm.cc
+[319/467] Compiling poly1305_vec.cc
+[320/467] Compiling pkcs7.cc
+[321/467] Compiling pkcs8_x509.cc
+[322/467] Compiling pkcs8.cc
+[323/467] Compiling p5_pbev2.cc
+[324/467] Compiling pkcs7_x509.cc
+[325/467] Compiling pem_xaux.cc
+[326/467] Compiling pem_x509.cc
+[327/467] Compiling pem_pkey.cc
+[328/467] Compiling pem_pk8.cc
+[329/467] Compiling pem_oth.cc
+[330/467] Compiling obj_xref.cc
+[331/467] Compiling pem_info.cc
+[332/467] Compiling pem_lib.cc
+[333/467] Compiling obj.cc
+[334/467] Compiling pem_all.cc
+[335/467] Compiling mlkem.cc
+[336/467] Compiling mldsa.cc
+[337/467] Compiling md5.cc
+[338/467] Compiling lhash.cc
+[339/467] Compiling md4.cc
+[340/467] Compiling mem.cc
+[341/467] Compiling fips_shared_support.cc
+[342/467] Compiling poly_rq_mul.S
+[343/467] Compiling kyber.cc
+[344/467] Compiling ex_data.cc
+[345/467] Compiling hpke.cc
+[346/467] Compiling sign.cc
+[347/467] Compiling hrss.cc
+[348/467] Compiling scrypt.cc
+[349/467] Compiling print.cc
+[350/467] Compiling pbkdf.cc
+[351/467] Compiling p_x25519.cc
+[352/467] Compiling p_x25519_asn1.cc
+[353/467] Compiling p_rsa_asn1.cc
+[354/467] Compiling p_rsa.cc
+[355/467] Compiling p_hkdf.cc
+[356/467] Compiling p_ed25519_asn1.cc
+[357/467] Compiling p_ed25519.cc
+[358/467] Compiling p_ec.cc
+[359/467] Compiling p_ec_asn1.cc
+[360/467] Compiling p_dh_asn1.cc
+[361/467] Compiling p_dsa_asn1.cc
+[362/467] Compiling p_dh.cc
+[363/467] Compiling evp_ctx.cc
+[364/467] Compiling evp.cc
+[365/467] Compiling evp_asn1.cc
+[366/467] Compiling engine.cc
+[367/467] Compiling err.cc
+[368/467] Compiling ecdsa_asn1.cc
+[369/467] Compiling ecdh.cc
+[370/467] Compiling ec_derive.cc
+[371/467] Compiling hash_to_curve.cc
+[372/467] Compiling ec_asn1.cc
+[373/467] Compiling dsa_asn1.cc
+[374/467] Compiling digest_extra.cc
+[375/467] Compiling dsa.cc
+[376/467] Compiling params.cc
+[377/467] Compiling dh_asn1.cc
+[378/467] Compiling spake25519.cc
+[379/467] Compiling x25519-asm-arm.S
+[380/467] Compiling des.cc
+[381/467] Compiling crypto.cc
+[382/467] Compiling cpu_intel.cc
+[383/467] Compiling cpu_arm_linux.cc
+[384/467] Compiling cpu_arm_freebsd.cc
+[385/467] Compiling curve25519_64_adx.cc
+[386/467] Compiling curve25519.cc
+[387/467] Compiling cpu_aarch64_openbsd.cc
+[388/467] Compiling cpu_aarch64_win.cc
+[389/467] Compiling cpu_aarch64_sysreg.cc
+[390/467] Compiling cpu_aarch64_linux.cc
+[391/467] Compiling cpu_aarch64_fuchsia.cc
+[392/467] Compiling cpu_aarch64_apple.cc
+[393/467] Compiling conf.cc
+[394/467] Compiling tls_cbc.cc
+[395/467] Compiling get_cipher.cc
+[396/467] Compiling e_tls.cc
+[397/467] Compiling e_rc4.cc
+[398/467] Compiling e_rc2.cc
+[399/467] Compiling e_null.cc
+[400/467] Compiling e_des.cc
+[401/467] Compiling e_chacha20poly1305.cc
+[402/467] Compiling e_aesctrhmac.cc
+[403/467] Compiling derive_key.cc
+[404/467] Compiling e_aesgcmsiv.cc
+[405/467] Compiling chacha.cc
+[406/467] Compiling unicode.cc
+[407/467] Compiling ber.cc
+[408/467] Compiling cbb.cc
+[409/467] Compiling cbs.cc
+[410/467] Compiling asn1_compat.cc
+[411/467] Compiling buf.cc
+[412/467] Compiling bn_asn1.cc
+[413/467] Compiling blake2.cc
+[414/467] Compiling convert.cc
+[415/467] Compiling socket_helper.cc
+[416/467] Compiling socket.cc
+[417/467] Compiling printf.cc
+[418/467] Compiling pair.cc
+[419/467] Compiling hexdump.cc
+[420/467] Compiling file.cc
+[421/467] Compiling errno.cc
+[422/467] Compiling fd.cc
+[423/467] Compiling connect.cc
+[424/467] Compiling bio_mem.cc
+[425/467] Compiling base64.cc
+[426/467] Compiling bio.cc
+[427/467] Compiling tasn_utl.cc
+[428/467] Compiling tasn_typ.cc
+[429/467] Compiling tasn_fre.cc
+[430/467] Compiling tasn_new.cc
+[431/467] Compiling tasn_enc.cc
+[432/467] Compiling posix_time.cc
+[433/467] Compiling f_string.cc
+[434/467] Compiling tasn_dec.cc
+[435/467] Compiling asn_pack.cc
+[436/467] Compiling f_int.cc
+[437/467] Compiling asn1_par.cc
+[438/467] Compiling asn1_lib.cc
+[439/467] Compiling a_type.cc
+[440/467] Compiling a_utctm.cc
+[441/467] Compiling a_time.cc
+[442/467] Compiling a_strnid.cc
+[443/467] Compiling a_octet.cc
+[444/467] Compiling a_strex.cc
+[445/467] Compiling a_object.cc
+[446/467] Compiling a_mbstr.cc
+[447/467] Compiling a_i2d_fp.cc
+[448/467] Compiling a_int.cc
+[449/467] Compiling a_gentm.cc
+[450/467] Compiling a_dup.cc
+[451/467] Compiling a_d2i_fp.cc
+[452/467] Compiling a_bool.cc
+[453/467] Compiling CAsyncHTTPClient CAsyncHTTPClient.c
+[454/467] Write sources
+[456/467] Compiling a_bitstr.cc
+[457/467] Write sources
+[458/469] Compiling bcm.cc
+[459/469] Compiling c-nioatomics.c
+[460/469] Compiling c-atomics.c
+[462/470] Compiling NIOConcurrencyHelpers NIOAtomic.swift
+[463/470] Compiling Atomics OptionalRawRepresentable.swift
+[464/471] Compiling Algorithms AdjacentPairs.swift
+[465/471] Compiling NIOCore AddressedEnvelope.swift
+[466/473] Compiling NIOEmbedded AsyncTestingChannel.swift
+[467/473] Compiling NIOPosix BSDSocketAPICommon.swift
+[468/474] Compiling NIO Exports.swift
+[469/478] Compiling NIOTLS ApplicationProtocolNegotiationHandler.swift
+[470/479] Compiling NIOSOCKS SOCKSClientHandler.swift
+[471/479] Compiling NIOFoundationCompat ByteBuffer-foundation.swift
+[472/480] Compiling NIOTransportServices AcceptHandler.swift
+[473/480] Compiling NIOHTTP1 ByteCollectionUtils.swift
+[474/482] Compiling NIOSSL AndroidCABundle.swift
+[475/482] Compiling NIOHTTPCompression HTTPCompression.swift
+[476/482] Compiling NIOHPACK DynamicHeaderTable.swift
+[477/483] Compiling NIOHTTP2 ConnectionStateMachine.swift
+[478/484] Compiling AsyncHTTPClient AnyAsyncSequence.swift
+[479/485] Compiling FountainCodex ClientGenerator.swift
+[480/487] Compiling clientgen_service main.swift
+[480/487] Write Objects.LinkFileList
+[481/487] Linking clientgen-service
+[483/487] Compiling PublishingFrontend DNSProvider.swift
+[484/489] Compiling publishing_frontend main.swift
+[484/489] Write Objects.LinkFileList
+[486/489] Compiling gateway_server CertificateManager.swift
+[486/489] Write Objects.LinkFileList
+[487/489] Linking publishing-frontend
+[488/489] Linking gateway-server
+Build complete! (212.53s)
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/logs/test-20250804104758.log
+++ b/logs/test-20250804104758.log
@@ -1,0 +1,507 @@
+[0/1] Planning build
+Building for production...
+[0/12] Write sources
+[5/18] Write swift-version--4EAD98957C2213E4.txt
+[7/23] Compiling _NIOBase64 Base64.swift
+[8/24] Compiling _NIODataStructures Heap.swift
+[9/25] Compiling InternalCollectionsUtilities FixedWidthInteger+roundUpToPowerOfTwo.swift
+[10/26] Compiling RealModule AlgebraicField.swift
+[11/27] Compiling FountainCore Models.swift
+[12/28] Compiling NIOConcurrencyHelpers NIOAtomic.swift
+[13/28] Compiling Logging Locks.swift
+[14/30] Compiling DequeModule Deque+Codable.swift
+[15/30] Compiling Atomics OptionalRawRepresentable.swift
+[16/30] Compiling FountainCoreTests FountainCoreTests.swift
+[17/31] Compiling Algorithms AdjacentPairs.swift
+[18/31] Compiling Yams AliasDereferencingStrategy.swift
+[19/31] Compiling NIOCore AddressedEnvelope.swift
+[20/33] Compiling NIOEmbedded AsyncTestingChannel.swift
+[21/33] Compiling NIOPosix BSDSocketAPICommon.swift
+[22/34] Compiling NIO Exports.swift
+[23/38] Compiling NIOFoundationCompat ByteBuffer-foundation.swift
+[24/38] Compiling NIOTLS ApplicationProtocolNegotiationHandler.swift
+[25/40] Compiling NIOSOCKS SOCKSClientHandler.swift
+[26/40] Compiling NIOTransportServices AcceptHandler.swift
+[27/40] Compiling NIOHTTP1 ByteCollectionUtils.swift
+[28/42] Compiling NIOSSL AndroidCABundle.swift
+[29/42] Compiling NIOHTTPCompression HTTPCompression.swift
+[30/42] Compiling NIOHPACK DynamicHeaderTable.swift
+[31/43] Compiling NIOHTTP2 ConnectionStateMachine.swift
+[32/44] Compiling AsyncHTTPClient AnyAsyncSequence.swift
+[33/45] Compiling FountainCodex ClientGenerator.swift
+[34/48] Compiling clientgen_service main.swift
+[34/48] Write Objects.LinkFileList
+[36/48] Compiling ClientGeneratorTests ClientGeneratorTests.swift
+/workspace/codex-deployer/Tests/ClientGeneratorTests/ClientGeneratorTests.swift:52:28: warning: 'init(contentsOf:)' is deprecated: Use `init(contentsOf:encoding:)` instead
+50 |         try ClientGenerator.emitClient(from: spec, to: outDir)
+51 |         let requestFile = outDir.appendingPathComponent("Requests/GetZone.swift")
+52 |         let contents = try String(contentsOf: requestFile)
+   |                            `- warning: 'init(contentsOf:)' is deprecated: Use `init(contentsOf:encoding:)` instead
+53 |         XCTAssertTrue(contents.contains("detail"))
+54 |         XCTAssertTrue(contents.contains("query.append(\"detail"))
+
+/workspace/codex-deployer/Tests/ClientGeneratorTests/SpecLoaderTests.swift:28:29: warning: result of call to 'createFile(atPath:contents:attributes:)' is unused
+26 |     func testLoadThrowsForEmptyFile() {
+27 |         let url = FileManager.default.temporaryDirectory.appendingPathComponent("empty.yml")
+28 |         FileManager.default.createFile(atPath: url.path, contents: Data())
+   |                             `- warning: result of call to 'createFile(atPath:contents:attributes:)' is unused
+29 |         XCTAssertThrowsError(try SpecLoader.load(from: url))
+30 |     }
+
+/workspace/codex-deployer/Tests/ClientGeneratorTests/SpecLoaderTests.swift:37:29: warning: result of call to 'createFile(atPath:contents:attributes:)' is unused
+35 |         let bytes: [UInt8] = [0xFF]
+36 |         let data = Data(bytes)
+37 |         FileManager.default.createFile(atPath: url.path, contents: data)
+   |                             `- warning: result of call to 'createFile(atPath:contents:attributes:)' is unused
+38 |         XCTAssertThrowsError(try SpecLoader.load(from: url))
+39 |     }
+[36/48] Linking clientgen-service
+[38/48] Compiling PublishingFrontend DNSProvider.swift
+[39/52] Compiling publishing_frontend main.swift
+[39/52] Write Objects.LinkFileList
+[41/52] Compiling gateway_server CertificateManager.swift
+[41/52] Write Objects.LinkFileList
+[43/52] Compiling PublishingFrontendTests HetznerDNSModelsTests.swift
+/workspace/codex-deployer/Tests/PublishingFrontendTests/PublishingFrontendTests.swift:39:37: warning: result of call to 'changeCurrentDirectoryPath' is unused
+ 37 |         try yaml.write(to: fileURL, atomically: true, encoding: .utf8)
+ 38 |         let cwd = FileManager.default.currentDirectoryPath
+ 39 |         defer { FileManager.default.changeCurrentDirectoryPath(cwd) }
+    |                                     `- warning: result of call to 'changeCurrentDirectoryPath' is unused
+ 40 |         FileManager.default.changeCurrentDirectoryPath(dir.path)
+ 41 |         let config = try loadPublishingConfig()
+
+/workspace/codex-deployer/Tests/PublishingFrontendTests/PublishingFrontendTests.swift:40:29: warning: result of call to 'changeCurrentDirectoryPath' is unused
+ 38 |         let cwd = FileManager.default.currentDirectoryPath
+ 39 |         defer { FileManager.default.changeCurrentDirectoryPath(cwd) }
+ 40 |         FileManager.default.changeCurrentDirectoryPath(dir.path)
+    |                             `- warning: result of call to 'changeCurrentDirectoryPath' is unused
+ 41 |         let config = try loadPublishingConfig()
+ 42 |         XCTAssertEqual(config.port, 1234)
+
+/workspace/codex-deployer/Tests/PublishingFrontendTests/PublishingFrontendTests.swift:65:37: warning: result of call to 'changeCurrentDirectoryPath' is unused
+ 63 |         try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+ 64 |         let cwd = FileManager.default.currentDirectoryPath
+ 65 |         defer { FileManager.default.changeCurrentDirectoryPath(cwd) }
+    |                                     `- warning: result of call to 'changeCurrentDirectoryPath' is unused
+ 66 |         FileManager.default.changeCurrentDirectoryPath(dir.path)
+ 67 |         XCTAssertThrowsError(try loadPublishingConfig())
+
+/workspace/codex-deployer/Tests/PublishingFrontendTests/PublishingFrontendTests.swift:66:29: warning: result of call to 'changeCurrentDirectoryPath' is unused
+ 64 |         let cwd = FileManager.default.currentDirectoryPath
+ 65 |         defer { FileManager.default.changeCurrentDirectoryPath(cwd) }
+ 66 |         FileManager.default.changeCurrentDirectoryPath(dir.path)
+    |                             `- warning: result of call to 'changeCurrentDirectoryPath' is unused
+ 67 |         XCTAssertThrowsError(try loadPublishingConfig())
+ 68 |     }
+[44/52] Compiling DNSTests APIClientTests.swift
+[44/52] Linking publishing-frontend
+[45/52] Linking gateway-server
+[47/53] Compiling IntegrationRuntimeTests AsyncHTTPClientDriverTests.swift
+[47/53] /workspace/codex-deployer/.build/x86_64-unknown-linux-gnu/release/FountainCoachPackageDiscoveredTests.derived/all-discovered-tests.swift
+[48/53] Write sources
+[50/54] Compiling FountainCoachPackageDiscoveredTests ClientGeneratorTests.swift
+[50/54] /workspace/codex-deployer/.build/x86_64-unknown-linux-gnu/release/FountainCoachPackageTests.derived/runner.swift
+[51/54] Write sources
+[53/55] Compiling FountainCoachPackageTests runner.swift
+[53/55] Write Objects.LinkFileList
+[54/55] Linking FountainCoachPackageTests.xctest
+Build complete! (125.94s)
+Test Suite 'All tests' started at 2025-08-04 10:53:39.526
+Test Suite 'release.xctest' started at 2025-08-04 10:53:39.540
+Test Suite 'FountainCoreTests' started at 2025-08-04 10:53:39.540
+Test Case 'FountainCoreTests.testTodoDecoding' started at 2025-08-04 10:53:39.540
+Test Case 'FountainCoreTests.testTodoDecoding' passed (0.006 seconds)
+Test Case 'FountainCoreTests.testTodoDecodingFailsForMissingID' started at 2025-08-04 10:53:39.546
+Test Case 'FountainCoreTests.testTodoDecodingFailsForMissingID' passed (0.101 seconds)
+Test Case 'FountainCoreTests.testTodoDecodingFailsForMissingName' started at 2025-08-04 10:53:39.647
+Test Case 'FountainCoreTests.testTodoDecodingFailsForMissingName' passed (0.0 seconds)
+Test Case 'FountainCoreTests.testTodoEncodingProducesExpectedJSON' started at 2025-08-04 10:53:39.648
+Test Case 'FountainCoreTests.testTodoEncodingProducesExpectedJSON' passed (0.001 seconds)
+Test Case 'FountainCoreTests.testTodoEncodingRoundTrip' started at 2025-08-04 10:53:39.649
+Test Case 'FountainCoreTests.testTodoEncodingRoundTrip' passed (0.0 seconds)
+Test Case 'FountainCoreTests.testTodoEquality' started at 2025-08-04 10:53:39.649
+Test Case 'FountainCoreTests.testTodoEquality' passed (0.0 seconds)
+Test Case 'FountainCoreTests.testTodosNotEqualWithDifferentID' started at 2025-08-04 10:53:39.649
+Test Case 'FountainCoreTests.testTodosNotEqualWithDifferentID' passed (0.0 seconds)
+Test Case 'FountainCoreTests.testTodosNotEqualWithDifferentName' started at 2025-08-04 10:53:39.649
+Test Case 'FountainCoreTests.testTodosNotEqualWithDifferentName' passed (0.0 seconds)
+Test Suite 'FountainCoreTests' passed at 2025-08-04 10:53:39.649
+	 Executed 8 tests, with 0 failures (0 unexpected) in 0.109 (0.109) seconds
+Test Suite 'APIClientTests' started at 2025-08-04 10:53:39.650
+Test Case 'APIClientTests.testBearerInitializerSetsHeader' started at 2025-08-04 10:53:39.650
+Test Case 'APIClientTests.testBearerInitializerSetsHeader' passed (0.001 seconds)
+Test Case 'APIClientTests.testRawDataResponse' started at 2025-08-04 10:53:39.651
+Test Case 'APIClientTests.testRawDataResponse' passed (0.001 seconds)
+Test Case 'APIClientTests.testSendDecodesResponse' started at 2025-08-04 10:53:39.652
+Test Case 'APIClientTests.testSendDecodesResponse' passed (0.0 seconds)
+Test Suite 'APIClientTests' passed at 2025-08-04 10:53:39.652
+	 Executed 3 tests, with 0 failures (0 unexpected) in 0.003 (0.003) seconds
+Test Suite 'CreatePrimaryServerRequestTests' started at 2025-08-04 10:53:39.652
+Test Case 'CreatePrimaryServerRequestTests.testMethodIsPOST' started at 2025-08-04 10:53:39.652
+Test Case 'CreatePrimaryServerRequestTests.testMethodIsPOST' passed (0.0 seconds)
+Test Case 'CreatePrimaryServerRequestTests.testPathIsCorrect' started at 2025-08-04 10:53:39.652
+Test Case 'CreatePrimaryServerRequestTests.testPathIsCorrect' passed (0.0 seconds)
+Test Suite 'CreatePrimaryServerRequestTests' passed at 2025-08-04 10:53:39.653
+	 Executed 2 tests, with 0 failures (0 unexpected) in 0.0 (0.0) seconds
+Test Suite 'DNSClientTests' started at 2025-08-04 10:53:39.653
+Test Case 'DNSClientTests.testRoute53CreateRecordErrorDetails' started at 2025-08-04 10:53:39.653
+Test Case 'DNSClientTests.testRoute53CreateRecordErrorDetails' passed (0.001 seconds)
+Test Case 'DNSClientTests.testRoute53CreateRecordStub' started at 2025-08-04 10:53:39.653
+Test Case 'DNSClientTests.testRoute53CreateRecordStub' passed (0.0 seconds)
+Test Case 'DNSClientTests.testRoute53DeleteRecordErrorDetails' started at 2025-08-04 10:53:39.653
+Test Case 'DNSClientTests.testRoute53DeleteRecordErrorDetails' passed (0.0 seconds)
+Test Case 'DNSClientTests.testRoute53DeleteRecordStub' started at 2025-08-04 10:53:39.654
+Test Case 'DNSClientTests.testRoute53DeleteRecordStub' passed (0.0 seconds)
+Test Case 'DNSClientTests.testRoute53ListZonesErrorDetails' started at 2025-08-04 10:53:39.654
+Test Case 'DNSClientTests.testRoute53ListZonesErrorDetails' passed (0.0 seconds)
+Test Case 'DNSClientTests.testRoute53Stub' started at 2025-08-04 10:53:39.654
+Test Case 'DNSClientTests.testRoute53Stub' passed (0.0 seconds)
+Test Case 'DNSClientTests.testRoute53UpdateRecordErrorDetails' started at 2025-08-04 10:53:39.654
+Test Case 'DNSClientTests.testRoute53UpdateRecordErrorDetails' passed (0.0 seconds)
+Test Case 'DNSClientTests.testRoute53UpdateRecordStub' started at 2025-08-04 10:53:39.655
+Test Case 'DNSClientTests.testRoute53UpdateRecordStub' passed (0.1 seconds)
+Test Suite 'DNSClientTests' passed at 2025-08-04 10:53:39.755
+	 Executed 8 tests, with 0 failures (0 unexpected) in 0.102 (0.102) seconds
+Test Suite 'DeletePrimaryServerRequestTests' started at 2025-08-04 10:53:39.755
+Test Case 'DeletePrimaryServerRequestTests.testMethodIsDELETE' started at 2025-08-04 10:53:39.755
+Test Case 'DeletePrimaryServerRequestTests.testMethodIsDELETE' passed (0.0 seconds)
+Test Case 'DeletePrimaryServerRequestTests.testPathIsCorrect' started at 2025-08-04 10:53:39.756
+Test Case 'DeletePrimaryServerRequestTests.testPathIsCorrect' passed (0.002 seconds)
+Test Suite 'DeletePrimaryServerRequestTests' passed at 2025-08-04 10:53:39.757
+	 Executed 2 tests, with 0 failures (0 unexpected) in 0.002 (0.002) seconds
+Test Suite 'DeleteRecordRequestTests' started at 2025-08-04 10:53:39.757
+Test Case 'DeleteRecordRequestTests.testDeleteRecordBuildsPathAndMethod' started at 2025-08-04 10:53:39.757
+Test Case 'DeleteRecordRequestTests.testDeleteRecordBuildsPathAndMethod' passed (0.0 seconds)
+Test Suite 'DeleteRecordRequestTests' passed at 2025-08-04 10:53:39.758
+	 Executed 1 test, with 0 failures (0 unexpected) in 0.0 (0.0) seconds
+Test Suite 'DeleteZoneRequestTests' started at 2025-08-04 10:53:39.758
+Test Case 'DeleteZoneRequestTests.testPathBuilderEncodesZoneId' started at 2025-08-04 10:53:39.758
+Test Case 'DeleteZoneRequestTests.testPathBuilderEncodesZoneId' passed (0.0 seconds)
+Test Suite 'DeleteZoneRequestTests' passed at 2025-08-04 10:53:39.758
+	 Executed 1 test, with 0 failures (0 unexpected) in 0.0 (0.0) seconds
+Test Suite 'GetPrimaryServerRequestTests' started at 2025-08-04 10:53:39.758
+Test Case 'GetPrimaryServerRequestTests.testMethodIsGET' started at 2025-08-04 10:53:39.758
+Test Case 'GetPrimaryServerRequestTests.testMethodIsGET' passed (0.0 seconds)
+Test Case 'GetPrimaryServerRequestTests.testPathBuilderReplacesId' started at 2025-08-04 10:53:39.758
+Test Case 'GetPrimaryServerRequestTests.testPathBuilderReplacesId' passed (0.0 seconds)
+Test Suite 'GetPrimaryServerRequestTests' passed at 2025-08-04 10:53:39.758
+	 Executed 2 tests, with 0 failures (0 unexpected) in 0.0 (0.0) seconds
+Test Suite 'GetRecordRequestTests' started at 2025-08-04 10:53:39.758
+Test Case 'GetRecordRequestTests.testPathBuilderReplacesRecordId' started at 2025-08-04 10:53:39.758
+Test Case 'GetRecordRequestTests.testPathBuilderReplacesRecordId' passed (0.0 seconds)
+Test Suite 'GetRecordRequestTests' passed at 2025-08-04 10:53:39.758
+	 Executed 1 test, with 0 failures (0 unexpected) in 0.0 (0.0) seconds
+Test Suite 'GetZoneRequestTests' started at 2025-08-04 10:53:39.758
+Test Case 'GetZoneRequestTests.testPathBuilderReplacesZoneId' started at 2025-08-04 10:53:39.759
+Test Case 'GetZoneRequestTests.testPathBuilderReplacesZoneId' passed (0.0 seconds)
+Test Suite 'GetZoneRequestTests' passed at 2025-08-04 10:53:39.759
+	 Executed 1 test, with 0 failures (0 unexpected) in 0.0 (0.0) seconds
+Test Suite 'HetznerDNSClientTests' started at 2025-08-04 10:53:39.759
+Test Case 'HetznerDNSClientTests.testCreateRecordRequest' started at 2025-08-04 10:53:39.759
+Test Case 'HetznerDNSClientTests.testCreateRecordRequest' passed (0.002 seconds)
+Test Case 'HetznerDNSClientTests.testCreateRecordSetsContentTypeHeader' started at 2025-08-04 10:53:39.760
+Test Case 'HetznerDNSClientTests.testCreateRecordSetsContentTypeHeader' passed (0.001 seconds)
+Test Case 'HetznerDNSClientTests.testDeleteRecordRequest' started at 2025-08-04 10:53:39.761
+Test Case 'HetznerDNSClientTests.testDeleteRecordRequest' passed (0.101 seconds)
+Test Case 'HetznerDNSClientTests.testListZonesPathBuilder' started at 2025-08-04 10:53:39.862
+Test Case 'HetznerDNSClientTests.testListZonesPathBuilder' passed (0.0 seconds)
+Test Case 'HetznerDNSClientTests.testListZonesReturnsIDs' started at 2025-08-04 10:53:39.862
+Test Case 'HetznerDNSClientTests.testListZonesReturnsIDs' passed (0.002 seconds)
+Test Case 'HetznerDNSClientTests.testUpdateRecordRequest' started at 2025-08-04 10:53:39.865
+Test Case 'HetznerDNSClientTests.testUpdateRecordRequest' passed (0.0 seconds)
+Test Suite 'HetznerDNSClientTests' passed at 2025-08-04 10:53:39.865
+	 Executed 6 tests, with 0 failures (0 unexpected) in 0.106 (0.106) seconds
+Test Suite 'ListPrimaryServersRequestTests' started at 2025-08-04 10:53:39.865
+Test Case 'ListPrimaryServersRequestTests.testPathBuilderAddsZoneIdQueryWhenProvided' started at 2025-08-04 10:53:39.865
+Test Case 'ListPrimaryServersRequestTests.testPathBuilderAddsZoneIdQueryWhenProvided' passed (0.0 seconds)
+Test Case 'ListPrimaryServersRequestTests.testPathBuilderWithoutZoneIdHasNoQuery' started at 2025-08-04 10:53:39.865
+Test Case 'ListPrimaryServersRequestTests.testPathBuilderWithoutZoneIdHasNoQuery' passed (0.1 seconds)
+Test Suite 'ListPrimaryServersRequestTests' passed at 2025-08-04 10:53:39.966
+	 Executed 2 tests, with 0 failures (0 unexpected) in 0.101 (0.101) seconds
+Test Suite 'ListRecordsRequestTests' started at 2025-08-04 10:53:39.966
+Test Case 'ListRecordsRequestTests.testPathBuilderEncodesQuery' started at 2025-08-04 10:53:39.966
+Test Case 'ListRecordsRequestTests.testPathBuilderEncodesQuery' passed (0.0 seconds)
+Test Suite 'ListRecordsRequestTests' passed at 2025-08-04 10:53:39.966
+	 Executed 1 test, with 0 failures (0 unexpected) in 0.0 (0.0) seconds
+Test Suite 'UpdateRecordRequestTests' started at 2025-08-04 10:53:39.966
+Test Case 'UpdateRecordRequestTests.testUpdateRecordBuildsPathAndMethod' started at 2025-08-04 10:53:39.966
+Test Case 'UpdateRecordRequestTests.testUpdateRecordBuildsPathAndMethod' passed (0.0 seconds)
+Test Case 'UpdateRecordRequestTests.testUpdateRecordStoresBody' started at 2025-08-04 10:53:39.967
+Test Case 'UpdateRecordRequestTests.testUpdateRecordStoresBody' passed (0.0 seconds)
+Test Suite 'UpdateRecordRequestTests' passed at 2025-08-04 10:53:39.967
+	 Executed 2 tests, with 0 failures (0 unexpected) in 0.0 (0.0) seconds
+Test Suite 'ClientGeneratorTests' started at 2025-08-04 10:53:39.967
+Test Case 'ClientGeneratorTests.testClientFilesGenerated' started at 2025-08-04 10:53:39.967
+Test Case 'ClientGeneratorTests.testClientFilesGenerated' passed (0.008 seconds)
+Test Case 'ClientGeneratorTests.testEmitRequestGeneratesQueryParameter' started at 2025-08-04 10:53:39.975
+Test Case 'ClientGeneratorTests.testEmitRequestGeneratesQueryParameter' passed (0.107 seconds)
+Test Suite 'ClientGeneratorTests' passed at 2025-08-04 10:53:40.082
+	 Executed 2 tests, with 0 failures (0 unexpected) in 0.115 (0.115) seconds
+Test Suite 'OpenAPIParameterTests' started at 2025-08-04 10:53:40.082
+Test Case 'OpenAPIParameterTests.testSwiftNameReplacesHyphenWithUnderscore' started at 2025-08-04 10:53:40.082
+Test Case 'OpenAPIParameterTests.testSwiftNameReplacesHyphenWithUnderscore' passed (0.0 seconds)
+Test Case 'OpenAPIParameterTests.testSwiftTypeUsesSchemaOrDefaultsToString' started at 2025-08-04 10:53:40.082
+Test Case 'OpenAPIParameterTests.testSwiftTypeUsesSchemaOrDefaultsToString' passed (0.0 seconds)
+Test Suite 'OpenAPIParameterTests' passed at 2025-08-04 10:53:40.082
+	 Executed 2 tests, with 0 failures (0 unexpected) in 0.0 (0.0) seconds
+Test Suite 'OpenAPISwiftTypeTests' started at 2025-08-04 10:53:40.082
+Test Case 'OpenAPISwiftTypeTests.testSchemaPropertyObjectSwiftType' started at 2025-08-04 10:53:40.082
+Test Case 'OpenAPISwiftTypeTests.testSchemaPropertyObjectSwiftType' passed (0.0 seconds)
+Test Case 'OpenAPISwiftTypeTests.testSchemaPropertySwiftType' started at 2025-08-04 10:53:40.083
+Test Case 'OpenAPISwiftTypeTests.testSchemaPropertySwiftType' passed (0.0 seconds)
+Test Case 'OpenAPISwiftTypeTests.testSchemaPropertyUnknownTypeDefaultsToString' started at 2025-08-04 10:53:40.083
+Test Case 'OpenAPISwiftTypeTests.testSchemaPropertyUnknownTypeDefaultsToString' passed (0.0 seconds)
+Test Case 'OpenAPISwiftTypeTests.testSchemaRefSwiftType' started at 2025-08-04 10:53:40.083
+Test Case 'OpenAPISwiftTypeTests.testSchemaRefSwiftType' passed (0.0 seconds)
+Test Suite 'OpenAPISwiftTypeTests' passed at 2025-08-04 10:53:40.083
+	 Executed 4 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
+Test Suite 'SecurityRequirementTests' started at 2025-08-04 10:53:40.083
+Test Case 'SecurityRequirementTests.testDecodesSchemesFromJSON' started at 2025-08-04 10:53:40.083
+Test Case 'SecurityRequirementTests.testDecodesSchemesFromJSON' passed (0.0 seconds)
+Test Case 'SecurityRequirementTests.testEncodesSchemesToJSON' started at 2025-08-04 10:53:40.084
+Test Case 'SecurityRequirementTests.testEncodesSchemesToJSON' passed (0.001 seconds)
+Test Suite 'SecurityRequirementTests' passed at 2025-08-04 10:53:40.085
+	 Executed 2 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
+Test Suite 'SpecLoaderTests' started at 2025-08-04 10:53:40.085
+Test Case 'SpecLoaderTests.testLoadThrowsForEmptyFile' started at 2025-08-04 10:53:40.085
+Test Case 'SpecLoaderTests.testLoadThrowsForEmptyFile' passed (0.003 seconds)
+Test Case 'SpecLoaderTests.testLoadThrowsForInvalidUTF8' started at 2025-08-04 10:53:40.088
+Test Case 'SpecLoaderTests.testLoadThrowsForInvalidUTF8' passed (0.001 seconds)
+Test Case 'SpecLoaderTests.testLoadsJSONRemovingCopyright' started at 2025-08-04 10:53:40.090
+Test Case 'SpecLoaderTests.testLoadsJSONRemovingCopyright' passed (0.001 seconds)
+Test Case 'SpecLoaderTests.testLoadsYAMLAndNormalizesInfoTitle' started at 2025-08-04 10:53:40.091
+Test Case 'SpecLoaderTests.testLoadsYAMLAndNormalizesInfoTitle' passed (0.003 seconds)
+Test Suite 'SpecLoaderTests' passed at 2025-08-04 10:53:40.094
+	 Executed 4 tests, with 0 failures (0 unexpected) in 0.009 (0.009) seconds
+Test Suite 'SpecValidatorTests' started at 2025-08-04 10:53:40.094
+Test Case 'SpecValidatorTests.testDuplicateOperationIdThrows' started at 2025-08-04 10:53:40.094
+Test Case 'SpecValidatorTests.testDuplicateOperationIdThrows' passed (0.0 seconds)
+Test Case 'SpecValidatorTests.testEmptyParameterLocationThrows' started at 2025-08-04 10:53:40.095
+Test Case 'SpecValidatorTests.testEmptyParameterLocationThrows' passed (0.0 seconds)
+Test Case 'SpecValidatorTests.testEmptyParameterNameThrows' started at 2025-08-04 10:53:40.095
+Test Case 'SpecValidatorTests.testEmptyParameterNameThrows' passed (0.0 seconds)
+Test Case 'SpecValidatorTests.testEmptyTitleThrows' started at 2025-08-04 10:53:40.095
+Test Case 'SpecValidatorTests.testEmptyTitleThrows' passed (0.0 seconds)
+Test Case 'SpecValidatorTests.testMissingPathParameterThrows' started at 2025-08-04 10:53:40.096
+Test Case 'SpecValidatorTests.testMissingPathParameterThrows' passed (0.0 seconds)
+Test Case 'SpecValidatorTests.testPathParameterMustBeRequired' started at 2025-08-04 10:53:40.096
+Test Case 'SpecValidatorTests.testPathParameterMustBeRequired' passed (0.0 seconds)
+Test Case 'SpecValidatorTests.testUnknownSecuritySchemeThrows' started at 2025-08-04 10:53:40.096
+Test Case 'SpecValidatorTests.testUnknownSecuritySchemeThrows' passed (0.0 seconds)
+Test Case 'SpecValidatorTests.testUnresolvedSchemaReferenceThrows' started at 2025-08-04 10:53:40.096
+Test Case 'SpecValidatorTests.testUnresolvedSchemaReferenceThrows' passed (0.0 seconds)
+Test Suite 'SpecValidatorTests' passed at 2025-08-04 10:53:40.096
+	 Executed 8 tests, with 0 failures (0 unexpected) in 0.002 (0.002) seconds
+Test Suite 'StringExtensionTests' started at 2025-08-04 10:53:40.096
+Test Case 'StringExtensionTests.testCamelCased' started at 2025-08-04 10:53:40.096
+Test Case 'StringExtensionTests.testCamelCased' passed (0.0 seconds)
+Test Case 'StringExtensionTests.testCamelCasedEmptyString' started at 2025-08-04 10:53:40.097
+Test Case 'StringExtensionTests.testCamelCasedEmptyString' passed (0.0 seconds)
+Test Case 'StringExtensionTests.testCamelCasedLeadingUnderscore' started at 2025-08-04 10:53:40.097
+Test Case 'StringExtensionTests.testCamelCasedLeadingUnderscore' passed (0.0 seconds)
+Test Case 'StringExtensionTests.testCamelCasedMultipleUnderscores' started at 2025-08-04 10:53:40.097
+Test Case 'StringExtensionTests.testCamelCasedMultipleUnderscores' passed (0.0 seconds)
+Test Case 'StringExtensionTests.testCamelCasedNumbers' started at 2025-08-04 10:53:40.097
+Test Case 'StringExtensionTests.testCamelCasedNumbers' passed (0.0 seconds)
+Test Suite 'StringExtensionTests' passed at 2025-08-04 10:53:40.097
+	 Executed 5 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
+Test Suite 'HetznerDNSModelsTests' started at 2025-08-04 10:53:40.097
+Test Case 'HetznerDNSModelsTests.testBulkRecordsCreateRequestCodable' started at 2025-08-04 10:53:40.097
+Test Case 'HetznerDNSModelsTests.testBulkRecordsCreateRequestCodable' passed (0.001 seconds)
+Test Case 'HetznerDNSModelsTests.testBulkRecordsUpdateRequestCodable' started at 2025-08-04 10:53:40.098
+Test Case 'HetznerDNSModelsTests.testBulkRecordsUpdateRequestCodable' passed (0.001 seconds)
+Test Case 'HetznerDNSModelsTests.testPrimaryServerCreateCodable' started at 2025-08-04 10:53:40.098
+Test Case 'HetznerDNSModelsTests.testPrimaryServerCreateCodable' passed (0.0 seconds)
+Test Case 'HetznerDNSModelsTests.testPrimaryServersResponseDecodes' started at 2025-08-04 10:53:40.099
+Test Case 'HetznerDNSModelsTests.testPrimaryServersResponseDecodes' passed (0.001 seconds)
+Test Case 'HetznerDNSModelsTests.testRecordResponseDecodes' started at 2025-08-04 10:53:40.100
+Test Case 'HetznerDNSModelsTests.testRecordResponseDecodes' passed (0.0 seconds)
+Test Case 'HetznerDNSModelsTests.testValidateZoneFileResponseDecodes' started at 2025-08-04 10:53:40.100
+Test Case 'HetznerDNSModelsTests.testValidateZoneFileResponseDecodes' passed (0.0 seconds)
+Test Case 'HetznerDNSModelsTests.testZoneCreateRequestCodable' started at 2025-08-04 10:53:40.100
+Test Case 'HetznerDNSModelsTests.testZoneCreateRequestCodable' passed (0.0 seconds)
+Test Case 'HetznerDNSModelsTests.testZoneResponseDecoding' started at 2025-08-04 10:53:40.101
+Test Case 'HetznerDNSModelsTests.testZoneResponseDecoding' passed (0.0 seconds)
+Test Suite 'HetznerDNSModelsTests' passed at 2025-08-04 10:53:40.101
+	 Executed 8 tests, with 0 failures (0 unexpected) in 0.004 (0.004) seconds
+Test Suite 'HetznerDNSRequestTests' started at 2025-08-04 10:53:40.101
+Test Case 'HetznerDNSRequestTests.testBulkCreateRecordsMethodIsPost' started at 2025-08-04 10:53:40.101
+Test Case 'HetznerDNSRequestTests.testBulkCreateRecordsMethodIsPost' passed (0.0 seconds)
+Test Case 'HetznerDNSRequestTests.testBulkCreateRecordsPath' started at 2025-08-04 10:53:40.101
+Test Case 'HetznerDNSRequestTests.testBulkCreateRecordsPath' passed (0.0 seconds)
+Test Case 'HetznerDNSRequestTests.testBulkUpdateRecordsMethodIsPut' started at 2025-08-04 10:53:40.101
+Test Case 'HetznerDNSRequestTests.testBulkUpdateRecordsMethodIsPut' passed (0.0 seconds)
+Test Case 'HetznerDNSRequestTests.testBulkUpdateRecordsPath' started at 2025-08-04 10:53:40.101
+Test Case 'HetznerDNSRequestTests.testBulkUpdateRecordsPath' passed (0.0 seconds)
+Test Case 'HetznerDNSRequestTests.testCreateZoneMethodIsPost' started at 2025-08-04 10:53:40.102
+Test Case 'HetznerDNSRequestTests.testCreateZoneMethodIsPost' passed (0.0 seconds)
+Test Case 'HetznerDNSRequestTests.testCreateZonePath' started at 2025-08-04 10:53:40.102
+Test Case 'HetznerDNSRequestTests.testCreateZonePath' passed (0.0 seconds)
+Test Case 'HetznerDNSRequestTests.testExportZoneFileMethodIsGet' started at 2025-08-04 10:53:40.102
+Test Case 'HetznerDNSRequestTests.testExportZoneFileMethodIsGet' passed (0.1 seconds)
+Test Case 'HetznerDNSRequestTests.testExportZoneFilePathIncludesZoneID' started at 2025-08-04 10:53:40.202
+Test Case 'HetznerDNSRequestTests.testExportZoneFilePathIncludesZoneID' passed (0.0 seconds)
+Test Case 'HetznerDNSRequestTests.testImportZoneFileMethodIsPost' started at 2025-08-04 10:53:40.203
+Test Case 'HetznerDNSRequestTests.testImportZoneFileMethodIsPost' passed (0.0 seconds)
+Test Case 'HetznerDNSRequestTests.testImportZoneFilePathIncludesZoneID' started at 2025-08-04 10:53:40.203
+Test Case 'HetznerDNSRequestTests.testImportZoneFilePathIncludesZoneID' passed (0.0 seconds)
+Test Case 'HetznerDNSRequestTests.testUpdatePrimaryServerMethodIsPut' started at 2025-08-04 10:53:40.203
+Test Case 'HetznerDNSRequestTests.testUpdatePrimaryServerMethodIsPut' passed (0.0 seconds)
+Test Case 'HetznerDNSRequestTests.testUpdatePrimaryServerPathIncludesID' started at 2025-08-04 10:53:40.203
+Test Case 'HetznerDNSRequestTests.testUpdatePrimaryServerPathIncludesID' passed (0.0 seconds)
+Test Case 'HetznerDNSRequestTests.testUpdateZoneMethodIsPut' started at 2025-08-04 10:53:40.204
+Test Case 'HetznerDNSRequestTests.testUpdateZoneMethodIsPut' passed (0.0 seconds)
+Test Case 'HetznerDNSRequestTests.testUpdateZonePathIncludesID' started at 2025-08-04 10:53:40.204
+Test Case 'HetznerDNSRequestTests.testUpdateZonePathIncludesID' passed (0.0 seconds)
+Test Case 'HetznerDNSRequestTests.testValidateZoneFileMethodIsPost' started at 2025-08-04 10:53:40.204
+Test Case 'HetznerDNSRequestTests.testValidateZoneFileMethodIsPost' passed (0.0 seconds)
+Test Case 'HetznerDNSRequestTests.testValidateZoneFilePath' started at 2025-08-04 10:53:40.204
+Test Case 'HetznerDNSRequestTests.testValidateZoneFilePath' passed (0.0 seconds)
+Test Suite 'HetznerDNSRequestTests' passed at 2025-08-04 10:53:40.204
+	 Executed 16 tests, with 0 failures (0 unexpected) in 0.103 (0.103) seconds
+Test Suite 'PublishingFrontendTests' started at 2025-08-04 10:53:40.205
+Test Case 'PublishingFrontendTests.testLoadPublishingConfigFailsForMissingFile' started at 2025-08-04 10:53:40.205
+Test Case 'PublishingFrontendTests.testLoadPublishingConfigFailsForMissingFile' passed (0.0 seconds)
+Test Case 'PublishingFrontendTests.testLoadPublishingConfigParsesYaml' started at 2025-08-04 10:53:40.205
+Test Case 'PublishingFrontendTests.testLoadPublishingConfigParsesYaml' passed (0.003 seconds)
+Test Case 'PublishingFrontendTests.testPublishingConfigCustomValues' started at 2025-08-04 10:53:40.208
+Test Case 'PublishingFrontendTests.testPublishingConfigCustomValues' passed (0.0 seconds)
+Test Case 'PublishingFrontendTests.testPublishingConfigDefaultValues' started at 2025-08-04 10:53:40.208
+Test Case 'PublishingFrontendTests.testPublishingConfigDefaultValues' passed (0.0 seconds)
+Test Case 'PublishingFrontendTests.testServerRejectsNonGetRequests' started at 2025-08-04 10:53:40.208
+Test Case 'PublishingFrontendTests.testServerRejectsNonGetRequests' passed (0.017 seconds)
+Test Case 'PublishingFrontendTests.testServerReturns404ForMissingFile' started at 2025-08-04 10:53:40.225
+Test Case 'PublishingFrontendTests.testServerReturns404ForMissingFile' passed (0.002 seconds)
+Test Case 'PublishingFrontendTests.testServerServesIndex' started at 2025-08-04 10:53:40.228
+Test Case 'PublishingFrontendTests.testServerServesIndex' passed (0.008 seconds)
+Test Case 'PublishingFrontendTests.testServerSetsContentTypeHeader' started at 2025-08-04 10:53:40.236
+Test Case 'PublishingFrontendTests.testServerSetsContentTypeHeader' passed (0.004 seconds)
+Test Suite 'PublishingFrontendTests' passed at 2025-08-04 10:53:40.240
+	 Executed 8 tests, with 0 failures (0 unexpected) in 0.035 (0.035) seconds
+Test Suite 'Route53ClientTests' started at 2025-08-04 10:53:40.240
+Test Case 'Route53ClientTests.testCreateRecordThrows' started at 2025-08-04 10:53:40.240
+Test Case 'Route53ClientTests.testCreateRecordThrows' passed (0.0 seconds)
+Test Case 'Route53ClientTests.testDeleteRecordThrows' started at 2025-08-04 10:53:40.240
+Test Case 'Route53ClientTests.testDeleteRecordThrows' passed (0.0 seconds)
+Test Case 'Route53ClientTests.testListZonesThrows' started at 2025-08-04 10:53:40.240
+Test Case 'Route53ClientTests.testListZonesThrows' passed (0.0 seconds)
+Test Case 'Route53ClientTests.testUpdateRecordThrows' started at 2025-08-04 10:53:40.241
+Test Case 'Route53ClientTests.testUpdateRecordThrows' passed (0.0 seconds)
+Test Suite 'Route53ClientTests' passed at 2025-08-04 10:53:40.241
+	 Executed 4 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
+Test Suite 'AsyncHTTPClientDriverTests' started at 2025-08-04 10:53:40.241
+Test Case 'AsyncHTTPClientDriverTests.testExecutePerformsRequest' started at 2025-08-04 10:53:40.241
+Test Case 'AsyncHTTPClientDriverTests.testExecutePerformsRequest' passed (0.006 seconds)
+Test Case 'AsyncHTTPClientDriverTests.testExecuteSendsBody' started at 2025-08-04 10:53:40.247
+Test Case 'AsyncHTTPClientDriverTests.testExecuteSendsBody' passed (0.002 seconds)
+Test Suite 'AsyncHTTPClientDriverTests' passed at 2025-08-04 10:53:40.248
+	 Executed 2 tests, with 0 failures (0 unexpected) in 0.008 (0.008) seconds
+Test Suite 'CertificateManagerTests' started at 2025-08-04 10:53:40.248
+Test Case 'CertificateManagerTests.testStartSchedulesRepeatedRuns' started at 2025-08-04 10:53:40.248
+Test Case 'CertificateManagerTests.testStartSchedulesRepeatedRuns' passed (1.002 seconds)
+Test Case 'CertificateManagerTests.testStopCancelsFutureRuns' started at 2025-08-04 10:53:41.250
+Test Case 'CertificateManagerTests.testStopCancelsFutureRuns' passed (3.004 seconds)
+Test Case 'CertificateManagerTests.testTriggerNowRunsScript' started at 2025-08-04 10:53:44.254
+Test Case 'CertificateManagerTests.testTriggerNowRunsScript' passed (1.003 seconds)
+Test Suite 'CertificateManagerTests' passed at 2025-08-04 10:53:45.257
+	 Executed 3 tests, with 0 failures (0 unexpected) in 5.008 (5.008) seconds
+Test Suite 'GatewayPluginTests' started at 2025-08-04 10:53:45.257
+Test Case 'GatewayPluginTests.testDefaultPrepareReturnsSameRequest' started at 2025-08-04 10:53:45.257
+Test Case 'GatewayPluginTests.testDefaultPrepareReturnsSameRequest' passed (0.0 seconds)
+Test Case 'GatewayPluginTests.testDefaultRespondReturnsSameResponse' started at 2025-08-04 10:53:45.257
+Test Case 'GatewayPluginTests.testDefaultRespondReturnsSameResponse' passed (0.0 seconds)
+Test Suite 'GatewayPluginTests' passed at 2025-08-04 10:53:45.258
+	 Executed 2 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
+Test Suite 'GatewayServerTests' started at 2025-08-04 10:53:45.258
+Test Case 'GatewayServerTests.testHealthEndpointResponds' started at 2025-08-04 10:53:45.258
+Test Case 'GatewayServerTests.testHealthEndpointResponds' passed (0.103 seconds)
+Test Case 'GatewayServerTests.testHealthEndpointSetsJSONContentType' started at 2025-08-04 10:53:45.361
+Test Case 'GatewayServerTests.testHealthEndpointSetsJSONContentType' passed (0.108 seconds)
+Test Case 'GatewayServerTests.testMetricsEndpointResponds' started at 2025-08-04 10:53:45.469
+Test Case 'GatewayServerTests.testMetricsEndpointResponds' passed (0.102 seconds)
+Test Case 'GatewayServerTests.testPluginCanRewriteRequestAndResponse' started at 2025-08-04 10:53:45.571
+Test Case 'GatewayServerTests.testPluginCanRewriteRequestAndResponse' passed (0.103 seconds)
+Test Case 'GatewayServerTests.testPluginsPrepareInRegistrationOrder' started at 2025-08-04 10:53:45.674
+Test Case 'GatewayServerTests.testPluginsPrepareInRegistrationOrder' passed (0.103 seconds)
+Test Case 'GatewayServerTests.testPluginsRespondInReverseOrder' started at 2025-08-04 10:53:45.777
+Test Case 'GatewayServerTests.testPluginsRespondInReverseOrder' passed (0.103 seconds)
+Test Case 'GatewayServerTests.testUnknownPathReturns404' started at 2025-08-04 10:53:45.880
+Test Case 'GatewayServerTests.testUnknownPathReturns404' passed (0.103 seconds)
+Test Suite 'GatewayServerTests' passed at 2025-08-04 10:53:45.983
+	 Executed 7 tests, with 0 failures (0 unexpected) in 0.725 (0.725) seconds
+Test Suite 'HTTPKernelTests' started at 2025-08-04 10:53:45.983
+Test Case 'HTTPKernelTests.testKernelPropagatesErrors' started at 2025-08-04 10:53:45.983
+Test Case 'HTTPKernelTests.testKernelPropagatesErrors' passed (0.0 seconds)
+Test Case 'HTTPKernelTests.testKernelRoutesRequest' started at 2025-08-04 10:53:45.983
+Test Case 'HTTPKernelTests.testKernelRoutesRequest' passed (0.0 seconds)
+Test Suite 'HTTPKernelTests' passed at 2025-08-04 10:53:45.983
+	 Executed 2 tests, with 0 failures (0 unexpected) in 0.0 (0.0) seconds
+Test Suite 'HTTPRequestTests' started at 2025-08-04 10:53:45.983
+Test Case 'HTTPRequestTests.testRequestDefaults' started at 2025-08-04 10:53:45.983
+Test Case 'HTTPRequestTests.testRequestDefaults' passed (0.0 seconds)
+Test Case 'HTTPRequestTests.testRequestInitializerStoresValues' started at 2025-08-04 10:53:45.983
+Test Case 'HTTPRequestTests.testRequestInitializerStoresValues' passed (0.0 seconds)
+Test Case 'HTTPRequestTests.testRequestMutation' started at 2025-08-04 10:53:45.983
+Test Case 'HTTPRequestTests.testRequestMutation' passed (0.0 seconds)
+Test Suite 'HTTPRequestTests' passed at 2025-08-04 10:53:45.984
+	 Executed 3 tests, with 0 failures (0 unexpected) in 0.0 (0.0) seconds
+Test Suite 'HTTPResponseDefaultsTests' started at 2025-08-04 10:53:45.984
+Test Case 'HTTPResponseDefaultsTests.testNoBodyCodable' started at 2025-08-04 10:53:45.984
+Test Case 'HTTPResponseDefaultsTests.testNoBodyCodable' passed (0.001 seconds)
+Test Case 'HTTPResponseDefaultsTests.testResponseBodyMutation' started at 2025-08-04 10:53:45.984
+Test Case 'HTTPResponseDefaultsTests.testResponseBodyMutation' passed (0.0 seconds)
+Test Case 'HTTPResponseDefaultsTests.testResponseDefaults' started at 2025-08-04 10:53:45.984
+Test Case 'HTTPResponseDefaultsTests.testResponseDefaults' passed (0.0 seconds)
+Test Case 'HTTPResponseDefaultsTests.testResponseHeadersMutation' started at 2025-08-04 10:53:45.985
+Test Case 'HTTPResponseDefaultsTests.testResponseHeadersMutation' passed (0.0 seconds)
+Test Case 'HTTPResponseDefaultsTests.testResponseInitializerStoresValues' started at 2025-08-04 10:53:45.985
+Test Case 'HTTPResponseDefaultsTests.testResponseInitializerStoresValues' passed (0.0 seconds)
+Test Case 'HTTPResponseDefaultsTests.testResponseStatusMutation' started at 2025-08-04 10:53:45.985
+Test Case 'HTTPResponseDefaultsTests.testResponseStatusMutation' passed (0.0 seconds)
+Test Suite 'HTTPResponseDefaultsTests' passed at 2025-08-04 10:53:45.985
+	 Executed 6 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
+Test Suite 'LoggingPluginTests' started at 2025-08-04 10:53:45.985
+Test Case 'LoggingPluginTests.testLoggingPluginPassThrough' started at 2025-08-04 10:53:45.985
+-> GET /
+<- 200 for /
+Test Case 'LoggingPluginTests.testLoggingPluginPassThrough' passed (0.201 seconds)
+Test Suite 'LoggingPluginTests' passed at 2025-08-04 10:53:46.186
+	 Executed 1 test, with 0 failures (0 unexpected) in 0.201 (0.201) seconds
+Test Suite 'NIOHTTPServerTests' started at 2025-08-04 10:53:46.186
+Test Case 'NIOHTTPServerTests.testServerHandlesConcurrentRequests' started at 2025-08-04 10:53:46.186
+Test Case 'NIOHTTPServerTests.testServerHandlesConcurrentRequests' passed (0.004 seconds)
+Test Case 'NIOHTTPServerTests.testServerReleasesPortOnStop' started at 2025-08-04 10:53:46.190
+Test Case 'NIOHTTPServerTests.testServerReleasesPortOnStop' passed (0.101 seconds)
+Test Case 'NIOHTTPServerTests.testServerResponds' started at 2025-08-04 10:53:46.291
+Test Case 'NIOHTTPServerTests.testServerResponds' passed (0.003 seconds)
+Test Suite 'NIOHTTPServerTests' passed at 2025-08-04 10:53:46.294
+	 Executed 3 tests, with 0 failures (0 unexpected) in 0.108 (0.108) seconds
+Test Suite 'PublishingFrontendPluginTests' started at 2025-08-04 10:53:46.294
+Test Case 'PublishingFrontendPluginTests.testPluginIgnoresNonGETRequests' started at 2025-08-04 10:53:46.294
+Test Case 'PublishingFrontendPluginTests.testPluginIgnoresNonGETRequests' passed (0.002 seconds)
+Test Case 'PublishingFrontendPluginTests.testPluginPassThroughWhenFileMissing' started at 2025-08-04 10:53:46.295
+Test Case 'PublishingFrontendPluginTests.testPluginPassThroughWhenFileMissing' passed (0.0 seconds)
+Test Case 'PublishingFrontendPluginTests.testPluginServesFile' started at 2025-08-04 10:53:46.296
+Test Case 'PublishingFrontendPluginTests.testPluginServesFile' passed (0.001 seconds)
+Test Case 'PublishingFrontendPluginTests.testPluginSetsContentTypeHeader' started at 2025-08-04 10:53:46.297
+Test Case 'PublishingFrontendPluginTests.testPluginSetsContentTypeHeader' passed (0.001 seconds)
+Test Suite 'PublishingFrontendPluginTests' passed at 2025-08-04 10:53:46.298
+	 Executed 4 tests, with 0 failures (0 unexpected) in 0.004 (0.004) seconds
+Test Suite 'URLSessionHTTPClientTests' started at 2025-08-04 10:53:46.298
+Test Case 'URLSessionHTTPClientTests.testExecuteCollectsMultipleHeaders' started at 2025-08-04 10:53:46.298
+Test Case 'URLSessionHTTPClientTests.testExecuteCollectsMultipleHeaders' passed (0.001 seconds)
+Test Case 'URLSessionHTTPClientTests.testExecuteHandlesEmptyBody' started at 2025-08-04 10:53:46.299
+Test Case 'URLSessionHTTPClientTests.testExecuteHandlesEmptyBody' passed (0.001 seconds)
+Test Case 'URLSessionHTTPClientTests.testExecutePerformsRequest' started at 2025-08-04 10:53:46.299
+Test Case 'URLSessionHTTPClientTests.testExecutePerformsRequest' passed (0.001 seconds)
+Test Suite 'URLSessionHTTPClientTests' passed at 2025-08-04 10:53:46.300
+	 Executed 3 tests, with 0 failures (0 unexpected) in 0.002 (0.002) seconds
+Test Suite 'release.xctest' passed at 2025-08-04 10:53:46.300
+	 Executed 139 tests, with 0 failures (0 unexpected) in 6.756 (6.756) seconds
+Test Suite 'All tests' passed at 2025-08-04 10:53:46.301
+	 Executed 139 tests, with 0 failures (0 unexpected) in 6.756 (6.756) seconds
+◇ Test run started.
+↳ Testing Library Version: 6.1 (43b6f88e2f2712e)
+↳ Target Platform: x86_64-unknown-linux-gnu
+✔ Test run with 0 tests passed after 0.001 seconds.
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- clarify Route53Client method parameters for zone and record operations
- add SpecValidator tests for empty titles and parameter fields
- record coverage rise and test count in project documentation

## Testing
- `Scripts/run-tests.sh`
- `llvm-profdata-19 merge -sparse .build/release/codecov/*.profraw -o /tmp/merged.profdata`
- `llvm-cov-19 report .build/x86_64-unknown-linux-gnu/release/FountainCoachPackageTests.xctest -instr-profile /tmp/merged.profdata`
- `llvm-cov-19 report -ignore-filename-regex='Tests|\.build' .build/x86_64-unknown-linux-gnu/release/FountainCoachPackageTests.xctest -instr-profile /tmp/merged.profdata`


------
https://chatgpt.com/codex/tasks/task_e_68908ed8070c83259bb5c2650b1e978e