### PR TITLE
Document Hetzner DNS auth header and test coverage

### DIFF
--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -5,10 +5,10 @@
 Running `swift test --enable-code-coverage` and analysing with `llvm-cov` produced the following totals:
 
 ```
-TOTAL                                          32007   26467    17.31%   14492 11475    20.82%   99908 81167    18.76%
+TOTAL                                          32029   26203    18.19%   14509 11248    22.48%   99966 80748    19.22%
 ```
 
-The repository contains **99,908** executable lines, with **18,741** lines covered (approx. **18.76%** line coverage).
+The repository contains **99,966** executable lines, with **19,218** lines covered (approx. **19.22%** line coverage).
 
 ### Repository source coverage
 
@@ -86,5 +86,6 @@ The new ``DeletePrimaryServerRequestTests`` raise the total test count to **105*
 - The new ``CamelCasedTrailingUnderscore`` and ``CamelCasedUppercaseInput`` tests raise the total test count to **141**.
 - The new ``ZoneUpdateRequestCodable`` and ``ZonesResponseDecodes`` tests raise the total test count to **143**.
 - The new ``LoadPublishingConfigFailsForInvalidYAML`` and ``LoadPublishingConfigFailsForNonNumericPort`` tests raise the total test count to **145**.
+- The new ``UpdateRecordSetsAuthHeader`` and ``DeleteRecordSetsAuthHeader`` tests raise the total test count to **147**.
 ---
 © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/PublishingFrontend/DNSProvider.swift
+++ b/Sources/PublishingFrontend/DNSProvider.swift
@@ -21,6 +21,7 @@ public struct HetznerDNSClient: DNSProvider {
     let api: APIClient
 
     /// Creates a new client with the given API token and session.
+    /// The token is attached as an `Auth-API-Token` header on every request.
     public init(token: String, session: HTTPSession = URLSession.shared) {
         self.api = APIClient(
             baseURL: URL(string: "https://dns.hetzner.com/api/v1")!,

--- a/docs/README.md
+++ b/docs/README.md
@@ -56,6 +56,7 @@ As modules gain documentation, brief summaries are added here.
 - **GatewayServer.start** and **stop** – documentation now explains certificate manager activation and graceful shutdown.
 - **APIClient.baseURL**, **session**, and **defaultHeaders** – stored properties document connection details.
 - **HetznerDNSClient.api** – underlying HTTP client property now documented.
+- **HetznerDNSClient.init** – notes automatic `Auth-API-Token` header injection for all requests.
 - **ServerGenerator emit helpers** – private functions now describe generated source responsibilities.
 - **BulkRecordsCreateRequest** and **validateZoneFileResponse** – documented models for batch record creation and zone validation feedback.
 - **PublishingFrontendPlugin.rootPath** – documented property describing the static file directory.


### PR DESCRIPTION
## Summary
- clarify that `HetznerDNSClient` attaches its API token as an `Auth-API-Token` header
- cover token header behaviour for record updates and deletions
- track coverage gains and documentation progress

## Testing
- `swift test --enable-code-coverage`

------
https://chatgpt.com/codex/tasks/task_e_6890a77b8b3c832594b20d9909fbed64