### PR TITLE
Expand LoggingPlugin tests and documentation

### DIFF
--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -5,10 +5,10 @@
 Running `swift test --enable-code-coverage` and analysing with `llvm-cov` produced the following totals:
 
 ```
-TOTAL                                          32029   26203    18.19%   14509 11248    22.48%   99966 80748    19.22%
+TOTAL                                          32061   26287    18.01%   14527 11401    21.52%   99999 80550    19.45%
 ```
 
-The repository contains **99,966** executable lines, with **19,218** lines covered (approx. **19.22%** line coverage).
+The repository contains **99,999** executable lines, with **19,449** lines covered (approx. **19.45%** line coverage).
 
 ### Repository source coverage
 
@@ -88,5 +88,6 @@ The new ``DeletePrimaryServerRequestTests`` raise the total test count to **105*
 - The new ``LoadPublishingConfigFailsForInvalidYAML`` and ``LoadPublishingConfigFailsForNonNumericPort`` tests raise the total test count to **145**.
 - The new ``UpdateRecordSetsAuthHeader`` and ``DeleteRecordSetsAuthHeader`` tests raise the total test count to **147**.
 - The new ``AsyncHTTPClientDriver`` unreachable host test and metrics endpoint header and body tests raise the total test count to **150**.
+- The new ``LoggingPlugin`` header and body preservation tests raise the total test count to **152**.
 ---
 © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/GatewayApp/LoggingPlugin.swift
+++ b/Sources/GatewayApp/LoggingPlugin.swift
@@ -10,8 +10,8 @@ public struct LoggingPlugin: GatewayPlugin {
     /// - Parameter request: The request about to be routed.
     /// - Returns: The unmodified request for further processing.
     public func prepare(_ request: HTTPRequest) async throws -> HTTPRequest {
-        print("-> \(request.method) \(request.path)")
-        return request
+        print("-> \(request.method) \(request.path)") // emit request line for debugging
+        return request // forward the request unchanged
     }
 
     /// Logs the response returned by the router.
@@ -20,8 +20,8 @@ public struct LoggingPlugin: GatewayPlugin {
     ///   - request: The original request that produced the response.
     /// - Returns: The response passed through unchanged.
     public func respond(_ response: HTTPResponse, for request: HTTPRequest) async throws -> HTTPResponse {
-        print("<- \(response.status) for \(request.path)")
-        return response
+        print("<- \(response.status) for \(request.path)") // log response status
+        return response // propagate original response
     }
 }
 

--- a/Tests/IntegrationRuntimeTests/LoggingPluginTests.swift
+++ b/Tests/IntegrationRuntimeTests/LoggingPluginTests.swift
@@ -13,6 +13,26 @@ final class LoggingPluginTests: XCTestCase {
         let resp = try await plugin.respond(response, for: req)
         XCTAssertEqual(resp.status, response.status)
     }
+
+    /// Ensures headers and body are forwarded unchanged when preparing requests.
+    func testPreparePreservesHeadersAndBody() async throws {
+        let plugin = LoggingPlugin()
+        let body = Data("hello".utf8)
+        let req = HTTPRequest(method: "POST", path: "/data", headers: ["Foo": "Bar"], body: body)
+        let prepared = try await plugin.prepare(req)
+        XCTAssertEqual(prepared.headers, req.headers)
+        XCTAssertEqual(prepared.body, req.body)
+    }
+
+    /// Ensures responses retain headers and body after logging.
+    func testRespondPreservesHeadersAndBody() async throws {
+        let plugin = LoggingPlugin()
+        let response = HTTPResponse(status: 201, headers: ["X": "1"], body: Data("ok".utf8))
+        let req = HTTPRequest(method: "GET", path: "/")
+        let returned = try await plugin.respond(response, for: req)
+        XCTAssertEqual(returned.headers, response.headers)
+        XCTAssertEqual(returned.body, response.body)
+    }
 }
 
 // © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,7 @@ As modules gain documentation, brief summaries are added here.
 - **HTTPHandler** – internal request dispatcher within `NIOHTTPServer` is now thoroughly documented.
 - **NIOHTTPServer.init** – initializer now documents kernel and event loop group parameters.
 - **LoggingPlugin** – prints requests and responses for debugging.
+- **LoggingPlugin.prepare** and **respond** – inline comments explain logging without mutating headers or bodies.
 - **GatewayPlugin** – protocol for request and response middleware.
 - **GatewayPlugin.prepare** and **respond** – default implementations now explain parameters and return values.
 - **CertificateManager** – runs periodic certificate renewal scripts.

