### PR TITLE
Document APIClient send behavior and expand tests

### DIFF
--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -5,10 +5,10 @@
 Running `swift test --enable-code-coverage` and analysing with `llvm-cov` produced the following totals:
 
 ```
-TOTAL                                          32097   26285    18.11%   14552 11399    21.67%  100080 80540    19.52%
+TOTAL                                          32112   26324    18.02%   14564 11415    21.62%  100116 80731    19.36%
 ```
 
-The repository contains **100,080** executable lines, with **19,540** lines covered (approx. **19.52%** line coverage).
+The repository contains **100,116** executable lines, with **19,385** lines covered (approx. **19.36%** line coverage).
 
 ### Repository source coverage
 
@@ -92,5 +92,6 @@ The new ``DeletePrimaryServerRequestTests`` raise the total test count to **105*
 
 - The new ``PublishingFrontendPlugin`` nested-file and header-preservation tests raise the total test count to **154**.
 - The new ``LoadPublishingConfigUsesDefaultRootPathWhenMissing`` and ``LoadPublishingConfigUsesDefaultPortWhenMissing`` tests raise the total test count to **156**.
+- The new ``APIClient`` NoBody and header omission tests raise the total test count to **158**.
 ---
 © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/PublishingFrontend/HetznerDNSClient/APIClient.swift
+++ b/Sources/PublishingFrontend/HetznerDNSClient/APIClient.swift
@@ -39,6 +39,8 @@ public struct APIClient {
     }
 
     /// Executes an ``APIRequest`` and decodes the server response.
+    /// When ``R.Response`` is ``Data``, the raw bytes are returned directly.
+    /// If ``R.Response`` is ``NoBody``, the response payload is discarded and an empty instance is provided.
     /// - Parameter request: The request to perform.
     /// - Returns: The decoded response value for ``R.Response``.
     public func send<R: APIRequest>(_ request: R) async throws -> R.Response {

--- a/Tests/DNSTests/APIClientTests.swift
+++ b/Tests/DNSTests/APIClientTests.swift
@@ -61,6 +61,36 @@ final class APIClientTests: XCTestCase {
         XCTAssertEqual(result, expected)
         XCTAssertEqual(session.request?.value(forHTTPHeaderField: "Content-Type"), "application/json")
     }
+
+    /// Returns a ``NoBody`` instance when the response type is ``NoBody``.
+    func testNoBodyResponseReturnsInstance() async throws {
+        struct Ping: APIRequest {
+            typealias Response = NoBody
+            var method: String { "GET" }
+            var path: String { "/ping" }
+            var body: NoBody? = nil
+        }
+        let session = MockSession(responseData: Data("ignored".utf8))
+        let client = APIClient(baseURL: URL(string: "http://localhost")!, session: session)
+        let result: NoBody = try await client.send(Ping())
+        _ = result
+        XCTAssertNil(session.request?.value(forHTTPHeaderField: "Content-Type"))
+    }
+
+    /// Ensures requests without bodies omit the `Content-Type` header.
+    func testRequestWithoutBodyOmitsContentType() async throws {
+        struct Echo: APIRequest {
+            typealias Response = String
+            var method: String { "GET" }
+            var path: String { "/echo" }
+            var body: NoBody? = nil
+        }
+        let data = try JSONEncoder().encode("ok")
+        let session = MockSession(responseData: data)
+        let client = APIClient(baseURL: URL(string: "http://localhost")!, session: session)
+        _ = try await client.send(Echo())
+        XCTAssertNil(session.request?.value(forHTTPHeaderField: "Content-Type"))
+    }
 }
 
 // © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/docs/README.md
+++ b/docs/README.md
@@ -84,6 +84,7 @@ As modules gain documentation, brief summaries are added here.
 - **ClientGenerator.emitRequest** – documents generation of request types handling path and query parameters.
 - **renew-certs.sh** – script obtaining TLS certificates via `certbot` with configurable environment variables.
 - **loadPublishingConfig** – documents error handling for missing files, invalid YAML, and defaulting of absent keys.
+- **APIClient.send** – documents special handling for `Data` and `NoBody` responses.
 
 Documentation coverage will expand alongside test coverage.
 


### PR DESCRIPTION
## Summary
- clarify APIClient.send behavior for raw Data and NoBody responses
- add APIClient tests for NoBody handling and Content-Type omission
- track documentation and coverage progress

## Testing
- `Scripts/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6890c22672408325b36f3e7af0dd81a6