### PR TITLE
Document camelCased edge cases and extend tests

### DIFF
--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -5,10 +5,10 @@
 Running `swift test --enable-code-coverage` and analysing with `llvm-cov` produced the following totals:
 
 ```
-TOTAL                                          31974   26506    17.10%   14466 11488    20.59%   99839 81363    18.51%
+TOTAL                                          31982   26475    17.22%   14474 11475    20.72%   99851 81192    18.69%
 ```
 
-The repository contains **99,839** executable lines, with **18,476** lines covered (approx. **18.51%** line coverage).
+The repository contains **99,851** executable lines, with **18,659** lines covered (approx. **18.69%** line coverage).
 
 ### Repository source coverage
 
@@ -83,6 +83,6 @@ The new ``DeletePrimaryServerRequestTests`` raise the total test count to **105*
 - The new ``CamelCasedLeadingUnderscore``, ``CamelCasedNumbers``, and ``EmitRequestGeneratesQueryParameter`` tests raise the total test count to **136**.
 
 - The new ``SpecValidator`` empty title, parameter name, and parameter location tests raise the total test count to **139**.
-
+- The new ``CamelCasedTrailingUnderscore`` and ``CamelCasedUppercaseInput`` tests raise the total test count to **141**.
 ---
 © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainCodex/ServerGenerator/ServerGenerator.swift
+++ b/Sources/FountainCodex/ServerGenerator/ServerGenerator.swift
@@ -199,6 +199,7 @@ extension String {
     /// Returns the string converted from `snake_case` to `camelCase`.
     /// Words are split on underscores with the first word lowercased and
     /// remaining words capitalized before joining them together.
+    /// Empty segments from leading or trailing underscores are ignored.
     var camelCased: String {
         guard !isEmpty else { return self }
         // Break the identifier into components separated by underscores.

--- a/Tests/ClientGeneratorTests/StringExtensionTests.swift
+++ b/Tests/ClientGeneratorTests/StringExtensionTests.swift
@@ -27,6 +27,16 @@ final class StringExtensionTests: XCTestCase {
     func testCamelCasedNumbers() {
         XCTAssertEqual("api_v2_endpoint".camelCased, "apiV2Endpoint")
     }
+
+    /// Trailing underscores are dropped during conversion.
+    func testCamelCasedTrailingUnderscore() {
+        XCTAssertEqual("value_".camelCased, "value")
+    }
+
+    /// Uppercase input is normalized with the first segment lowercased.
+    func testCamelCasedUppercaseInput() {
+        XCTAssertEqual("FOO_BAR".camelCased, "fooBar")
+    }
 }
 
 // © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,7 +28,7 @@ As modules gain documentation, brief summaries are added here.
 - **APIClient** – initializer and URLSession extension now documented for clarity.
 - **URLSessionHTTPClientTests** – updated for Linux compatibility ensuring network client coverage.
 - **OpenAPISpec.swiftType** – documented helper converting schemas to Swift types.
-- **String.camelCased** – extension for transforming snake case identifiers; implementation now comments underscore splitting and recombination logic for clarity.
+- **String.camelCased** – extension for transforming snake case identifiers; now documents that leading and trailing underscores are ignored with comments explaining underscore splitting and recombination logic for clarity.
 - **Agent.main** – entry point usage instructions are now documented.
 - **publishing-frontend CLI** – documented main entrypoint starting the static server.
 - **clientgen-service CLI** – wrapper around GeneratorCLI is now documented.


### PR DESCRIPTION
## Summary
- document that `String.camelCased` drops leading and trailing underscores
- test `camelCased` behaviour for trailing underscores and uppercase input
- refresh coverage report and documentation notes

## Testing
- `Scripts/run-tests.sh`
- `llvm-cov-19 report .build/x86_64-unknown-linux-gnu/release/FountainCoachPackageTests.xctest -instr-profile .build/x86_64-unknown-linux-gnu/release/codecov/default.profdata`


------
https://chatgpt.com/codex/tasks/task_e_68909697cdfc8325885da1e9fa8388a3