--- a/logs/build-20250804132540.log
+++ b/logs/build-20250804132540.log
@@ -1,0 +1,614 @@
+Fetching https://github.com/apple/swift-nio.git
+Fetching https://github.com/swift-server/async-http-client.git
+Fetching https://github.com/jpsim/Yams.git
+[1/10997] Fetching yams
+[2/25062] Fetching yams, async-http-client
+[19675/102251] Fetching yams, async-http-client, swift-nio
+Fetched https://github.com/jpsim/Yams.git from cache (1.56s)
+[61923/91254] Fetching async-http-client, swift-nio
+Fetched https://github.com/swift-server/async-http-client.git from cache (4.69s)
+Fetched https://github.com/apple/swift-nio.git from cache (4.79s)
+Computing version for https://github.com/jpsim/Yams.git
+Computed https://github.com/jpsim/Yams.git at 5.4.0 (7.35s)
+Computing version for https://github.com/swift-server/async-http-client.git
+Computed https://github.com/swift-server/async-http-client.git at 1.26.1 (0.59s)
+Fetching https://github.com/apple/swift-log.git
+Fetching https://github.com/apple/swift-atomics.git
+Fetching https://github.com/apple/swift-algorithms.git
+[1/1808] Fetching swift-atomics
+[200/5688] Fetching swift-atomics, swift-log
+[3478/11647] Fetching swift-atomics, swift-log, swift-algorithms
+Fetched https://github.com/apple/swift-atomics.git from cache (0.56s)
+Fetching https://github.com/apple/swift-nio-transport-services.git
+Fetched https://github.com/apple/swift-log.git from cache (0.65s)
+Fetched https://github.com/apple/swift-algorithms.git from cache (0.65s)
+Fetching https://github.com/apple/swift-nio-extras.git
+Fetching https://github.com/apple/swift-nio-http2.git
+[1/2701] Fetching swift-nio-transport-services
+[785/8824] Fetching swift-nio-transport-services, swift-nio-extras
+[4539/20485] Fetching swift-nio-transport-services, swift-nio-extras, swift-nio-http2
+Fetched https://github.com/apple/swift-nio-transport-services.git from cache (0.55s)
+[3669/17784] Fetching swift-nio-extras, swift-nio-http2
+Fetching https://github.com/apple/swift-nio-ssl.git
+[17785/32769] Fetching swift-nio-extras, swift-nio-http2, swift-nio-ssl
+Fetched https://github.com/apple/swift-nio-extras.git from cache (1.10s)
+[13160/26646] Fetching swift-nio-http2, swift-nio-ssl
+Fetched https://github.com/apple/swift-nio-http2.git from cache (1.10s)
+[1649/14985] Fetching swift-nio-ssl
+Fetched https://github.com/apple/swift-nio-ssl.git from cache (1.79s)
+Computing version for https://github.com/apple/swift-nio-transport-services.git
+Computed https://github.com/apple/swift-nio-transport-services.git at 1.25.0 (3.51s)
+Computing version for https://github.com/apple/swift-nio.git
+Computed https://github.com/apple/swift-nio.git at 2.85.0 (0.78s)
+Fetching https://github.com/apple/swift-system.git
+Fetching https://github.com/apple/swift-collections.git
+[1/4839] Fetching swift-system
+[98/21766] Fetching swift-system, swift-collections
+Fetched https://github.com/apple/swift-system.git from cache (0.64s)
+[1185/16927] Fetching swift-collections
+Fetched https://github.com/apple/swift-collections.git from cache (1.69s)
+Computing version for https://github.com/apple/swift-atomics.git
+Computed https://github.com/apple/swift-atomics.git at 1.3.0 (2.29s)
+Computing version for https://github.com/apple/swift-nio-http2.git
+Computed https://github.com/apple/swift-nio-http2.git at 1.38.0 (0.61s)
+Computing version for https://github.com/apple/swift-algorithms.git
+Computed https://github.com/apple/swift-algorithms.git at 1.2.1 (0.66s)
+Fetching https://github.com/apple/swift-numerics.git
+[1/5769] Fetching swift-numerics
+Fetched https://github.com/apple/swift-numerics.git from cache (0.78s)
+Computing version for https://github.com/apple/swift-nio-ssl.git
+Computed https://github.com/apple/swift-nio-ssl.git at 2.33.0 (1.50s)
+Computing version for https://github.com/apple/swift-numerics.git
+Computed https://github.com/apple/swift-numerics.git at 1.0.3 (0.66s)
+Computing version for https://github.com/apple/swift-log.git
+Computed https://github.com/apple/swift-log.git at 1.6.4 (0.56s)
+Computing version for https://github.com/apple/swift-nio-extras.git
+Computed https://github.com/apple/swift-nio-extras.git at 1.29.0 (0.62s)
+Fetching https://github.com/apple/swift-async-algorithms.git
+Fetching https://github.com/swift-server/swift-service-lifecycle.git
+Fetching https://github.com/apple/swift-asn1.git
+[1/2433] Fetching swift-service-lifecycle
+[1291/7445] Fetching swift-service-lifecycle, swift-async-algorithms
+[7162/9074] Fetching swift-service-lifecycle, swift-async-algorithms, swift-asn1
+Fetched https://github.com/apple/swift-async-algorithms.git from cache (0.44s)
+[3329/4062] Fetching swift-service-lifecycle, swift-asn1
+Fetching https://github.com/apple/swift-certificates.git
+Fetched https://github.com/swift-server/swift-service-lifecycle.git from cache (0.50s)
+Fetched https://github.com/apple/swift-asn1.git from cache (0.50s)
+Fetching https://github.com/apple/swift-http-structured-headers.git
+Fetching https://github.com/apple/swift-http-types.git
+[1/1176] Fetching swift-http-structured-headers
+[37/2093] Fetching swift-http-structured-headers, swift-http-types
+[152/8553] Fetching swift-http-structured-headers, swift-http-types, swift-certificates
+Fetched https://github.com/apple/swift-http-types.git from cache (0.45s)
+[2598/7636] Fetching swift-http-structured-headers, swift-certificates
+Fetched https://github.com/apple/swift-http-structured-headers.git from cache (0.46s)
+[1874/6460] Fetching swift-certificates
+Fetched https://github.com/apple/swift-certificates.git from cache (0.67s)
+Computing version for https://github.com/swift-server/swift-service-lifecycle.git
+Computed https://github.com/swift-server/swift-service-lifecycle.git at 2.8.0 (1.69s)
+Computing version for https://github.com/apple/swift-async-algorithms.git
+Computed https://github.com/apple/swift-async-algorithms.git at 1.0.4 (0.65s)
+Computing version for https://github.com/apple/swift-asn1.git
+Computed https://github.com/apple/swift-asn1.git at 1.4.0 (0.65s)
+Computing version for https://github.com/apple/swift-certificates.git
+Computed https://github.com/apple/swift-certificates.git at 1.11.0 (0.65s)
+Fetching https://github.com/apple/swift-crypto.git
+[1/15933] Fetching swift-crypto
+Fetched https://github.com/apple/swift-crypto.git from cache (1.60s)
+Computing version for https://github.com/apple/swift-http-types.git
+Computed https://github.com/apple/swift-http-types.git at 1.4.0 (2.21s)
+Computing version for https://github.com/apple/swift-http-structured-headers.git
+Computed https://github.com/apple/swift-http-structured-headers.git at 1.3.0 (0.57s)
+Computing version for https://github.com/apple/swift-system.git
+Computed https://github.com/apple/swift-system.git at 1.6.2 (0.60s)
+Computing version for https://github.com/apple/swift-crypto.git
+Computed https://github.com/apple/swift-crypto.git at 3.13.3 (1.40s)
+Computing version for https://github.com/apple/swift-collections.git
+Computed https://github.com/apple/swift-collections.git at 1.2.1 (0.71s)
+Creating working copy for https://github.com/apple/swift-numerics.git
+Working copy of https://github.com/apple/swift-numerics.git resolved at 1.0.3
+Creating working copy for https://github.com/jpsim/Yams.git
+Working copy of https://github.com/jpsim/Yams.git resolved at 5.4.0
+Creating working copy for https://github.com/apple/swift-nio-http2.git
+Working copy of https://github.com/apple/swift-nio-http2.git resolved at 1.38.0
+Creating working copy for https://github.com/swift-server/swift-service-lifecycle.git
+Working copy of https://github.com/swift-server/swift-service-lifecycle.git resolved at 2.8.0
+Creating working copy for https://github.com/apple/swift-system.git
+Working copy of https://github.com/apple/swift-system.git resolved at 1.6.2
+Creating working copy for https://github.com/apple/swift-collections.git
+Working copy of https://github.com/apple/swift-collections.git resolved at 1.2.1
+Creating working copy for https://github.com/apple/swift-certificates.git
+Working copy of https://github.com/apple/swift-certificates.git resolved at 1.11.0
+Creating working copy for https://github.com/apple/swift-asn1.git
+Working copy of https://github.com/apple/swift-asn1.git resolved at 1.4.0
+Creating working copy for https://github.com/apple/swift-algorithms.git
+Working copy of https://github.com/apple/swift-algorithms.git resolved at 1.2.1
+Creating working copy for https://github.com/apple/swift-nio-ssl.git
+Working copy of https://github.com/apple/swift-nio-ssl.git resolved at 2.33.0
+Creating working copy for https://github.com/apple/swift-nio.git
+Working copy of https://github.com/apple/swift-nio.git resolved at 2.85.0
+Creating working copy for https://github.com/swift-server/async-http-client.git
+Working copy of https://github.com/swift-server/async-http-client.git resolved at 1.26.1
+Creating working copy for https://github.com/apple/swift-log.git
+Working copy of https://github.com/apple/swift-log.git resolved at 1.6.4
+Creating working copy for https://github.com/apple/swift-atomics.git
+Working copy of https://github.com/apple/swift-atomics.git resolved at 1.3.0
+Creating working copy for https://github.com/apple/swift-nio-transport-services.git
+Working copy of https://github.com/apple/swift-nio-transport-services.git resolved at 1.25.0
+Creating working copy for https://github.com/apple/swift-async-algorithms.git
+Working copy of https://github.com/apple/swift-async-algorithms.git resolved at 1.0.4
+Creating working copy for https://github.com/apple/swift-crypto.git
+Working copy of https://github.com/apple/swift-crypto.git resolved at 3.13.3
+Creating working copy for https://github.com/apple/swift-http-types.git
+Working copy of https://github.com/apple/swift-http-types.git resolved at 1.4.0
+Creating working copy for https://github.com/apple/swift-http-structured-headers.git
+Working copy of https://github.com/apple/swift-http-structured-headers.git resolved at 1.3.0
+Creating working copy for https://github.com/apple/swift-nio-extras.git
+Working copy of https://github.com/apple/swift-nio-extras.git resolved at 1.29.0
+Building for production...
+[0/459] Write sources
+[11/459] Compiling poly1305_arm_asm.S
+[12/459] Compiling _NumericsShims _NumericsShims.c
+[13/459] Write sources
+[15/459] Compiling _AtomicsShims.c
+[15/459] Write sources
+[31/459] Compiling writer.c
+[32/459] Compiling deterministic.cc
+[33/459] Compiling reader.c
+[34/459] Compiling pool.cc
+[35/459] Write swift-version--4EAD98957C2213E4.txt
+[36/459] Compiling poly1305_vec.cc
+[37/460] Compiling parser.c
+[38/460] Compiling api.c
+[39/462] Compiling emitter.c
+[40/462] Compiling scanner.c
+[42/464] Compiling _NIOBase64 Base64.swift
+[43/465] Compiling RealModule AlgebraicField.swift
+[44/465] Compiling _NIODataStructures Heap.swift
+[44/466] Compiling CNIOWindows shim.c
+[45/466] Compiling CNIOWindows WSAStartup.c
+[46/466] Compiling CNIOWASI CNIOWASI.c
+[47/466] Compiling CNIOPosix event_loop_id.c
+[49/466] Compiling FountainCore Models.swift
+[49/466] Compiling CNIOLinux shim.c
+[50/466] Compiling CNIOLinux liburing_shims.c
+[51/466] Compiling CNIOLLHTTP c_nio_http.c
+[52/466] Compiling CNIOLLHTTP c_nio_api.c
+[53/466] Compiling CNIOExtrasZlib empty.c
+[54/466] Compiling CNIODarwin shim.c
+[56/466] Compiling InternalCollectionsUtilities FixedWidthInteger+roundUpToPowerOfTwo.swift
+[56/466] Compiling CNIOBoringSSLShims shims.c
+[57/466] Compiling fiat_p256_adx_sqr.S
+[58/467] Compiling fiat_p256_adx_mul.S
+[59/467] Compiling fiat_curve25519_adx_square.S
+[60/467] Compiling CNIOLLHTTP c_nio_llhttp.c
+[61/467] Compiling fiat_curve25519_adx_mul.S
+[63/467] Compiling Logging Locks.swift
+[63/467] Compiling tls_record.cc
+[64/467] Compiling tls_method.cc
+[66/467] Compiling DequeModule Deque+Codable.swift
+[66/467] Compiling tls13_server.cc
+[67/467] Compiling tls13_enc.cc
+[68/467] Compiling tls13_client.cc
+[69/467] Compiling tls13_both.cc
+[70/467] Compiling t1_enc.cc
+[71/467] Compiling ssl_versions.cc
+[72/467] Compiling ssl_x509.cc
+[73/467] Compiling ssl_transcript.cc
+[74/467] Compiling ssl_stat.cc
+[75/467] Compiling ssl_session.cc
+[76/467] Compiling ssl_privkey.cc
+[77/467] Compiling ssl_key_share.cc
+[78/467] Compiling ssl_lib.cc
+[79/467] Compiling ssl_file.cc
+[80/467] Compiling ssl_credential.cc
+[81/467] Compiling ssl_cipher.cc
+[82/467] Compiling ssl_buffer.cc
+[83/467] Compiling ssl_cert.cc
+[84/467] Compiling ssl_asn1.cc
+[85/467] Compiling s3_pkt.cc
+[86/467] Compiling ssl_aead_ctx.cc
+[87/467] Compiling s3_lib.cc
+[88/467] Compiling handshake_server.cc
+[90/467] Compiling Yams AliasDereferencingStrategy.swift
+[90/467] Compiling s3_both.cc
+[91/467] Compiling handshake_client.cc
+[92/467] Compiling handshake.cc
+[93/467] Compiling encrypted_client_hello.cc
+[94/467] Compiling handoff.cc
+[95/467] Compiling dtls_record.cc
+[96/467] Compiling extensions.cc
+[97/467] Compiling dtls_method.cc
+[98/467] Compiling d1_srtp.cc
+[99/467] Compiling md5-x86_64-linux.S
+[100/467] Compiling d1_pkt.cc
+[101/467] Compiling md5-x86_64-apple.S
+[102/467] Compiling md5-586-linux.S
+[103/467] Compiling bio_ssl.cc
+[104/467] Compiling md5-586-apple.S
+[105/467] Compiling chacha20_poly1305_x86_64-apple.S
+[106/467] Compiling chacha20_poly1305_x86_64-linux.S
+[107/467] Compiling err_data.cc
+[108/467] Compiling chacha20_poly1305_armv8-linux.S
+[109/467] Compiling chacha20_poly1305_armv8-win.S
+[110/467] Compiling chacha20_poly1305_armv8-apple.S
+[111/467] Compiling d1_lib.cc
+[112/467] Compiling chacha-x86_64-apple.S
+[113/467] Compiling chacha-x86_64-linux.S
+[114/467] Compiling chacha-x86-linux.S
+[115/467] Compiling chacha-x86-apple.S
+[115/467] Compiling chacha-armv8-win.S
+[117/467] Compiling chacha-armv8-linux.S
+[118/467] Compiling chacha-armv8-apple.S
+[119/467] Compiling aes128gcmsiv-x86_64-apple.S
+[120/467] Compiling chacha-armv4-linux.S
+[121/467] Compiling aes128gcmsiv-x86_64-linux.S
+[122/467] Compiling x86_64-mont5-linux.S
+[123/467] Compiling x86_64-mont5-apple.S
+[124/467] Compiling x86_64-mont-linux.S
+[125/467] Compiling x86_64-mont-apple.S
+[126/467] Compiling d1_both.cc
+[127/467] Compiling x86-mont-linux.S
+[128/467] Compiling x86-mont-apple.S
+[129/467] Compiling vpaes-x86_64-apple.S
+[130/467] Compiling vpaes-x86_64-linux.S
+[131/467] Compiling vpaes-x86-linux.S
+[132/467] Compiling vpaes-armv8-win.S
+[132/467] Compiling vpaes-armv8-linux.S
+[134/467] Compiling vpaes-armv7-linux.S
+[135/467] Compiling vpaes-x86-apple.S
+[136/467] Compiling vpaes-armv8-apple.S
+[137/467] Compiling sha512-armv8-linux.S
+[138/467] Compiling sha512-armv8-win.S
+[139/467] Compiling sha512-x86_64-apple.S
+[140/467] Compiling sha512-armv8-apple.S
+[141/467] Compiling sha512-x86_64-linux.S
+[142/467] Compiling sha512-586-linux.S
+[143/467] Compiling sha512-586-apple.S
+[144/467] Compiling sha512-armv4-linux.S
+[145/467] Compiling sha256-x86_64-apple.S
+[146/467] Compiling sha256-x86_64-linux.S
+[147/467] Compiling sha256-armv8-win.S
+[147/467] Compiling sha256-armv8-linux.S
+[149/467] Compiling sha256-armv8-apple.S
+[150/467] Compiling sha256-armv4-linux.S
+[151/467] Compiling sha256-586-linux.S
+[152/467] Compiling sha256-586-apple.S
+[153/467] Compiling sha1-x86_64-apple.S
+[154/467] Compiling sha1-x86_64-linux.S
+[155/467] Compiling sha1-armv8-win.S
+[156/467] Compiling sha1-armv8-linux.S
+[157/467] Compiling sha1-armv4-large-linux.S
+[158/467] Compiling sha1-armv8-apple.S
+[159/467] Compiling sha1-586-linux.S
+[160/467] Compiling sha1-586-apple.S
+[161/467] Compiling rsaz-avx2-linux.S
+[162/467] Compiling rsaz-avx2-apple.S
+[163/467] Compiling rdrand-x86_64-linux.S
+[164/467] Compiling rdrand-x86_64-apple.S
+[165/467] Compiling p256_beeu-x86_64-asm-linux.S
+[166/467] Compiling p256_beeu-x86_64-asm-apple.S
+[167/467] Compiling p256_beeu-armv8-asm-win.S
+[168/467] Compiling p256_beeu-armv8-asm-linux.S
+[169/467] Compiling p256_beeu-armv8-asm-apple.S
+[170/467] Compiling p256-x86_64-asm-linux.S
+[171/467] Compiling p256-x86_64-asm-apple.S
+[172/467] Compiling p256-armv8-asm-win.S
+[173/467] Compiling p256-armv8-asm-linux.S
+[174/467] Compiling p256-armv8-asm-apple.S
+[175/467] Compiling ghashv8-armv8-win.S
+[176/467] Compiling ghashv8-armv8-linux.S
+[177/467] Compiling ghashv8-armv8-apple.S
+[178/467] Compiling ghashv8-armv7-linux.S
+[179/467] Compiling ghash-x86_64-linux.S
+[180/467] Compiling ghash-x86_64-apple.S
+[181/467] Compiling ghash-x86-linux.S
+[182/467] Compiling ghash-x86-apple.S
+[183/467] Compiling ghash-ssse3-x86_64-linux.S
+[184/467] Compiling ghash-ssse3-x86-linux.S
+[185/467] Compiling ghash-ssse3-x86_64-apple.S
+[186/467] Compiling ghash-ssse3-x86-apple.S
+[187/467] Compiling ghash-neon-armv8-win.S
+[188/467] Compiling ghash-neon-armv8-linux.S
+[189/467] Compiling ghash-neon-armv8-apple.S
+[190/467] Compiling ghash-armv4-linux.S
+[191/467] Compiling co-586-linux.S
+[192/467] Compiling co-586-apple.S
+[193/467] Compiling bsaes-armv7-linux.S
+[194/467] Compiling bn-armv8-win.S
+[195/467] Compiling bn-armv8-linux.S
+[196/467] Compiling bn-armv8-apple.S
+[197/467] Compiling bn-586-apple.S
+[198/467] Compiling bn-586-linux.S
+[199/467] Compiling armv8-mont-win.S
+[200/467] Compiling armv8-mont-linux.S
+[201/467] Compiling armv8-mont-apple.S
+[202/467] Compiling armv4-mont-linux.S
+[203/467] Compiling aesv8-gcm-armv8-win.S
+[204/467] Compiling aesv8-gcm-armv8-linux.S
+[205/467] Compiling aesv8-gcm-armv8-apple.S
+[206/467] Compiling aesv8-armv8-win.S
+[207/467] Compiling aesv8-armv8-linux.S
+[208/467] Compiling aesv8-armv8-apple.S
+[209/467] Compiling aesv8-armv7-linux.S
+[210/467] Compiling aesni-x86_64-linux.S
+[211/467] Compiling aesni-x86_64-apple.S
+[212/467] Compiling aesni-x86-linux.S
+[213/467] Compiling aesni-x86-apple.S
+[214/467] Compiling aesni-gcm-x86_64-linux.S
+[215/467] Compiling aesni-gcm-x86_64-apple.S
+[216/467] Compiling aes-gcm-avx2-x86_64-linux.S
+[217/467] Compiling aes-gcm-avx2-x86_64-apple.S
+[218/467] Compiling aes-gcm-avx10-x86_64-linux.S
+[219/467] Compiling aes-gcm-avx10-x86_64-apple.S
+[220/467] Compiling x_x509a.cc
+[221/467] Compiling x_val.cc
+[222/467] Compiling x_spki.cc
+[223/467] Compiling x_sig.cc
+[224/467] Compiling x_x509.cc
+[225/467] Compiling x_req.cc
+[226/467] Compiling x_pubkey.cc
+[227/467] Compiling x_exten.cc
+[228/467] Compiling x_name.cc
+[229/467] Compiling x_crl.cc
+[230/467] Compiling x_attrib.cc
+[231/467] Compiling x_algor.cc
+[232/467] Compiling x509spki.cc
+[233/467] Compiling x_all.cc
+[234/467] Compiling x509rset.cc
+[235/467] Compiling x509name.cc
+[236/467] Compiling x509cset.cc
+[237/467] Compiling x509_vpm.cc
+[238/467] Compiling x509_v3.cc
+[239/467] Compiling x509_vfy.cc
+[240/467] Compiling x509_txt.cc
+[241/467] Compiling x509_trs.cc
+[242/467] Compiling x509_set.cc
+[243/467] Compiling x509_req.cc
+[244/467] Compiling x509_obj.cc
+[245/467] Compiling x509_lu.cc
+[246/467] Compiling x509_ext.cc
+[247/467] Compiling x509_def.cc
+[248/467] Compiling x509_d2.cc
+[249/467] Compiling x509_cmp.cc
+[250/467] Compiling x509.cc
+[251/467] Compiling x509_att.cc
+[252/467] Compiling v3_skey.cc
+[253/467] Compiling v3_utl.cc
+[254/467] Compiling v3_purp.cc
+[255/467] Compiling v3_prn.cc
+[256/467] Compiling v3_pmaps.cc
+[257/467] Compiling v3_pcons.cc
+[258/467] Compiling v3_ocsp.cc
+[259/467] Compiling v3_ncons.cc
+[260/467] Compiling v3_int.cc
+[261/467] Compiling v3_lib.cc
+[262/467] Compiling v3_ia5.cc
+[263/467] Compiling v3_info.cc
+[264/467] Compiling v3_genn.cc
+[265/467] Compiling v3_extku.cc
+[266/467] Compiling v3_enum.cc
+[267/467] Compiling v3_crld.cc
+[268/467] Compiling v3_cpols.cc
+[269/467] Compiling v3_conf.cc
+[270/467] Compiling v3_bitst.cc
+[271/467] Compiling v3_bcons.cc
+[272/467] Compiling v3_akeya.cc
+[273/467] Compiling v3_alt.cc
+[274/467] Compiling v3_akey.cc
+[275/467] Compiling t_x509a.cc
+[276/467] Compiling t_x509.cc
+[277/467] Compiling t_crl.cc
+[278/467] Compiling t_req.cc
+[279/467] Compiling rsa_pss.cc
+[280/467] Compiling name_print.cc
+[281/467] Compiling i2d_pr.cc
+[282/467] Compiling policy.cc
+[283/467] Compiling by_file.cc
+[284/467] Compiling by_dir.cc
+[285/467] Compiling algorithm.cc
+[286/467] Compiling a_verify.cc
+[287/467] Compiling asn1_gen.cc
+[288/467] Compiling a_sign.cc
+[289/467] Compiling a_digest.cc
+[290/467] Compiling voprf.cc
+[291/467] Compiling trust_token.cc
+[292/467] Compiling thread_win.cc
+[293/467] Compiling pmbtoken.cc
+[294/467] Compiling thread_pthread.cc
+[294/467] Compiling thread.cc
+[296/467] Compiling thread_none.cc
+[297/467] Compiling stack.cc
+[298/467] Compiling sha512.cc
+[299/467] Compiling slhdsa.cc
+[300/467] Compiling siphash.cc
+[301/467] Compiling spake2plus.cc
+[302/467] Compiling sha256.cc
+[303/467] Compiling sha1.cc
+[304/467] Compiling rsa_print.cc
+[305/467] Compiling rsa_extra.cc
+[306/467] Compiling refcount.cc
+[307/467] Compiling rsa_asn1.cc
+[308/467] Compiling rc4.cc
+[309/467] Compiling rsa_crypt.cc
+[310/467] Compiling windows.cc
+[311/467] Compiling trusty.cc
+[312/467] Compiling rand.cc
+[313/467] Compiling urandom.cc
+[314/467] Compiling passive.cc
+[315/467] Compiling ios.cc
+[316/467] Compiling getentropy.cc
+[317/467] Compiling forkunsafe.cc
+[318/467] Compiling fork_detect.cc
+[319/467] Compiling poly1305_arm.cc
+[320/467] Compiling poly1305.cc
+[321/467] Compiling pkcs7.cc
+[322/467] Compiling pkcs8.cc
+[323/467] Compiling pkcs8_x509.cc
+[324/467] Compiling p5_pbev2.cc
+[325/467] Compiling pkcs7_x509.cc
+[326/467] Compiling pem_xaux.cc
+[327/467] Compiling pem_x509.cc
+[328/467] Compiling pem_pkey.cc
+[329/467] Compiling pem_pk8.cc
+[330/467] Compiling pem_oth.cc
+[331/467] Compiling obj_xref.cc
+[332/467] Compiling pem_lib.cc
+[333/467] Compiling pem_info.cc
+[334/467] Compiling pem_all.cc
+[335/467] Compiling mlkem.cc
+[336/467] Compiling obj.cc
+[337/467] Compiling mldsa.cc
+[338/467] Compiling md5.cc
+[339/467] Compiling mem.cc
+[340/467] Compiling lhash.cc
+[341/467] Compiling md4.cc
+[342/467] Compiling fips_shared_support.cc
+[343/467] Compiling poly_rq_mul.S
+[344/467] Compiling ex_data.cc
+[345/467] Compiling kyber.cc
+[346/467] Compiling hpke.cc
+[347/467] Compiling sign.cc
+[348/467] Compiling hrss.cc
+[349/467] Compiling scrypt.cc
+[350/467] Compiling print.cc
+[351/467] Compiling pbkdf.cc
+[352/467] Compiling p_x25519_asn1.cc
+[353/467] Compiling p_x25519.cc
+[354/467] Compiling p_rsa.cc
+[355/467] Compiling p_rsa_asn1.cc
+[356/467] Compiling p_hkdf.cc
+[357/467] Compiling p_ed25519_asn1.cc
+[358/467] Compiling p_ed25519.cc
+[359/467] Compiling p_ec_asn1.cc
+[360/467] Compiling p_ec.cc
+[361/467] Compiling p_dsa_asn1.cc
+[362/467] Compiling p_dh_asn1.cc
+[363/467] Compiling p_dh.cc
+[364/467] Compiling evp_ctx.cc
+[365/467] Compiling evp.cc
+[366/467] Compiling evp_asn1.cc
+[367/467] Compiling err.cc
+[368/467] Compiling engine.cc
+[369/467] Compiling ecdh.cc
+[370/467] Compiling ecdsa_asn1.cc
+[371/467] Compiling ec_derive.cc
+[372/467] Compiling hash_to_curve.cc
+[373/467] Compiling ec_asn1.cc
+[374/467] Compiling dsa_asn1.cc
+[375/467] Compiling dsa.cc
+[376/467] Compiling digest_extra.cc
+[377/467] Compiling params.cc
+[378/467] Compiling dh_asn1.cc
+[379/467] Compiling spake25519.cc
+[380/467] Compiling x25519-asm-arm.S
+[381/467] Compiling des.cc
+[382/467] Compiling crypto.cc
+[383/467] Compiling cpu_intel.cc
+[384/467] Compiling curve25519_64_adx.cc
+[385/467] Compiling curve25519.cc
+[386/467] Compiling cpu_arm_freebsd.cc
+[387/467] Compiling cpu_arm_linux.cc
+[388/467] Compiling cpu_aarch64_win.cc
+[389/467] Compiling cpu_aarch64_sysreg.cc
+[390/467] Compiling cpu_aarch64_openbsd.cc
+[391/467] Compiling cpu_aarch64_linux.cc
+[392/467] Compiling cpu_aarch64_fuchsia.cc
+[393/467] Compiling cpu_aarch64_apple.cc
+[394/467] Compiling conf.cc
+[395/467] Compiling tls_cbc.cc
+[396/467] Compiling get_cipher.cc
+[397/467] Compiling e_tls.cc
+[398/467] Compiling e_rc4.cc
+[399/467] Compiling e_null.cc
+[400/467] Compiling e_rc2.cc
+[401/467] Compiling e_des.cc
+[402/467] Compiling e_chacha20poly1305.cc
+[403/467] Compiling derive_key.cc
+[404/467] Compiling e_aesctrhmac.cc
+[405/467] Compiling e_aesgcmsiv.cc
+[406/467] Compiling chacha.cc
+[407/467] Compiling unicode.cc
+[408/467] Compiling ber.cc
+[409/467] Compiling cbb.cc
+[410/467] Compiling cbs.cc
+[411/467] Compiling asn1_compat.cc
+[412/467] Compiling buf.cc
+[413/467] Compiling bn_asn1.cc
+[414/467] Compiling convert.cc
+[415/467] Compiling blake2.cc
+[416/467] Compiling socket_helper.cc
+[417/467] Compiling socket.cc
+[418/467] Compiling printf.cc
+[419/467] Compiling pair.cc
+[420/467] Compiling hexdump.cc
+[421/467] Compiling file.cc
+[422/467] Compiling fd.cc
+[423/467] Compiling errno.cc
+[424/467] Compiling connect.cc
+[425/467] Compiling bio_mem.cc
+[426/467] Compiling bio.cc
+[427/467] Compiling base64.cc
+[428/467] Compiling tasn_utl.cc
+[429/467] Compiling tasn_typ.cc
+[430/467] Compiling tasn_fre.cc
+[431/467] Compiling tasn_new.cc
+[432/467] Compiling tasn_enc.cc
+[433/467] Compiling posix_time.cc
+[434/467] Compiling f_string.cc
+[435/467] Compiling tasn_dec.cc
+[436/467] Compiling f_int.cc
+[437/467] Compiling asn_pack.cc
+[438/467] Compiling asn1_par.cc
+[439/467] Compiling asn1_lib.cc
+[440/467] Compiling a_utctm.cc
+[441/467] Compiling a_type.cc
+[442/467] Compiling a_time.cc
+[443/467] Compiling a_strnid.cc
+[444/467] Compiling a_octet.cc
+[445/467] Compiling a_strex.cc
+[446/467] Compiling a_object.cc
+[447/467] Compiling a_mbstr.cc
+[448/467] Compiling a_i2d_fp.cc
+[449/467] Compiling a_int.cc
+[450/467] Compiling a_gentm.cc
+[451/467] Compiling a_dup.cc
+[452/467] Compiling a_d2i_fp.cc
+[453/467] Compiling a_bool.cc
+[454/467] Compiling a_bitstr.cc
+[454/467] Write sources
+[457/467] Compiling CAsyncHTTPClient CAsyncHTTPClient.c
+[458/469] Compiling c-nioatomics.c
+[459/469] Compiling bcm.cc
+[460/469] Compiling c-atomics.c
+[462/470] Compiling NIOConcurrencyHelpers NIOAtomic.swift
+[463/470] Compiling Atomics OptionalRawRepresentable.swift
+[464/471] Compiling Algorithms AdjacentPairs.swift
+[465/471] Compiling NIOCore AddressedEnvelope.swift
+[466/473] Compiling NIOEmbedded AsyncTestingChannel.swift
+[467/473] Compiling NIOPosix BSDSocketAPICommon.swift
+[468/474] Compiling NIO Exports.swift
+[469/478] Compiling NIOTLS ApplicationProtocolNegotiationHandler.swift
+[470/479] Compiling NIOSOCKS SOCKSClientHandler.swift
+[471/479] Compiling NIOFoundationCompat ByteBuffer-foundation.swift
+[472/480] Compiling NIOTransportServices AcceptHandler.swift
+[473/480] Compiling NIOHTTP1 ByteCollectionUtils.swift
+[474/482] Compiling NIOHTTPCompression HTTPCompression.swift
+[475/482] Compiling NIOSSL AndroidCABundle.swift
+[476/482] Compiling NIOHPACK DynamicHeaderTable.swift
+[477/483] Compiling NIOHTTP2 ConnectionStateMachine.swift
+[478/484] Compiling AsyncHTTPClient AnyAsyncSequence.swift
+[479/485] Compiling FountainCodex ClientGenerator.swift
+[480/487] Compiling clientgen_service main.swift
+[480/487] Write Objects.LinkFileList
+[481/487] Linking clientgen-service
+[483/487] Compiling PublishingFrontend DNSProvider.swift
+[484/489] Compiling publishing_frontend main.swift
+[484/489] Write Objects.LinkFileList
+[486/489] Compiling gateway_server CertificateManager.swift
+[486/489] Write Objects.LinkFileList
+[487/489] Linking publishing-frontend
+[488/489] Linking gateway-server
+Build complete! (216.60s)
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/logs/test-20250804132540.log
+++ b/logs/test-20250804132540.log
@@ -1,0 +1,567 @@
+[0/1] Planning build
+Building for production...
+[0/12] Write sources
+[5/18] Write swift-version--4EAD98957C2213E4.txt
+[7/23] Compiling _NIOBase64 Base64.swift
+[8/24] Compiling RealModule AlgebraicField.swift
+[9/24] Compiling _NIODataStructures Heap.swift
+[10/25] Compiling NIOConcurrencyHelpers NIOAtomic.swift
+[11/27] Compiling FountainCore Models.swift
+[12/28] Compiling InternalCollectionsUtilities FixedWidthInteger+roundUpToPowerOfTwo.swift
+[13/29] Compiling Logging Locks.swift
+[14/30] Compiling Atomics OptionalRawRepresentable.swift
+[15/30] Compiling DequeModule Deque+Codable.swift
+[16/31] Compiling FountainCoreTests FountainCoreTests.swift
+[17/31] Compiling Algorithms AdjacentPairs.swift
+[18/31] Compiling Yams AliasDereferencingStrategy.swift
+[19/31] Compiling NIOCore AddressedEnvelope.swift
+[20/33] Compiling NIOEmbedded AsyncTestingChannel.swift
+[21/33] Compiling NIOPosix BSDSocketAPICommon.swift
+[22/34] Compiling NIO Exports.swift
+[23/38] Compiling NIOFoundationCompat ByteBuffer-foundation.swift
+[24/38] Compiling NIOTLS ApplicationProtocolNegotiationHandler.swift
+[25/40] Compiling NIOSOCKS SOCKSClientHandler.swift
+[26/40] Compiling NIOTransportServices AcceptHandler.swift
+[27/40] Compiling NIOHTTP1 ByteCollectionUtils.swift
+[28/42] Compiling NIOSSL AndroidCABundle.swift
+[29/42] Compiling NIOHTTPCompression HTTPCompression.swift
+[30/42] Compiling NIOHPACK DynamicHeaderTable.swift
+[31/43] Compiling NIOHTTP2 ConnectionStateMachine.swift
+[32/44] Compiling AsyncHTTPClient AnyAsyncSequence.swift
+[33/45] Compiling FountainCodex ClientGenerator.swift
+[34/48] Compiling clientgen_service main.swift
+[34/48] Write Objects.LinkFileList
+[36/48] Compiling ClientGeneratorTests ClientGeneratorTests.swift
+/workspace/codex-deployer/Tests/ClientGeneratorTests/ClientGeneratorTests.swift:52:28: warning: 'init(contentsOf:)' is deprecated: Use `init(contentsOf:encoding:)` instead
+50 |         try ClientGenerator.emitClient(from: spec, to: outDir)
+51 |         let requestFile = outDir.appendingPathComponent("Requests/GetZone.swift")
+52 |         let contents = try String(contentsOf: requestFile)
+   |                            `- warning: 'init(contentsOf:)' is deprecated: Use `init(contentsOf:encoding:)` instead
+53 |         XCTAssertTrue(contents.contains("detail"))
+54 |         XCTAssertTrue(contents.contains("query.append(\"detail"))
+
+/workspace/codex-deployer/Tests/ClientGeneratorTests/SpecLoaderTests.swift:28:29: warning: result of call to 'createFile(atPath:contents:attributes:)' is unused
+26 |     func testLoadThrowsForEmptyFile() {
+27 |         let url = FileManager.default.temporaryDirectory.appendingPathComponent("empty.yml")
+28 |         FileManager.default.createFile(atPath: url.path, contents: Data())
+   |                             `- warning: result of call to 'createFile(atPath:contents:attributes:)' is unused
+29 |         XCTAssertThrowsError(try SpecLoader.load(from: url))
+30 |     }
+
+/workspace/codex-deployer/Tests/ClientGeneratorTests/SpecLoaderTests.swift:37:29: warning: result of call to 'createFile(atPath:contents:attributes:)' is unused
+35 |         let bytes: [UInt8] = [0xFF]
+36 |         let data = Data(bytes)
+37 |         FileManager.default.createFile(atPath: url.path, contents: data)
+   |                             `- warning: result of call to 'createFile(atPath:contents:attributes:)' is unused
+38 |         XCTAssertThrowsError(try SpecLoader.load(from: url))
+39 |     }
+[36/48] Linking clientgen-service
+[38/48] Compiling PublishingFrontend DNSProvider.swift
+[39/52] Compiling publishing_frontend main.swift
+[39/52] Write Objects.LinkFileList
+[41/52] Compiling gateway_server CertificateManager.swift
+[41/52] Write Objects.LinkFileList
+[43/52] Compiling PublishingFrontendTests HetznerDNSModelsTests.swift
+/workspace/codex-deployer/Tests/PublishingFrontendTests/PublishingFrontendTests.swift:39:37: warning: result of call to 'changeCurrentDirectoryPath' is unused
+ 37 |         try yaml.write(to: fileURL, atomically: true, encoding: .utf8)
+ 38 |         let cwd = FileManager.default.currentDirectoryPath
+ 39 |         defer { FileManager.default.changeCurrentDirectoryPath(cwd) }
+    |                                     `- warning: result of call to 'changeCurrentDirectoryPath' is unused
+ 40 |         FileManager.default.changeCurrentDirectoryPath(dir.path)
+ 41 |         let config = try loadPublishingConfig()
+
+/workspace/codex-deployer/Tests/PublishingFrontendTests/PublishingFrontendTests.swift:40:29: warning: result of call to 'changeCurrentDirectoryPath' is unused
+ 38 |         let cwd = FileManager.default.currentDirectoryPath
+ 39 |         defer { FileManager.default.changeCurrentDirectoryPath(cwd) }
+ 40 |         FileManager.default.changeCurrentDirectoryPath(dir.path)
+    |                             `- warning: result of call to 'changeCurrentDirectoryPath' is unused
+ 41 |         let config = try loadPublishingConfig()
+ 42 |         XCTAssertEqual(config.port, 1234)
+
+/workspace/codex-deployer/Tests/PublishingFrontendTests/PublishingFrontendTests.swift:65:37: warning: result of call to 'changeCurrentDirectoryPath' is unused
+ 63 |         try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+ 64 |         let cwd = FileManager.default.currentDirectoryPath
+ 65 |         defer { FileManager.default.changeCurrentDirectoryPath(cwd) }
+    |                                     `- warning: result of call to 'changeCurrentDirectoryPath' is unused
+ 66 |         FileManager.default.changeCurrentDirectoryPath(dir.path)
+ 67 |         XCTAssertThrowsError(try loadPublishingConfig())
+
+/workspace/codex-deployer/Tests/PublishingFrontendTests/PublishingFrontendTests.swift:66:29: warning: result of call to 'changeCurrentDirectoryPath' is unused
+ 64 |         let cwd = FileManager.default.currentDirectoryPath
+ 65 |         defer { FileManager.default.changeCurrentDirectoryPath(cwd) }
+ 66 |         FileManager.default.changeCurrentDirectoryPath(dir.path)
+    |                             `- warning: result of call to 'changeCurrentDirectoryPath' is unused
+ 67 |         XCTAssertThrowsError(try loadPublishingConfig())
+ 68 |     }
+
+/workspace/codex-deployer/Tests/PublishingFrontendTests/PublishingFrontendTests.swift:79:37: warning: result of call to 'changeCurrentDirectoryPath' is unused
+ 77 |         try "port: [123".write(to: fileURL, atomically: true, encoding: .utf8)
+ 78 |         let cwd = FileManager.default.currentDirectoryPath
+ 79 |         defer { FileManager.default.changeCurrentDirectoryPath(cwd) }
+    |                                     `- warning: result of call to 'changeCurrentDirectoryPath' is unused
+ 80 |         FileManager.default.changeCurrentDirectoryPath(dir.path)
+ 81 |         XCTAssertThrowsError(try loadPublishingConfig())
+
+/workspace/codex-deployer/Tests/PublishingFrontendTests/PublishingFrontendTests.swift:80:29: warning: result of call to 'changeCurrentDirectoryPath' is unused
+ 78 |         let cwd = FileManager.default.currentDirectoryPath
+ 79 |         defer { FileManager.default.changeCurrentDirectoryPath(cwd) }
+ 80 |         FileManager.default.changeCurrentDirectoryPath(dir.path)
+    |                             `- warning: result of call to 'changeCurrentDirectoryPath' is unused
+ 81 |         XCTAssertThrowsError(try loadPublishingConfig())
+ 82 |     }
+
+/workspace/codex-deployer/Tests/PublishingFrontendTests/PublishingFrontendTests.swift:97:37: warning: result of call to 'changeCurrentDirectoryPath' is unused
+ 95 |         try yaml.write(to: fileURL, atomically: true, encoding: .utf8)
+ 96 |         let cwd = FileManager.default.currentDirectoryPath
+ 97 |         defer { FileManager.default.changeCurrentDirectoryPath(cwd) }
+    |                                     `- warning: result of call to 'changeCurrentDirectoryPath' is unused
+ 98 |         FileManager.default.changeCurrentDirectoryPath(dir.path)
+ 99 |         XCTAssertThrowsError(try loadPublishingConfig())
+
+/workspace/codex-deployer/Tests/PublishingFrontendTests/PublishingFrontendTests.swift:98:29: warning: result of call to 'changeCurrentDirectoryPath' is unused
+ 96 |         let cwd = FileManager.default.currentDirectoryPath
+ 97 |         defer { FileManager.default.changeCurrentDirectoryPath(cwd) }
+ 98 |         FileManager.default.changeCurrentDirectoryPath(dir.path)
+    |                             `- warning: result of call to 'changeCurrentDirectoryPath' is unused
+ 99 |         XCTAssertThrowsError(try loadPublishingConfig())
+100 |     }
+[44/52] Compiling DNSTests APIClientTests.swift
+[44/52] Linking publishing-frontend
+[45/52] Linking gateway-server
+[47/53] Compiling IntegrationRuntimeTests AsyncHTTPClientDriverTests.swift
+[47/53] /workspace/codex-deployer/.build/x86_64-unknown-linux-gnu/release/FountainCoachPackageDiscoveredTests.derived/all-discovered-tests.swift
+[48/53] Write sources
+[50/54] Compiling FountainCoachPackageDiscoveredTests ClientGeneratorTests.swift
+[50/54] /workspace/codex-deployer/.build/x86_64-unknown-linux-gnu/release/FountainCoachPackageTests.derived/runner.swift
+[51/54] Write sources
+[53/55] Compiling FountainCoachPackageTests runner.swift
+[53/55] Write Objects.LinkFileList
+[54/55] Linking FountainCoachPackageTests.xctest
+Build complete! (131.17s)
+Test Suite 'All tests' started at 2025-08-04 13:31:30.705
+Test Suite 'release.xctest' started at 2025-08-04 13:31:30.730
+Test Suite 'FountainCoreTests' started at 2025-08-04 13:31:30.730
+Test Case 'FountainCoreTests.testTodoDecoding' started at 2025-08-04 13:31:30.730
+Test Case 'FountainCoreTests.testTodoDecoding' passed (0.004 seconds)
+Test Case 'FountainCoreTests.testTodoDecodingFailsForMissingID' started at 2025-08-04 13:31:30.734
+Test Case 'FountainCoreTests.testTodoDecodingFailsForMissingID' passed (0.001 seconds)
+Test Case 'FountainCoreTests.testTodoDecodingFailsForMissingName' started at 2025-08-04 13:31:30.735
+Test Case 'FountainCoreTests.testTodoDecodingFailsForMissingName' passed (0.0 seconds)
+Test Case 'FountainCoreTests.testTodoEncodingProducesExpectedJSON' started at 2025-08-04 13:31:30.735
+Test Case 'FountainCoreTests.testTodoEncodingProducesExpectedJSON' passed (0.001 seconds)
+Test Case 'FountainCoreTests.testTodoEncodingRoundTrip' started at 2025-08-04 13:31:30.736
+Test Case 'FountainCoreTests.testTodoEncodingRoundTrip' passed (0.0 seconds)
+Test Case 'FountainCoreTests.testTodoEquality' started at 2025-08-04 13:31:30.736
+Test Case 'FountainCoreTests.testTodoEquality' passed (0.0 seconds)
+Test Case 'FountainCoreTests.testTodosNotEqualWithDifferentID' started at 2025-08-04 13:31:30.736
+Test Case 'FountainCoreTests.testTodosNotEqualWithDifferentID' passed (0.0 seconds)
+Test Case 'FountainCoreTests.testTodosNotEqualWithDifferentName' started at 2025-08-04 13:31:30.737
+Test Case 'FountainCoreTests.testTodosNotEqualWithDifferentName' passed (0.0 seconds)
+Test Suite 'FountainCoreTests' passed at 2025-08-04 13:31:30.737
+	 Executed 8 tests, with 0 failures (0 unexpected) in 0.007 (0.007) seconds
+Test Suite 'HetznerDNSModelsTests' started at 2025-08-04 13:31:30.737
+Test Case 'HetznerDNSModelsTests.testBulkRecordsCreateRequestCodable' started at 2025-08-04 13:31:30.737
+Test Case 'HetznerDNSModelsTests.testBulkRecordsCreateRequestCodable' passed (0.001 seconds)
+Test Case 'HetznerDNSModelsTests.testBulkRecordsUpdateRequestCodable' started at 2025-08-04 13:31:30.738
+Test Case 'HetznerDNSModelsTests.testBulkRecordsUpdateRequestCodable' passed (0.001 seconds)
+Test Case 'HetznerDNSModelsTests.testPrimaryServerCreateCodable' started at 2025-08-04 13:31:30.739
+Test Case 'HetznerDNSModelsTests.testPrimaryServerCreateCodable' passed (0.0 seconds)
+Test Case 'HetznerDNSModelsTests.testPrimaryServersResponseDecodes' started at 2025-08-04 13:31:30.739
+Test Case 'HetznerDNSModelsTests.testPrimaryServersResponseDecodes' passed (0.001 seconds)
+Test Case 'HetznerDNSModelsTests.testRecordResponseDecodes' started at 2025-08-04 13:31:30.740
+Test Case 'HetznerDNSModelsTests.testRecordResponseDecodes' passed (0.0 seconds)
+Test Case 'HetznerDNSModelsTests.testValidateZoneFileResponseDecodes' started at 2025-08-04 13:31:30.740
+Test Case 'HetznerDNSModelsTests.testValidateZoneFileResponseDecodes' passed (0.0 seconds)
+Test Case 'HetznerDNSModelsTests.testZoneCreateRequestCodable' started at 2025-08-04 13:31:30.741
+Test Case 'HetznerDNSModelsTests.testZoneCreateRequestCodable' passed (0.0 seconds)
+Test Case 'HetznerDNSModelsTests.testZoneResponseDecoding' started at 2025-08-04 13:31:30.741
+Test Case 'HetznerDNSModelsTests.testZoneResponseDecoding' passed (0.001 seconds)
+Test Case 'HetznerDNSModelsTests.testZoneUpdateRequestCodable' started at 2025-08-04 13:31:30.742
+Test Case 'HetznerDNSModelsTests.testZoneUpdateRequestCodable' passed (0.0 seconds)
+Test Case 'HetznerDNSModelsTests.testZonesResponseDecodes' started at 2025-08-04 13:31:30.742
+Test Case 'HetznerDNSModelsTests.testZonesResponseDecodes' passed (0.0 seconds)
+Test Suite 'HetznerDNSModelsTests' passed at 2025-08-04 13:31:30.743
+	 Executed 10 tests, with 0 failures (0 unexpected) in 0.006 (0.006) seconds
+Test Suite 'HetznerDNSRequestTests' started at 2025-08-04 13:31:30.743
+Test Case 'HetznerDNSRequestTests.testBulkCreateRecordsMethodIsPost' started at 2025-08-04 13:31:30.743
+Test Case 'HetznerDNSRequestTests.testBulkCreateRecordsMethodIsPost' passed (0.0 seconds)
+Test Case 'HetznerDNSRequestTests.testBulkCreateRecordsPath' started at 2025-08-04 13:31:30.743
+Test Case 'HetznerDNSRequestTests.testBulkCreateRecordsPath' passed (0.0 seconds)
+Test Case 'HetznerDNSRequestTests.testBulkUpdateRecordsMethodIsPut' started at 2025-08-04 13:31:30.743
+Test Case 'HetznerDNSRequestTests.testBulkUpdateRecordsMethodIsPut' passed (0.0 seconds)
+Test Case 'HetznerDNSRequestTests.testBulkUpdateRecordsPath' started at 2025-08-04 13:31:30.743
+Test Case 'HetznerDNSRequestTests.testBulkUpdateRecordsPath' passed (0.1 seconds)
+Test Case 'HetznerDNSRequestTests.testCreateZoneMethodIsPost' started at 2025-08-04 13:31:30.843
+Test Case 'HetznerDNSRequestTests.testCreateZoneMethodIsPost' passed (0.0 seconds)
+Test Case 'HetznerDNSRequestTests.testCreateZonePath' started at 2025-08-04 13:31:30.844
+Test Case 'HetznerDNSRequestTests.testCreateZonePath' passed (0.0 seconds)
+Test Case 'HetznerDNSRequestTests.testExportZoneFileMethodIsGet' started at 2025-08-04 13:31:30.844
+Test Case 'HetznerDNSRequestTests.testExportZoneFileMethodIsGet' passed (0.0 seconds)
+Test Case 'HetznerDNSRequestTests.testExportZoneFilePathIncludesZoneID' started at 2025-08-04 13:31:30.844
+Test Case 'HetznerDNSRequestTests.testExportZoneFilePathIncludesZoneID' passed (0.001 seconds)
+Test Case 'HetznerDNSRequestTests.testImportZoneFileMethodIsPost' started at 2025-08-04 13:31:30.845
+Test Case 'HetznerDNSRequestTests.testImportZoneFileMethodIsPost' passed (0.0 seconds)
+Test Case 'HetznerDNSRequestTests.testImportZoneFilePathIncludesZoneID' started at 2025-08-04 13:31:30.846
+Test Case 'HetznerDNSRequestTests.testImportZoneFilePathIncludesZoneID' passed (0.0 seconds)
+Test Case 'HetznerDNSRequestTests.testUpdatePrimaryServerMethodIsPut' started at 2025-08-04 13:31:30.846
+Test Case 'HetznerDNSRequestTests.testUpdatePrimaryServerMethodIsPut' passed (0.0 seconds)
+Test Case 'HetznerDNSRequestTests.testUpdatePrimaryServerPathIncludesID' started at 2025-08-04 13:31:30.846
+Test Case 'HetznerDNSRequestTests.testUpdatePrimaryServerPathIncludesID' passed (0.0 seconds)
+Test Case 'HetznerDNSRequestTests.testUpdateZoneMethodIsPut' started at 2025-08-04 13:31:30.846
+Test Case 'HetznerDNSRequestTests.testUpdateZoneMethodIsPut' passed (0.0 seconds)
+Test Case 'HetznerDNSRequestTests.testUpdateZonePathIncludesID' started at 2025-08-04 13:31:30.846
+Test Case 'HetznerDNSRequestTests.testUpdateZonePathIncludesID' passed (0.0 seconds)
+Test Case 'HetznerDNSRequestTests.testValidateZoneFileMethodIsPost' started at 2025-08-04 13:31:30.846
+Test Case 'HetznerDNSRequestTests.testValidateZoneFileMethodIsPost' passed (0.0 seconds)
+Test Case 'HetznerDNSRequestTests.testValidateZoneFilePath' started at 2025-08-04 13:31:30.847
+Test Case 'HetznerDNSRequestTests.testValidateZoneFilePath' passed (0.0 seconds)
+Test Suite 'HetznerDNSRequestTests' passed at 2025-08-04 13:31:30.847
+	 Executed 16 tests, with 0 failures (0 unexpected) in 0.104 (0.104) seconds
+Test Suite 'PublishingFrontendTests' started at 2025-08-04 13:31:30.847
+Test Case 'PublishingFrontendTests.testLoadPublishingConfigFailsForInvalidYAML' started at 2025-08-04 13:31:30.847
+Test Case 'PublishingFrontendTests.testLoadPublishingConfigFailsForInvalidYAML' passed (0.006 seconds)
+Test Case 'PublishingFrontendTests.testLoadPublishingConfigFailsForMissingFile' started at 2025-08-04 13:31:30.853
+Test Case 'PublishingFrontendTests.testLoadPublishingConfigFailsForMissingFile' passed (0.101 seconds)
+Test Case 'PublishingFrontendTests.testLoadPublishingConfigFailsForNonNumericPort' started at 2025-08-04 13:31:30.953
+Test Case 'PublishingFrontendTests.testLoadPublishingConfigFailsForNonNumericPort' passed (0.005 seconds)
+Test Case 'PublishingFrontendTests.testLoadPublishingConfigParsesYaml' started at 2025-08-04 13:31:30.959
+Test Case 'PublishingFrontendTests.testLoadPublishingConfigParsesYaml' passed (0.002 seconds)
+Test Case 'PublishingFrontendTests.testPublishingConfigCustomValues' started at 2025-08-04 13:31:30.961
+Test Case 'PublishingFrontendTests.testPublishingConfigCustomValues' passed (0.0 seconds)
+Test Case 'PublishingFrontendTests.testPublishingConfigDefaultValues' started at 2025-08-04 13:31:30.961
+Test Case 'PublishingFrontendTests.testPublishingConfigDefaultValues' passed (0.0 seconds)
+Test Case 'PublishingFrontendTests.testServerRejectsNonGetRequests' started at 2025-08-04 13:31:30.961
+Test Case 'PublishingFrontendTests.testServerRejectsNonGetRequests' passed (0.018 seconds)
+Test Case 'PublishingFrontendTests.testServerReturns404ForMissingFile' started at 2025-08-04 13:31:30.979
+Test Case 'PublishingFrontendTests.testServerReturns404ForMissingFile' passed (0.002 seconds)
+Test Case 'PublishingFrontendTests.testServerServesIndex' started at 2025-08-04 13:31:30.981
+Test Case 'PublishingFrontendTests.testServerServesIndex' passed (0.105 seconds)
+Test Case 'PublishingFrontendTests.testServerSetsContentTypeHeader' started at 2025-08-04 13:31:31.085
+Test Case 'PublishingFrontendTests.testServerSetsContentTypeHeader' passed (0.003 seconds)
+Test Suite 'PublishingFrontendTests' passed at 2025-08-04 13:31:31.089
+	 Executed 10 tests, with 0 failures (0 unexpected) in 0.242 (0.242) seconds
+Test Suite 'Route53ClientTests' started at 2025-08-04 13:31:31.089
+Test Case 'Route53ClientTests.testCreateRecordThrows' started at 2025-08-04 13:31:31.089
+Test Case 'Route53ClientTests.testCreateRecordThrows' passed (0.0 seconds)
+Test Case 'Route53ClientTests.testDeleteRecordThrows' started at 2025-08-04 13:31:31.089
+Test Case 'Route53ClientTests.testDeleteRecordThrows' passed (0.0 seconds)
+Test Case 'Route53ClientTests.testListZonesThrows' started at 2025-08-04 13:31:31.089
+Test Case 'Route53ClientTests.testListZonesThrows' passed (0.0 seconds)
+Test Case 'Route53ClientTests.testUpdateRecordThrows' started at 2025-08-04 13:31:31.090
+Test Case 'Route53ClientTests.testUpdateRecordThrows' passed (0.0 seconds)
+Test Suite 'Route53ClientTests' passed at 2025-08-04 13:31:31.090
+	 Executed 4 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
+Test Suite 'ClientGeneratorTests' started at 2025-08-04 13:31:31.090
+Test Case 'ClientGeneratorTests.testClientFilesGenerated' started at 2025-08-04 13:31:31.090
+Test Case 'ClientGeneratorTests.testClientFilesGenerated' passed (0.018 seconds)
+Test Case 'ClientGeneratorTests.testEmitRequestGeneratesQueryParameter' started at 2025-08-04 13:31:31.108
+Test Case 'ClientGeneratorTests.testEmitRequestGeneratesQueryParameter' passed (0.011 seconds)
+Test Suite 'ClientGeneratorTests' passed at 2025-08-04 13:31:31.118
+	 Executed 2 tests, with 0 failures (0 unexpected) in 0.029 (0.029) seconds
+Test Suite 'OpenAPIParameterTests' started at 2025-08-04 13:31:31.119
+Test Case 'OpenAPIParameterTests.testSwiftNameReplacesHyphenWithUnderscore' started at 2025-08-04 13:31:31.119
+Test Case 'OpenAPIParameterTests.testSwiftNameReplacesHyphenWithUnderscore' passed (0.0 seconds)
+Test Case 'OpenAPIParameterTests.testSwiftTypeUsesSchemaOrDefaultsToString' started at 2025-08-04 13:31:31.119
+Test Case 'OpenAPIParameterTests.testSwiftTypeUsesSchemaOrDefaultsToString' passed (0.0 seconds)
+Test Suite 'OpenAPIParameterTests' passed at 2025-08-04 13:31:31.119
+	 Executed 2 tests, with 0 failures (0 unexpected) in 0.0 (0.0) seconds
+Test Suite 'OpenAPISwiftTypeTests' started at 2025-08-04 13:31:31.119
+Test Case 'OpenAPISwiftTypeTests.testSchemaPropertyObjectSwiftType' started at 2025-08-04 13:31:31.119
+Test Case 'OpenAPISwiftTypeTests.testSchemaPropertyObjectSwiftType' passed (0.0 seconds)
+Test Case 'OpenAPISwiftTypeTests.testSchemaPropertySwiftType' started at 2025-08-04 13:31:31.119
+Test Case 'OpenAPISwiftTypeTests.testSchemaPropertySwiftType' passed (0.0 seconds)
+Test Case 'OpenAPISwiftTypeTests.testSchemaPropertyUnknownTypeDefaultsToString' started at 2025-08-04 13:31:31.119
+Test Case 'OpenAPISwiftTypeTests.testSchemaPropertyUnknownTypeDefaultsToString' passed (0.0 seconds)
+Test Case 'OpenAPISwiftTypeTests.testSchemaRefSwiftType' started at 2025-08-04 13:31:31.119
+Test Case 'OpenAPISwiftTypeTests.testSchemaRefSwiftType' passed (0.0 seconds)
+Test Suite 'OpenAPISwiftTypeTests' passed at 2025-08-04 13:31:31.120
+	 Executed 4 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
+Test Suite 'SecurityRequirementTests' started at 2025-08-04 13:31:31.120
+Test Case 'SecurityRequirementTests.testDecodesSchemesFromJSON' started at 2025-08-04 13:31:31.120
+Test Case 'SecurityRequirementTests.testDecodesSchemesFromJSON' passed (0.0 seconds)
+Test Case 'SecurityRequirementTests.testEncodesSchemesToJSON' started at 2025-08-04 13:31:31.120
+Test Case 'SecurityRequirementTests.testEncodesSchemesToJSON' passed (0.101 seconds)
+Test Suite 'SecurityRequirementTests' passed at 2025-08-04 13:31:31.221
+	 Executed 2 tests, with 0 failures (0 unexpected) in 0.101 (0.101) seconds
+Test Suite 'SpecLoaderTests' started at 2025-08-04 13:31:31.221
+Test Case 'SpecLoaderTests.testLoadThrowsForEmptyFile' started at 2025-08-04 13:31:31.221
+Test Case 'SpecLoaderTests.testLoadThrowsForEmptyFile' passed (0.001 seconds)
+Test Case 'SpecLoaderTests.testLoadThrowsForInvalidUTF8' started at 2025-08-04 13:31:31.221
+Test Case 'SpecLoaderTests.testLoadThrowsForInvalidUTF8' passed (0.002 seconds)
+Test Case 'SpecLoaderTests.testLoadsJSONRemovingCopyright' started at 2025-08-04 13:31:31.223
+Test Case 'SpecLoaderTests.testLoadsJSONRemovingCopyright' passed (0.001 seconds)
+Test Case 'SpecLoaderTests.testLoadsYAMLAndNormalizesInfoTitle' started at 2025-08-04 13:31:31.224
+Test Case 'SpecLoaderTests.testLoadsYAMLAndNormalizesInfoTitle' passed (0.007 seconds)
+Test Suite 'SpecLoaderTests' passed at 2025-08-04 13:31:31.232
+	 Executed 4 tests, with 0 failures (0 unexpected) in 0.011 (0.011) seconds
+Test Suite 'SpecValidatorTests' started at 2025-08-04 13:31:31.232
+Test Case 'SpecValidatorTests.testDuplicateOperationIdThrows' started at 2025-08-04 13:31:31.232
+Test Case 'SpecValidatorTests.testDuplicateOperationIdThrows' passed (0.0 seconds)
+Test Case 'SpecValidatorTests.testEmptyParameterLocationThrows' started at 2025-08-04 13:31:31.232
+Test Case 'SpecValidatorTests.testEmptyParameterLocationThrows' passed (0.0 seconds)
+Test Case 'SpecValidatorTests.testEmptyParameterNameThrows' started at 2025-08-04 13:31:31.232
+Test Case 'SpecValidatorTests.testEmptyParameterNameThrows' passed (0.0 seconds)
+Test Case 'SpecValidatorTests.testEmptyTitleThrows' started at 2025-08-04 13:31:31.232
+Test Case 'SpecValidatorTests.testEmptyTitleThrows' passed (0.0 seconds)
+Test Case 'SpecValidatorTests.testMissingPathParameterThrows' started at 2025-08-04 13:31:31.233
+Test Case 'SpecValidatorTests.testMissingPathParameterThrows' passed (0.0 seconds)
+Test Case 'SpecValidatorTests.testPathParameterMustBeRequired' started at 2025-08-04 13:31:31.233
+Test Case 'SpecValidatorTests.testPathParameterMustBeRequired' passed (0.0 seconds)
+Test Case 'SpecValidatorTests.testUnknownSecuritySchemeThrows' started at 2025-08-04 13:31:31.233
+Test Case 'SpecValidatorTests.testUnknownSecuritySchemeThrows' passed (0.0 seconds)
+Test Case 'SpecValidatorTests.testUnresolvedSchemaReferenceThrows' started at 2025-08-04 13:31:31.233
+Test Case 'SpecValidatorTests.testUnresolvedSchemaReferenceThrows' passed (0.0 seconds)
+Test Suite 'SpecValidatorTests' passed at 2025-08-04 13:31:31.233
+	 Executed 8 tests, with 0 failures (0 unexpected) in 0.002 (0.002) seconds
+Test Suite 'StringExtensionTests' started at 2025-08-04 13:31:31.233
+Test Case 'StringExtensionTests.testCamelCased' started at 2025-08-04 13:31:31.233
+Test Case 'StringExtensionTests.testCamelCased' passed (0.0 seconds)
+Test Case 'StringExtensionTests.testCamelCasedEmptyString' started at 2025-08-04 13:31:31.233
+Test Case 'StringExtensionTests.testCamelCasedEmptyString' passed (0.0 seconds)
+Test Case 'StringExtensionTests.testCamelCasedLeadingUnderscore' started at 2025-08-04 13:31:31.234
+Test Case 'StringExtensionTests.testCamelCasedLeadingUnderscore' passed (0.0 seconds)
+Test Case 'StringExtensionTests.testCamelCasedMultipleUnderscores' started at 2025-08-04 13:31:31.234
+Test Case 'StringExtensionTests.testCamelCasedMultipleUnderscores' passed (0.0 seconds)
+Test Case 'StringExtensionTests.testCamelCasedNumbers' started at 2025-08-04 13:31:31.234
+Test Case 'StringExtensionTests.testCamelCasedNumbers' passed (0.0 seconds)
+Test Case 'StringExtensionTests.testCamelCasedTrailingUnderscore' started at 2025-08-04 13:31:31.234
+Test Case 'StringExtensionTests.testCamelCasedTrailingUnderscore' passed (0.0 seconds)
+Test Case 'StringExtensionTests.testCamelCasedUppercaseInput' started at 2025-08-04 13:31:31.234
+Test Case 'StringExtensionTests.testCamelCasedUppercaseInput' passed (0.0 seconds)
+Test Suite 'StringExtensionTests' passed at 2025-08-04 13:31:31.234
+	 Executed 7 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
+Test Suite 'AsyncHTTPClientDriverTests' started at 2025-08-04 13:31:31.234
+Test Case 'AsyncHTTPClientDriverTests.testExecuteFailsForUnreachableHost' started at 2025-08-04 13:31:31.234
+Test Case 'AsyncHTTPClientDriverTests.testExecuteFailsForUnreachableHost' passed (5.003 seconds)
+Test Case 'AsyncHTTPClientDriverTests.testExecutePerformsRequest' started at 2025-08-04 13:31:36.237
+Test Case 'AsyncHTTPClientDriverTests.testExecutePerformsRequest' passed (0.004 seconds)
+Test Case 'AsyncHTTPClientDriverTests.testExecuteSendsBody' started at 2025-08-04 13:31:36.241
+Test Case 'AsyncHTTPClientDriverTests.testExecuteSendsBody' passed (0.002 seconds)
+Test Suite 'AsyncHTTPClientDriverTests' passed at 2025-08-04 13:31:36.243
+	 Executed 3 tests, with 0 failures (0 unexpected) in 5.009 (5.009) seconds
+Test Suite 'CertificateManagerTests' started at 2025-08-04 13:31:36.243
+Test Case 'CertificateManagerTests.testStartSchedulesRepeatedRuns' started at 2025-08-04 13:31:36.243
+Test Case 'CertificateManagerTests.testStartSchedulesRepeatedRuns' passed (1.043 seconds)
+Test Case 'CertificateManagerTests.testStopCancelsFutureRuns' started at 2025-08-04 13:31:37.287
+Test Case 'CertificateManagerTests.testStopCancelsFutureRuns' passed (3.003 seconds)
+Test Case 'CertificateManagerTests.testTriggerNowRunsScript' started at 2025-08-04 13:31:40.290
+Test Case 'CertificateManagerTests.testTriggerNowRunsScript' passed (1.103 seconds)
+Test Suite 'CertificateManagerTests' passed at 2025-08-04 13:31:41.393
+	 Executed 3 tests, with 0 failures (0 unexpected) in 5.149 (5.149) seconds
+Test Suite 'GatewayPluginTests' started at 2025-08-04 13:31:41.393
+Test Case 'GatewayPluginTests.testDefaultPrepareReturnsSameRequest' started at 2025-08-04 13:31:41.393
+Test Case 'GatewayPluginTests.testDefaultPrepareReturnsSameRequest' passed (0.0 seconds)
+Test Case 'GatewayPluginTests.testDefaultRespondReturnsSameResponse' started at 2025-08-04 13:31:41.393
+Test Case 'GatewayPluginTests.testDefaultRespondReturnsSameResponse' passed (0.0 seconds)
+Test Suite 'GatewayPluginTests' passed at 2025-08-04 13:31:41.393
+	 Executed 2 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
+Test Suite 'GatewayServerTests' started at 2025-08-04 13:31:41.393
+Test Case 'GatewayServerTests.testHealthEndpointResponds' started at 2025-08-04 13:31:41.393
+Test Case 'GatewayServerTests.testHealthEndpointResponds' passed (0.103 seconds)
+Test Case 'GatewayServerTests.testHealthEndpointSetsJSONContentType' started at 2025-08-04 13:31:41.497
+Test Case 'GatewayServerTests.testHealthEndpointSetsJSONContentType' passed (0.103 seconds)
+Test Case 'GatewayServerTests.testMetricsEndpointResponds' started at 2025-08-04 13:31:41.599
+Test Case 'GatewayServerTests.testMetricsEndpointResponds' passed (0.103 seconds)
+Test Case 'GatewayServerTests.testMetricsEndpointReturnsEmptyArray' started at 2025-08-04 13:31:41.702
+Test Case 'GatewayServerTests.testMetricsEndpointReturnsEmptyArray' passed (0.102 seconds)
+Test Case 'GatewayServerTests.testMetricsEndpointSetsJSONContentType' started at 2025-08-04 13:31:41.804
+Test Case 'GatewayServerTests.testMetricsEndpointSetsJSONContentType' passed (0.103 seconds)
+Test Case 'GatewayServerTests.testPluginCanRewriteRequestAndResponse' started at 2025-08-04 13:31:41.907
+Test Case 'GatewayServerTests.testPluginCanRewriteRequestAndResponse' passed (0.103 seconds)
+Test Case 'GatewayServerTests.testPluginsPrepareInRegistrationOrder' started at 2025-08-04 13:31:42.010
+Test Case 'GatewayServerTests.testPluginsPrepareInRegistrationOrder' passed (0.103 seconds)
+Test Case 'GatewayServerTests.testPluginsRespondInReverseOrder' started at 2025-08-04 13:31:42.113
+Test Case 'GatewayServerTests.testPluginsRespondInReverseOrder' passed (0.103 seconds)
+Test Case 'GatewayServerTests.testUnknownPathReturns404' started at 2025-08-04 13:31:42.216
+Test Case 'GatewayServerTests.testUnknownPathReturns404' passed (0.103 seconds)
+Test Suite 'GatewayServerTests' passed at 2025-08-04 13:31:42.319
+	 Executed 9 tests, with 0 failures (0 unexpected) in 0.925 (0.925) seconds
+Test Suite 'HTTPKernelTests' started at 2025-08-04 13:31:42.319
+Test Case 'HTTPKernelTests.testKernelPropagatesErrors' started at 2025-08-04 13:31:42.319
+Test Case 'HTTPKernelTests.testKernelPropagatesErrors' passed (0.0 seconds)
+Test Case 'HTTPKernelTests.testKernelRoutesRequest' started at 2025-08-04 13:31:42.319
+Test Case 'HTTPKernelTests.testKernelRoutesRequest' passed (0.0 seconds)
+Test Suite 'HTTPKernelTests' passed at 2025-08-04 13:31:42.319
+	 Executed 2 tests, with 0 failures (0 unexpected) in 0.0 (0.0) seconds
+Test Suite 'HTTPRequestTests' started at 2025-08-04 13:31:42.319
+Test Case 'HTTPRequestTests.testRequestDefaults' started at 2025-08-04 13:31:42.319
+Test Case 'HTTPRequestTests.testRequestDefaults' passed (0.0 seconds)
+Test Case 'HTTPRequestTests.testRequestInitializerStoresValues' started at 2025-08-04 13:31:42.319
+Test Case 'HTTPRequestTests.testRequestInitializerStoresValues' passed (0.0 seconds)
+Test Case 'HTTPRequestTests.testRequestMutation' started at 2025-08-04 13:31:42.319
+Test Case 'HTTPRequestTests.testRequestMutation' passed (0.0 seconds)
+Test Suite 'HTTPRequestTests' passed at 2025-08-04 13:31:42.319
+	 Executed 3 tests, with 0 failures (0 unexpected) in 0.0 (0.0) seconds
+Test Suite 'HTTPResponseDefaultsTests' started at 2025-08-04 13:31:42.319
+Test Case 'HTTPResponseDefaultsTests.testNoBodyCodable' started at 2025-08-04 13:31:42.319
+Test Case 'HTTPResponseDefaultsTests.testNoBodyCodable' passed (0.0 seconds)
+Test Case 'HTTPResponseDefaultsTests.testResponseBodyMutation' started at 2025-08-04 13:31:42.320
+Test Case 'HTTPResponseDefaultsTests.testResponseBodyMutation' passed (0.0 seconds)
+Test Case 'HTTPResponseDefaultsTests.testResponseDefaults' started at 2025-08-04 13:31:42.320
+Test Case 'HTTPResponseDefaultsTests.testResponseDefaults' passed (0.0 seconds)
+Test Case 'HTTPResponseDefaultsTests.testResponseHeadersMutation' started at 2025-08-04 13:31:42.320
+Test Case 'HTTPResponseDefaultsTests.testResponseHeadersMutation' passed (0.0 seconds)
+Test Case 'HTTPResponseDefaultsTests.testResponseInitializerStoresValues' started at 2025-08-04 13:31:42.320
+Test Case 'HTTPResponseDefaultsTests.testResponseInitializerStoresValues' passed (0.0 seconds)
+Test Case 'HTTPResponseDefaultsTests.testResponseStatusMutation' started at 2025-08-04 13:31:42.320
+Test Case 'HTTPResponseDefaultsTests.testResponseStatusMutation' passed (0.0 seconds)
+Test Suite 'HTTPResponseDefaultsTests' passed at 2025-08-04 13:31:42.320
+	 Executed 6 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
+Test Suite 'LoggingPluginTests' started at 2025-08-04 13:31:42.320
+Test Case 'LoggingPluginTests.testLoggingPluginPassThrough' started at 2025-08-04 13:31:42.320
+-> GET /
+<- 200 for /
+Test Case 'LoggingPluginTests.testLoggingPluginPassThrough' passed (0.0 seconds)
+Test Case 'LoggingPluginTests.testPreparePreservesHeadersAndBody' started at 2025-08-04 13:31:42.321
+-> POST /data
+Test Case 'LoggingPluginTests.testPreparePreservesHeadersAndBody' passed (0.0 seconds)
+Test Case 'LoggingPluginTests.testRespondPreservesHeadersAndBody' started at 2025-08-04 13:31:42.321
+<- 201 for /
+Test Case 'LoggingPluginTests.testRespondPreservesHeadersAndBody' passed (0.0 seconds)
+Test Suite 'LoggingPluginTests' passed at 2025-08-04 13:31:42.321
+	 Executed 3 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
+Test Suite 'NIOHTTPServerTests' started at 2025-08-04 13:31:42.321
+Test Case 'NIOHTTPServerTests.testServerHandlesConcurrentRequests' started at 2025-08-04 13:31:42.321
+Test Case 'NIOHTTPServerTests.testServerHandlesConcurrentRequests' passed (0.002 seconds)
+Test Case 'NIOHTTPServerTests.testServerReleasesPortOnStop' started at 2025-08-04 13:31:42.323
+Test Case 'NIOHTTPServerTests.testServerReleasesPortOnStop' passed (0.001 seconds)
+Test Case 'NIOHTTPServerTests.testServerResponds' started at 2025-08-04 13:31:42.324
+Test Case 'NIOHTTPServerTests.testServerResponds' passed (0.001 seconds)
+Test Suite 'NIOHTTPServerTests' passed at 2025-08-04 13:31:42.325
+	 Executed 3 tests, with 0 failures (0 unexpected) in 0.004 (0.004) seconds
+Test Suite 'PublishingFrontendPluginTests' started at 2025-08-04 13:31:42.325
+Test Case 'PublishingFrontendPluginTests.testPluginIgnoresNonGETRequests' started at 2025-08-04 13:31:42.325
+Test Case 'PublishingFrontendPluginTests.testPluginIgnoresNonGETRequests' passed (0.002 seconds)
+Test Case 'PublishingFrontendPluginTests.testPluginPassThroughWhenFileMissing' started at 2025-08-04 13:31:42.327
+Test Case 'PublishingFrontendPluginTests.testPluginPassThroughWhenFileMissing' passed (0.0 seconds)
+Test Case 'PublishingFrontendPluginTests.testPluginServesFile' started at 2025-08-04 13:31:42.327
+Test Case 'PublishingFrontendPluginTests.testPluginServesFile' passed (0.005 seconds)
+Test Case 'PublishingFrontendPluginTests.testPluginSetsContentTypeHeader' started at 2025-08-04 13:31:42.332
+Test Case 'PublishingFrontendPluginTests.testPluginSetsContentTypeHeader' passed (0.002 seconds)
+Test Suite 'PublishingFrontendPluginTests' passed at 2025-08-04 13:31:42.333
+	 Executed 4 tests, with 0 failures (0 unexpected) in 0.008 (0.008) seconds
+Test Suite 'URLSessionHTTPClientTests' started at 2025-08-04 13:31:42.333
+Test Case 'URLSessionHTTPClientTests.testExecuteCollectsMultipleHeaders' started at 2025-08-04 13:31:42.333
+Test Case 'URLSessionHTTPClientTests.testExecuteCollectsMultipleHeaders' passed (0.001 seconds)
+Test Case 'URLSessionHTTPClientTests.testExecuteHandlesEmptyBody' started at 2025-08-04 13:31:42.334
+Test Case 'URLSessionHTTPClientTests.testExecuteHandlesEmptyBody' passed (0.001 seconds)
+Test Case 'URLSessionHTTPClientTests.testExecutePerformsRequest' started at 2025-08-04 13:31:42.335
+Test Case 'URLSessionHTTPClientTests.testExecutePerformsRequest' passed (0.001 seconds)
+Test Suite 'URLSessionHTTPClientTests' passed at 2025-08-04 13:31:42.336
+	 Executed 3 tests, with 0 failures (0 unexpected) in 0.003 (0.003) seconds
+Test Suite 'APIClientTests' started at 2025-08-04 13:31:42.336
+Test Case 'APIClientTests.testBearerInitializerSetsHeader' started at 2025-08-04 13:31:42.336
+Test Case 'APIClientTests.testBearerInitializerSetsHeader' passed (0.0 seconds)
+Test Case 'APIClientTests.testRawDataResponse' started at 2025-08-04 13:31:42.336
+Test Case 'APIClientTests.testRawDataResponse' passed (0.0 seconds)
+Test Case 'APIClientTests.testSendDecodesResponse' started at 2025-08-04 13:31:42.337
+Test Case 'APIClientTests.testSendDecodesResponse' passed (0.0 seconds)
+Test Suite 'APIClientTests' passed at 2025-08-04 13:31:42.337
+	 Executed 3 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
+Test Suite 'CreatePrimaryServerRequestTests' started at 2025-08-04 13:31:42.337
+Test Case 'CreatePrimaryServerRequestTests.testMethodIsPOST' started at 2025-08-04 13:31:42.337
+Test Case 'CreatePrimaryServerRequestTests.testMethodIsPOST' passed (0.0 seconds)
+Test Case 'CreatePrimaryServerRequestTests.testPathIsCorrect' started at 2025-08-04 13:31:42.337
+Test Case 'CreatePrimaryServerRequestTests.testPathIsCorrect' passed (0.0 seconds)
+Test Suite 'CreatePrimaryServerRequestTests' passed at 2025-08-04 13:31:42.337
+	 Executed 2 tests, with 0 failures (0 unexpected) in 0.0 (0.0) seconds
+Test Suite 'DNSClientTests' started at 2025-08-04 13:31:42.337
+Test Case 'DNSClientTests.testRoute53CreateRecordErrorDetails' started at 2025-08-04 13:31:42.337
+Test Case 'DNSClientTests.testRoute53CreateRecordErrorDetails' passed (0.0 seconds)
+Test Case 'DNSClientTests.testRoute53CreateRecordStub' started at 2025-08-04 13:31:42.337
+Test Case 'DNSClientTests.testRoute53CreateRecordStub' passed (0.0 seconds)
+Test Case 'DNSClientTests.testRoute53DeleteRecordErrorDetails' started at 2025-08-04 13:31:42.338
+Test Case 'DNSClientTests.testRoute53DeleteRecordErrorDetails' passed (0.0 seconds)
+Test Case 'DNSClientTests.testRoute53DeleteRecordStub' started at 2025-08-04 13:31:42.338
+Test Case 'DNSClientTests.testRoute53DeleteRecordStub' passed (0.0 seconds)
+Test Case 'DNSClientTests.testRoute53ListZonesErrorDetails' started at 2025-08-04 13:31:42.338
+Test Case 'DNSClientTests.testRoute53ListZonesErrorDetails' passed (0.0 seconds)
+Test Case 'DNSClientTests.testRoute53Stub' started at 2025-08-04 13:31:42.338
+Test Case 'DNSClientTests.testRoute53Stub' passed (0.1 seconds)
+Test Case 'DNSClientTests.testRoute53UpdateRecordErrorDetails' started at 2025-08-04 13:31:42.439
+Test Case 'DNSClientTests.testRoute53UpdateRecordErrorDetails' passed (0.0 seconds)
+Test Case 'DNSClientTests.testRoute53UpdateRecordStub' started at 2025-08-04 13:31:42.439
+Test Case 'DNSClientTests.testRoute53UpdateRecordStub' passed (0.0 seconds)
+Test Suite 'DNSClientTests' passed at 2025-08-04 13:31:42.439
+	 Executed 8 tests, with 0 failures (0 unexpected) in 0.102 (0.102) seconds
+Test Suite 'DeletePrimaryServerRequestTests' started at 2025-08-04 13:31:42.439
+Test Case 'DeletePrimaryServerRequestTests.testMethodIsDELETE' started at 2025-08-04 13:31:42.439
+Test Case 'DeletePrimaryServerRequestTests.testMethodIsDELETE' passed (0.0 seconds)
+Test Case 'DeletePrimaryServerRequestTests.testPathIsCorrect' started at 2025-08-04 13:31:42.440
+Test Case 'DeletePrimaryServerRequestTests.testPathIsCorrect' passed (0.0 seconds)
+Test Suite 'DeletePrimaryServerRequestTests' passed at 2025-08-04 13:31:42.440
+	 Executed 2 tests, with 0 failures (0 unexpected) in 0.0 (0.0) seconds
+Test Suite 'DeleteRecordRequestTests' started at 2025-08-04 13:31:42.440
+Test Case 'DeleteRecordRequestTests.testDeleteRecordBuildsPathAndMethod' started at 2025-08-04 13:31:42.440
+Test Case 'DeleteRecordRequestTests.testDeleteRecordBuildsPathAndMethod' passed (0.0 seconds)
+Test Suite 'DeleteRecordRequestTests' passed at 2025-08-04 13:31:42.440
+	 Executed 1 test, with 0 failures (0 unexpected) in 0.0 (0.0) seconds
+Test Suite 'DeleteZoneRequestTests' started at 2025-08-04 13:31:42.440
+Test Case 'DeleteZoneRequestTests.testPathBuilderEncodesZoneId' started at 2025-08-04 13:31:42.440
+Test Case 'DeleteZoneRequestTests.testPathBuilderEncodesZoneId' passed (0.0 seconds)
+Test Suite 'DeleteZoneRequestTests' passed at 2025-08-04 13:31:42.440
+	 Executed 1 test, with 0 failures (0 unexpected) in 0.0 (0.0) seconds
+Test Suite 'GetPrimaryServerRequestTests' started at 2025-08-04 13:31:42.440
+Test Case 'GetPrimaryServerRequestTests.testMethodIsGET' started at 2025-08-04 13:31:42.440
+Test Case 'GetPrimaryServerRequestTests.testMethodIsGET' passed (0.0 seconds)
+Test Case 'GetPrimaryServerRequestTests.testPathBuilderReplacesId' started at 2025-08-04 13:31:42.440
+Test Case 'GetPrimaryServerRequestTests.testPathBuilderReplacesId' passed (0.0 seconds)
+Test Suite 'GetPrimaryServerRequestTests' passed at 2025-08-04 13:31:42.440
+	 Executed 2 tests, with 0 failures (0 unexpected) in 0.0 (0.0) seconds
+Test Suite 'GetRecordRequestTests' started at 2025-08-04 13:31:42.440
+Test Case 'GetRecordRequestTests.testPathBuilderReplacesRecordId' started at 2025-08-04 13:31:42.440
+Test Case 'GetRecordRequestTests.testPathBuilderReplacesRecordId' passed (0.0 seconds)
+Test Suite 'GetRecordRequestTests' passed at 2025-08-04 13:31:42.440
+	 Executed 1 test, with 0 failures (0 unexpected) in 0.0 (0.0) seconds
+Test Suite 'GetZoneRequestTests' started at 2025-08-04 13:31:42.441
+Test Case 'GetZoneRequestTests.testPathBuilderReplacesZoneId' started at 2025-08-04 13:31:42.441
+Test Case 'GetZoneRequestTests.testPathBuilderReplacesZoneId' passed (0.0 seconds)
+Test Suite 'GetZoneRequestTests' passed at 2025-08-04 13:31:42.441
+	 Executed 1 test, with 0 failures (0 unexpected) in 0.0 (0.0) seconds
+Test Suite 'HetznerDNSClientTests' started at 2025-08-04 13:31:42.441
+Test Case 'HetznerDNSClientTests.testCreateRecordRequest' started at 2025-08-04 13:31:42.441
+Test Case 'HetznerDNSClientTests.testCreateRecordRequest' passed (0.001 seconds)
+Test Case 'HetznerDNSClientTests.testCreateRecordSetsContentTypeHeader' started at 2025-08-04 13:31:42.441
+Test Case 'HetznerDNSClientTests.testCreateRecordSetsContentTypeHeader' passed (0.0 seconds)
+Test Case 'HetznerDNSClientTests.testDeleteRecordRequest' started at 2025-08-04 13:31:42.442
+Test Case 'HetznerDNSClientTests.testDeleteRecordRequest' passed (0.0 seconds)
+Test Case 'HetznerDNSClientTests.testDeleteRecordSetsAuthHeader' started at 2025-08-04 13:31:42.442
+Test Case 'HetznerDNSClientTests.testDeleteRecordSetsAuthHeader' passed (0.0 seconds)
+Test Case 'HetznerDNSClientTests.testListZonesPathBuilder' started at 2025-08-04 13:31:42.442
+Test Case 'HetznerDNSClientTests.testListZonesPathBuilder' passed (0.0 seconds)
+Test Case 'HetznerDNSClientTests.testListZonesReturnsIDs' started at 2025-08-04 13:31:42.442
+Test Case 'HetznerDNSClientTests.testListZonesReturnsIDs' passed (0.001 seconds)
+Test Case 'HetznerDNSClientTests.testUpdateRecordRequest' started at 2025-08-04 13:31:42.443
+Test Case 'HetznerDNSClientTests.testUpdateRecordRequest' passed (0.0 seconds)
+Test Case 'HetznerDNSClientTests.testUpdateRecordSetsAuthHeader' started at 2025-08-04 13:31:42.443
+Test Case 'HetznerDNSClientTests.testUpdateRecordSetsAuthHeader' passed (0.0 seconds)
+Test Suite 'HetznerDNSClientTests' passed at 2025-08-04 13:31:42.443
+	 Executed 8 tests, with 0 failures (0 unexpected) in 0.003 (0.003) seconds
+Test Suite 'ListPrimaryServersRequestTests' started at 2025-08-04 13:31:42.443
+Test Case 'ListPrimaryServersRequestTests.testPathBuilderAddsZoneIdQueryWhenProvided' started at 2025-08-04 13:31:42.443
+Test Case 'ListPrimaryServersRequestTests.testPathBuilderAddsZoneIdQueryWhenProvided' passed (0.0 seconds)
+Test Case 'ListPrimaryServersRequestTests.testPathBuilderWithoutZoneIdHasNoQuery' started at 2025-08-04 13:31:42.444
+Test Case 'ListPrimaryServersRequestTests.testPathBuilderWithoutZoneIdHasNoQuery' passed (0.0 seconds)
+Test Suite 'ListPrimaryServersRequestTests' passed at 2025-08-04 13:31:42.444
+	 Executed 2 tests, with 0 failures (0 unexpected) in 0.0 (0.0) seconds
+Test Suite 'ListRecordsRequestTests' started at 2025-08-04 13:31:42.444
+Test Case 'ListRecordsRequestTests.testPathBuilderEncodesQuery' started at 2025-08-04 13:31:42.444
+Test Case 'ListRecordsRequestTests.testPathBuilderEncodesQuery' passed (0.0 seconds)
+Test Suite 'ListRecordsRequestTests' passed at 2025-08-04 13:31:42.444
+	 Executed 1 test, with 0 failures (0 unexpected) in 0.0 (0.0) seconds
+Test Suite 'UpdateRecordRequestTests' started at 2025-08-04 13:31:42.444
+Test Case 'UpdateRecordRequestTests.testUpdateRecordBuildsPathAndMethod' started at 2025-08-04 13:31:42.444
+Test Case 'UpdateRecordRequestTests.testUpdateRecordBuildsPathAndMethod' passed (0.0 seconds)
+Test Case 'UpdateRecordRequestTests.testUpdateRecordStoresBody' started at 2025-08-04 13:31:42.444
+Test Case 'UpdateRecordRequestTests.testUpdateRecordStoresBody' passed (0.0 seconds)
+Test Suite 'UpdateRecordRequestTests' passed at 2025-08-04 13:31:42.444
+	 Executed 2 tests, with 0 failures (0 unexpected) in 0.0 (0.0) seconds
+Test Suite 'release.xctest' passed at 2025-08-04 13:31:42.444
+	 Executed 152 tests, with 0 failures (0 unexpected) in 11.711 (11.711) seconds
+Test Suite 'All tests' passed at 2025-08-04 13:31:42.444
+	 Executed 152 tests, with 0 failures (0 unexpected) in 11.711 (11.711) seconds
+◇ Test run started.
+↳ Testing Library Version: 6.1 (43b6f88e2f2712e)
+↳ Target Platform: x86_64-unknown-linux-gnu
+✔ Test run with 0 tests passed after 0.001 seconds.
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- document LoggingPlugin request and response handlers to clarify pass-through behavior
- test LoggingPlugin preserves headers and bodies for prepare/respond
- record logging plugin documentation and updated coverage metrics

## Testing
- `Scripts/run-tests.sh`
- `llvm-cov-19 report .build/x86_64-unknown-linux-gnu/release/FountainCoachPackageTests.xctest -instr-profile .build/x86_64-unknown-linux-gnu/release/codecov/default.profdata`
- `llvm-cov-19 report .build/x86_64-unknown-linux-gnu/release/FountainCoachPackageTests.xctest -instr-profile .build/x86_64-unknown-linux-gnu/release/codecov/default.profdata -ignore-filename-regex='(\.build|/Tests/)'`


------
https://chatgpt.com/codex/tasks/task_e_6890b41d6f648325aca99bd32ad5864f