### PR TITLE
docs: align OpenAPI specs with server routes

### DIFF
--- a/Sources/FountainOps/FountainAi/openAPI/v1/baseline-awareness.yml
+++ b/Sources/FountainOps/FountainAi/openAPI/v1/baseline-awareness.yml
@@ -229,6 +229,32 @@ paths:
                 type: object
         '422':
           description: Validation Error
+  /corpus/history/stream:
+    get:
+      summary: Stream History Analytics
+      operationId: streamHistoryAnalytics
+      description: Stream historical analytics of the corpus.
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: object
+        '422':
+          description: Validation Error
+  /metrics:
+    get:
+      summary: Metrics
+      description: Endpoint that serves Prometheus metrics.
+      operationId: metrics_metrics_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            text/plain:
+              schema:
+                type: string
 components:
   schemas:
     BaselineRequest:

--- a/Sources/FountainOps/FountainAi/openAPI/v1/bootstrap.yml
+++ b/Sources/FountainOps/FountainAi/openAPI/v1/bootstrap.yml
@@ -189,6 +189,18 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /metrics:
+    get:
+      summary: Metrics
+      description: Endpoint that serves Prometheus metrics.
+      operationId: metrics_metrics_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            text/plain:
+              schema:
+                type: string
 components:
   schemas:
     BaselineIn:

--- a/Sources/FountainOps/FountainAi/openAPI/v1/function-caller.yml
+++ b/Sources/FountainOps/FountainAi/openAPI/v1/function-caller.yml
@@ -128,6 +128,19 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  /metrics:
+    get:
+      summary: Metrics
+      description: Endpoint that serves Prometheus metrics.
+      operationId: metrics_metrics_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            text/plain:
+              schema:
+                type: string
+
 components:
   schemas:
     FunctionInfo:

--- a/Sources/FountainOps/FountainAi/openAPI/v1/persist.yml
+++ b/Sources/FountainOps/FountainAi/openAPI/v1/persist.yml
@@ -277,6 +277,19 @@ paths:
         '404':
           $ref: '#/components/responses/ErrorResponse'
 
+  /metrics:
+    get:
+      summary: Metrics
+      description: Endpoint that serves Prometheus metrics.
+      operationId: metrics_metrics_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            text/plain:
+              schema:
+                type: string
+
 components:
   schemas:
     BaseEntity:

--- a/Sources/FountainOps/FountainAi/openAPI/v1/planner.yml
+++ b/Sources/FountainOps/FountainAi/openAPI/v1/planner.yml
@@ -164,6 +164,18 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /metrics:
+    get:
+      summary: Metrics
+      description: Endpoint that serves Prometheus metrics.
+      operationId: metrics_metrics_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            text/plain:
+              schema:
+                type: string
 components:
   schemas:
     ChatReflectionRequest:

--- a/Sources/FountainOps/FountainAi/openAPI/v1/tools-factory.yml
+++ b/Sources/FountainOps/FountainAi/openAPI/v1/tools-factory.yml
@@ -70,7 +70,18 @@ paths:
                 $ref: '#/components/schemas/FunctionListResponse'
         '422':
           $ref: '#/components/responses/ValidationErrorResponse'
-
+  /metrics:
+    get:
+      summary: Metrics
+      description: Endpoint that serves Prometheus metrics.
+      operationId: metrics_metrics_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            text/plain:
+              schema:
+                type: string
 components:
   schemas:
     FunctionInfo:

--- a/agent.md
+++ b/agent.md
@@ -23,7 +23,7 @@ This agent maintains an up-to-date view of outstanding development tasks across 
 | CI pipeline            | root                                     | Add CI workflow to run tests and coverage                        | ❌     | Choose CI platform                        | ci, test          |
 | Test coverage          | various                                  | Expand tests for under-tested modules (e.g., stubs)              | ⚠️     | Missing implementations, time             | test              |
 | Documentation sync     | `docs` vs `code`                         | Update developer docs with actual CLI entrypoints and generators | ✅     | None                                   | docs, cli         |
-| OpenAPI specs          | `Sources/FountainOps/FountainAi/openAPI`| Ensure specs reflect implemented endpoints                       | ⚠️     | Spec changes vs code divergence           | parser, docs      |
+| OpenAPI specs          | `Sources/FountainOps/FountainAi/openAPI`| Ensure specs reflect implemented endpoints                       | ✅     | None           | parser, docs      |
 
 ---
 

--- a/logs/openapi-20250804192804.log
+++ b/logs/openapi-20250804192804.log
@@ -1,0 +1,3 @@
+[2025-08-04T19:28:04Z] OpenAPI specs: added metrics endpoints and history streaming to match server routes.
+[2025-08-04T19:28:04Z] Tests: swift test passed.
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/logs/test-20250804192322.log
+++ b/logs/test-20250804192322.log
@@ -1,0 +1,1762 @@
+Fetching https://github.com/apple/swift-nio.git
+Fetching https://github.com/swift-server/async-http-client.git
+Fetching https://github.com/jpsim/Yams.git
+[1/10997] Fetching yams
+[331/25062] Fetching yams, async-http-client
+[15716/102258] Fetching yams, async-http-client, swift-nio
+Fetched https://github.com/swift-server/async-http-client.git from cache (1.24s)
+[30635/88193] Fetching yams, swift-nio
+Fetched https://github.com/jpsim/Yams.git from cache (1.79s)
+[50178/77196] Fetching swift-nio
+Fetched https://github.com/apple/swift-nio.git from cache (5.50s)
+Computing version for https://github.com/jpsim/Yams.git
+Computed https://github.com/jpsim/Yams.git at 5.4.0 (8.87s)
+Computing version for https://github.com/swift-server/async-http-client.git
+Computed https://github.com/swift-server/async-http-client.git at 1.26.1 (0.83s)
+Fetching https://github.com/apple/swift-log.git
+Fetching https://github.com/apple/swift-atomics.git
+Fetching https://github.com/apple/swift-algorithms.git
+[1/3880] Fetching swift-log
+[2/9839] Fetching swift-log, swift-algorithms
+[9840/11647] Fetching swift-log, swift-algorithms, swift-atomics
+Fetched https://github.com/apple/swift-log.git from cache (0.76s)
+Fetching https://github.com/apple/swift-nio-transport-services.git
+Fetched https://github.com/apple/swift-atomics.git from cache (0.91s)
+Fetched https://github.com/apple/swift-algorithms.git from cache (0.91s)
+Fetching https://github.com/apple/swift-nio-http2.git
+Fetching https://github.com/apple/swift-nio-extras.git
+[1/2701] Fetching swift-nio-transport-services
+[1568/8824] Fetching swift-nio-transport-services, swift-nio-extras
+[7050/20485] Fetching swift-nio-transport-services, swift-nio-extras, swift-nio-http2
+Fetched https://github.com/apple/swift-nio-transport-services.git from cache (0.70s)
+[6590/17784] Fetching swift-nio-extras, swift-nio-http2
+Fetching https://github.com/apple/swift-nio-ssl.git
+Fetched https://github.com/apple/swift-nio-extras.git from cache (0.70s)
+[2799/11661] Fetching swift-nio-http2
+[11662/26646] Fetching swift-nio-http2, swift-nio-ssl
+Fetched https://github.com/apple/swift-nio-http2.git from cache (1.43s)
+[3897/14985] Fetching swift-nio-ssl
+Fetched https://github.com/apple/swift-nio-ssl.git from cache (2.10s)
+Computing version for https://github.com/apple/swift-nio-transport-services.git
+Computed https://github.com/apple/swift-nio-transport-services.git at 1.25.0 (4.44s)
+Computing version for https://github.com/apple/swift-nio.git
+Computed https://github.com/apple/swift-nio.git at 2.85.0 (1.21s)
+Fetching https://github.com/apple/swift-system.git
+Fetching https://github.com/apple/swift-collections.git
+[1/4839] Fetching swift-system
+[437/21766] Fetching swift-system, swift-collections
+Fetched https://github.com/apple/swift-system.git from cache (1.47s)
+Fetched https://github.com/apple/swift-collections.git from cache (1.48s)
+Computing version for https://github.com/apple/swift-atomics.git
+Computed https://github.com/apple/swift-atomics.git at 1.3.0 (2.37s)
+Computing version for https://github.com/apple/swift-nio-http2.git
+Computed https://github.com/apple/swift-nio-http2.git at 1.38.0 (0.88s)
+Computing version for https://github.com/apple/swift-algorithms.git
+Computed https://github.com/apple/swift-algorithms.git at 1.2.1 (0.95s)
+Fetching https://github.com/apple/swift-numerics.git
+[1/5769] Fetching swift-numerics
+Fetched https://github.com/apple/swift-numerics.git from cache (0.66s)
+Computing version for https://github.com/apple/swift-nio-ssl.git
+Computed https://github.com/apple/swift-nio-ssl.git at 2.33.0 (1.68s)
+Computing version for https://github.com/apple/swift-numerics.git
+Computed https://github.com/apple/swift-numerics.git at 1.0.3 (0.98s)
+Computing version for https://github.com/apple/swift-log.git
+Computed https://github.com/apple/swift-log.git at 1.6.4 (0.82s)
+Computing version for https://github.com/apple/swift-nio-extras.git
+Computed https://github.com/apple/swift-nio-extras.git at 1.29.0 (0.90s)
+Fetching https://github.com/swift-server/swift-service-lifecycle.git
+Fetching https://github.com/apple/swift-async-algorithms.git
+Fetching https://github.com/apple/swift-asn1.git
+[1/2433] Fetching swift-service-lifecycle
+[50/4062] Fetching swift-service-lifecycle, swift-asn1
+[717/9074] Fetching swift-service-lifecycle, swift-asn1, swift-async-algorithms
+Fetched https://github.com/apple/swift-asn1.git from cache (0.61s)
+Fetched https://github.com/apple/swift-async-algorithms.git from cache (0.61s)
+Fetched https://github.com/swift-server/swift-service-lifecycle.git from cache (0.61s)
+Fetching https://github.com/apple/swift-certificates.git
+Fetching https://github.com/apple/swift-http-types.git
+Fetching https://github.com/apple/swift-http-structured-headers.git
+[1/1176] Fetching swift-http-structured-headers
+[872/2093] Fetching swift-http-structured-headers, swift-http-types
+[1184/8553] Fetching swift-http-structured-headers, swift-http-types, swift-certificates
+Fetched https://github.com/apple/swift-http-types.git from cache (0.52s)
+[1887/7636] Fetching swift-http-structured-headers, swift-certificates
+Fetched https://github.com/apple/swift-http-structured-headers.git from cache (0.55s)
+[1422/6460] Fetching swift-certificates
+Fetched https://github.com/apple/swift-certificates.git from cache (0.74s)
+Computing version for https://github.com/swift-server/swift-service-lifecycle.git
+Computed https://github.com/swift-server/swift-service-lifecycle.git at 2.8.0 (2.18s)
+Computing version for https://github.com/apple/swift-async-algorithms.git
+Computed https://github.com/apple/swift-async-algorithms.git at 1.0.4 (0.91s)
+Computing version for https://github.com/apple/swift-asn1.git
+Computed https://github.com/apple/swift-asn1.git at 1.4.0 (0.92s)
+Computing version for https://github.com/apple/swift-certificates.git
+Computed https://github.com/apple/swift-certificates.git at 1.11.0 (0.98s)
+Fetching https://github.com/apple/swift-crypto.git
+[1/15976] Fetching swift-crypto
+Fetched https://github.com/apple/swift-crypto.git from cache (1.92s)
+Computing version for https://github.com/apple/swift-http-types.git
+Computed https://github.com/apple/swift-http-types.git at 1.4.0 (2.77s)
+Computing version for https://github.com/apple/swift-http-structured-headers.git
+Computed https://github.com/apple/swift-http-structured-headers.git at 1.3.0 (0.79s)
+Computing version for https://github.com/apple/swift-system.git
+Computed https://github.com/apple/swift-system.git at 1.6.2 (0.87s)
+Computing version for https://github.com/apple/swift-crypto.git
+Computed https://github.com/apple/swift-crypto.git at 3.13.3 (1.94s)
+Computing version for https://github.com/apple/swift-collections.git
+Computed https://github.com/apple/swift-collections.git at 1.2.1 (1.21s)
+Creating working copy for https://github.com/apple/swift-asn1.git
+Working copy of https://github.com/apple/swift-asn1.git resolved at 1.4.0
+Creating working copy for https://github.com/apple/swift-http-structured-headers.git
+Working copy of https://github.com/apple/swift-http-structured-headers.git resolved at 1.3.0
+Creating working copy for https://github.com/apple/swift-numerics.git
+Working copy of https://github.com/apple/swift-numerics.git resolved at 1.0.3
+Creating working copy for https://github.com/apple/swift-http-types.git
+Working copy of https://github.com/apple/swift-http-types.git resolved at 1.4.0
+Creating working copy for https://github.com/apple/swift-crypto.git
+Working copy of https://github.com/apple/swift-crypto.git resolved at 3.13.3
+Creating working copy for https://github.com/apple/swift-atomics.git
+Working copy of https://github.com/apple/swift-atomics.git resolved at 1.3.0
+Creating working copy for https://github.com/jpsim/Yams.git
+Working copy of https://github.com/jpsim/Yams.git resolved at 5.4.0
+Creating working copy for https://github.com/apple/swift-nio.git
+Working copy of https://github.com/apple/swift-nio.git resolved at 2.85.0
+Creating working copy for https://github.com/apple/swift-algorithms.git
+Working copy of https://github.com/apple/swift-algorithms.git resolved at 1.2.1
+Creating working copy for https://github.com/apple/swift-nio-extras.git
+Working copy of https://github.com/apple/swift-nio-extras.git resolved at 1.29.0
+Creating working copy for https://github.com/apple/swift-nio-http2.git
+Working copy of https://github.com/apple/swift-nio-http2.git resolved at 1.38.0
+Creating working copy for https://github.com/apple/swift-async-algorithms.git
+Working copy of https://github.com/apple/swift-async-algorithms.git resolved at 1.0.4
+Creating working copy for https://github.com/swift-server/async-http-client.git
+Working copy of https://github.com/swift-server/async-http-client.git resolved at 1.26.1
+Creating working copy for https://github.com/swift-server/swift-service-lifecycle.git
+Working copy of https://github.com/swift-server/swift-service-lifecycle.git resolved at 2.8.0
+Creating working copy for https://github.com/apple/swift-log.git
+Working copy of https://github.com/apple/swift-log.git resolved at 1.6.4
+Creating working copy for https://github.com/apple/swift-collections.git
+Working copy of https://github.com/apple/swift-collections.git resolved at 1.2.1
+Creating working copy for https://github.com/apple/swift-nio-ssl.git
+Working copy of https://github.com/apple/swift-nio-ssl.git resolved at 2.33.0
+Creating working copy for https://github.com/apple/swift-system.git
+Working copy of https://github.com/apple/swift-system.git resolved at 1.6.2
+Creating working copy for https://github.com/apple/swift-nio-transport-services.git
+Working copy of https://github.com/apple/swift-nio-transport-services.git resolved at 1.25.0
+Creating working copy for https://github.com/apple/swift-certificates.git
+Working copy of https://github.com/apple/swift-certificates.git resolved at 1.11.0
+Building for debugging...
+[0/507] Write sources
+[11/507] Compiling buf.cc
+[12/507] Compiling ber.cc
+[12/507] Write sources
+[15/507] Compiling asn1_compat.cc
+[16/507] Write sources
+[35/507] Write swift-version--4EAD98957C2213E4.txt
+[36/507] Compiling cbb.cc
+[37/507] Compiling _AtomicsShims.c
+[38/507] Compiling _NumericsShims _NumericsShims.c
+[39/507] Compiling writer.c
+[40/527] Compiling scanner.c
+[42/540] Emitting module InternalCollectionsUtilities
+[43/542] Compiling _NIOBase64 Base64.swift
+[44/542] Emitting module _NIOBase64
+[45/542] Compiling InternalCollectionsUtilities UInt+reversed.swift
+[46/542] Compiling InternalCollectionsUtilities _UnsafeBitSet+Index.swift
+[49/543] Compiling InternalCollectionsUtilities _UnsafeBitSet+_Word.swift
+[50/545] Compiling InternalCollectionsUtilities UnsafeBufferPointer+Extras.swift
+[51/545] Compiling InternalCollectionsUtilities UnsafeMutableBufferPointer+Extras.swift
+[52/545] Compiling InternalCollectionsUtilities FixedWidthInteger+roundUpToPowerOfTwo.swift
+[53/545] Compiling InternalCollectionsUtilities Integer rank.swift
+[54/545] Compiling InternalCollectionsUtilities Descriptions.swift
+[55/545] Compiling InternalCollectionsUtilities RandomAccessCollection+Offsets.swift
+[57/545] Emitting module RealModule
+[59/545] Compiling InternalCollectionsUtilities Debugging.swift
+[60/545] Compiling _NIODataStructures PriorityQueue.swift
+[61/545] Compiling _NIODataStructures _TinyArray.swift
+[65/545] Compiling RealModule RealFunctions.swift
+[66/545] Compiling InternalCollectionsUtilities _SortedCollection.swift
+[67/545] Compiling InternalCollectionsUtilities _UniqueCollection.swift
+[70/545] Compiling RealModule Real.swift
+[74/549] Wrapping AST for _NIOBase64 for debugging
+[76/549] Compiling FountainCore Models.swift
+[77/549] Emitting module FountainCore
+[78/564] Wrapping AST for InternalCollectionsUtilities for debugging
+[80/564] Compiling Logging MetadataProvider.swift
+[80/564] Wrapping AST for RealModule for debugging
+[82/564] Compiling Logging Locks.swift
+[83/564] Compiling _NIODataStructures Heap.swift
+[84/564] Emitting module _NIODataStructures
+[85/567] Compiling DequeModule Deque+Hashable.swift
+[86/567] Compiling DequeModule Deque+Testing.swift
+[87/567] Compiling DequeModule Deque._Storage.swift
+[88/567] Compiling DequeModule Deque+Equatable.swift
+[89/567] Compiling DequeModule Deque+ExpressibleByArrayLiteral.swift
+[90/567] Compiling DequeModule Deque+Extras.swift
+[91/570] Compiling DequeModule Deque+Codable.swift
+[92/570] Compiling DequeModule Deque+Collection.swift
+[93/570] Compiling DequeModule Deque+CustomReflectable.swift
+[94/570] Compiling DequeModule Deque+Descriptions.swift
+[94/570] Wrapping AST for FountainCore for debugging
+[97/570] Emitting module Logging
+[98/570] Compiling Logging LogHandler.swift
+[99/570] Compiling Logging Logging.swift
+[99/570] Compiling reader.c
+[101/571] Compiling DequeModule Deque._UnsafeHandle.swift
+[102/571] Compiling DequeModule Deque.swift
+[103/571] Compiling DequeModule _DequeBuffer.swift
+[104/571] Emitting module DequeModule
+[104/571] Compiling parser.c
+[106/571] Wrapping AST for _NIODataStructures for debugging
+[108/571] Compiling DequeModule _DequeBufferHeader.swift
+[109/571] Compiling DequeModule _DequeSlot.swift
+[110/571] Compiling DequeModule _UnsafeWrappedBuffer.swift
+[110/572] Compiling emitter.c
+[111/572] Wrapping AST for Logging for debugging
+[112/572] Compiling api.c
+[113/572] Compiling CNIOWindows shim.c
+[114/572] Compiling CNIOWindows WSAStartup.c
+[116/572] Compiling CNIOWASI CNIOWASI.c
+[117/572] Compiling CNIOPosix event_loop_id.c
+[118/572] Compiling CNIOLinux liburing_shims.c
+[119/590] Compiling CNIOLinux shim.c
+[120/590] Wrapping AST for DequeModule for debugging
+[121/590] Compiling CNIOLLHTTP c_nio_http.c
+[122/590] Compiling CNIOExtrasZlib empty.c
+[123/590] Compiling CNIODarwin shim.c
+[124/590] Compiling CNIOLLHTTP c_nio_api.c
+[125/590] Compiling CNIOLLHTTP c_nio_llhttp.c
+[126/590] Compiling fiat_p256_adx_sqr.S
+[127/590] Compiling fiat_p256_adx_mul.S
+[128/590] Compiling fiat_curve25519_adx_square.S
+[129/590] Compiling fiat_curve25519_adx_mul.S
+[130/590] Compiling CNIOBoringSSLShims shims.c
+[131/590] Compiling tls_record.cc
+[131/590] Compiling tls_method.cc
+[133/590] Compiling tls13_server.cc
+[135/590] Compiling FountainCoreTests FountainCoreTests.swift
+[136/590] Emitting module FountainCoreTests
+[138/591] Compiling Yams Encoder.swift
+[139/591] Compiling Yams Mark.swift
+[140/591] Compiling Yams Node.Alias.swift
+[141/591] Compiling Yams Node.Mapping.swift
+[142/595] Emitting module Yams
+[143/595] Compiling Yams RedundancyAliasingStrategy.swift
+[144/595] Compiling Yams Representer.swift
+[145/595] Compiling Yams Resolver.swift
+[146/595] Compiling Yams String+Yams.swift
+[147/595] Compiling Yams Tag.swift
+[148/595] Compiling Yams YamlAnchorProviding.swift
+[149/595] Compiling Yams YamlError.swift
+[150/595] Compiling Yams YamlTagProviding.swift
+[150/595] Compiling tls13_enc.cc
+[151/595] Wrapping AST for FountainCoreTests for debugging
+[152/595] Compiling tls13_client.cc
+[153/595] Compiling tls13_both.cc
+[155/595] Compiling Yams Node.Scalar.swift
+[156/595] Compiling Yams Node.Sequence.swift
+[157/595] Compiling Yams Node.swift
+[158/595] Compiling Yams Parser.swift
+[159/595] Compiling Yams AliasDereferencingStrategy.swift
+[160/595] Compiling Yams Anchor.swift
+[161/595] Compiling Yams Constructor.swift
+[162/595] Compiling Yams Decoder.swift
+[163/595] Compiling Yams Emitter.swift
+[163/596] Compiling t1_enc.cc
+[165/596] Wrapping AST for Yams for debugging
+[166/596] Compiling ssl_transcript.cc
+[167/596] Compiling ssl_versions.cc
+[168/596] Compiling ssl_stat.cc
+[169/596] Compiling ssl_x509.cc
+[170/596] Compiling ssl_session.cc
+[171/596] Compiling ssl_privkey.cc
+[172/596] Compiling ssl_file.cc
+[173/596] Compiling ssl_key_share.cc
+[174/596] Compiling ssl_lib.cc
+[175/596] Compiling ssl_credential.cc
+[176/596] Compiling ssl_buffer.cc
+[177/596] Compiling ssl_cipher.cc
+[178/596] Compiling ssl_cert.cc
+[179/596] Compiling ssl_asn1.cc
+[180/596] Compiling ssl_aead_ctx.cc
+[181/596] Compiling s3_pkt.cc
+[182/596] Compiling s3_lib.cc
+[183/596] Compiling s3_both.cc
+[184/596] Compiling handshake_server.cc
+[185/596] Compiling handshake_client.cc
+[186/596] Compiling handshake.cc
+[187/596] Compiling handoff.cc
+[188/596] Compiling extensions.cc
+[189/596] Compiling encrypted_client_hello.cc
+[190/596] Compiling dtls_record.cc
+[191/596] Compiling dtls_method.cc
+[192/596] Compiling d1_srtp.cc
+[193/596] Compiling md5-x86_64-linux.S
+[194/596] Compiling md5-x86_64-apple.S
+[195/596] Compiling md5-586-linux.S
+[196/596] Compiling d1_pkt.cc
+[197/596] Compiling md5-586-apple.S
+[198/596] Compiling chacha20_poly1305_x86_64-linux.S
+[199/596] Compiling err_data.cc
+[200/596] Compiling bio_ssl.cc
+[201/596] Compiling d1_lib.cc
+[202/596] Compiling chacha20_poly1305_x86_64-apple.S
+[203/596] Compiling chacha20_poly1305_armv8-win.S
+[204/596] Compiling chacha20_poly1305_armv8-linux.S
+[205/596] Compiling chacha20_poly1305_armv8-apple.S
+[206/596] Compiling chacha-x86_64-linux.S
+[207/596] Compiling chacha-x86_64-apple.S
+[208/596] Compiling chacha-x86-apple.S
+[209/596] Compiling chacha-x86-linux.S
+[210/596] Compiling chacha-armv8-win.S
+[211/596] Compiling d1_both.cc
+[212/596] Compiling chacha-armv8-linux.S
+[213/596] Compiling chacha-armv8-apple.S
+[214/596] Compiling chacha-armv4-linux.S
+[215/596] Compiling aes128gcmsiv-x86_64-apple.S
+[216/596] Compiling aes128gcmsiv-x86_64-linux.S
+[217/596] Compiling x86_64-mont5-linux.S
+[218/596] Compiling x86_64-mont5-apple.S
+[219/596] Compiling x86_64-mont-linux.S
+[220/596] Compiling x86_64-mont-apple.S
+[221/596] Compiling x86-mont-linux.S
+[222/596] Compiling x86-mont-apple.S
+[223/596] Compiling vpaes-x86_64-apple.S
+[224/596] Compiling vpaes-x86_64-linux.S
+[225/596] Compiling vpaes-x86-linux.S
+[226/596] Compiling vpaes-x86-apple.S
+[227/596] Compiling vpaes-armv8-win.S
+[228/596] Compiling vpaes-armv8-apple.S
+[229/596] Compiling vpaes-armv8-linux.S
+[230/596] Compiling vpaes-armv7-linux.S
+[231/596] Compiling sha512-x86_64-linux.S
+[232/596] Compiling sha512-x86_64-apple.S
+[233/596] Compiling sha512-armv8-linux.S
+[234/596] Compiling sha512-armv8-win.S
+[235/596] Compiling sha512-armv8-apple.S
+[236/596] Compiling sha512-armv4-linux.S
+[237/596] Compiling sha512-586-linux.S
+[238/596] Compiling sha512-586-apple.S
+[239/596] Compiling sha256-x86_64-apple.S
+[240/596] Compiling sha256-armv8-win.S
+[241/596] Compiling sha256-x86_64-linux.S
+[242/596] Compiling sha256-armv8-linux.S
+[243/596] Compiling sha256-armv8-apple.S
+[244/596] Compiling sha256-armv4-linux.S
+[245/596] Compiling sha256-586-linux.S
+[246/596] Compiling sha256-586-apple.S
+[247/596] Compiling sha1-armv8-win.S
+[248/596] Compiling sha1-armv8-apple.S
+[249/596] Compiling sha1-x86_64-apple.S
+[250/596] Compiling sha1-x86_64-linux.S
+[251/596] Compiling sha1-armv8-linux.S
+[252/596] Compiling sha1-586-apple.S
+[253/596] Compiling sha1-586-linux.S
+[254/596] Compiling rsaz-avx2-apple.S
+[255/596] Compiling sha1-armv4-large-linux.S
+[256/596] Compiling rsaz-avx2-linux.S
+[257/596] Compiling p256_beeu-x86_64-asm-linux.S
+[258/596] Compiling rdrand-x86_64-linux.S
+[259/596] Compiling rdrand-x86_64-apple.S
+[260/596] Compiling p256_beeu-x86_64-asm-apple.S
+[261/596] Compiling p256_beeu-armv8-asm-win.S
+[262/596] Compiling p256_beeu-armv8-asm-linux.S
+[263/596] Compiling p256_beeu-armv8-asm-apple.S
+[264/596] Compiling p256-x86_64-asm-apple.S
+[265/596] Compiling p256-x86_64-asm-linux.S
+[266/596] Compiling p256-armv8-asm-win.S
+[267/596] Compiling p256-armv8-asm-linux.S
+[268/596] Compiling ghashv8-armv8-win.S
+[269/596] Compiling ghashv8-armv8-linux.S
+[270/596] Compiling p256-armv8-asm-apple.S
+[271/596] Compiling ghashv8-armv8-apple.S
+[272/596] Compiling ghashv8-armv7-linux.S
+[273/596] Compiling ghash-x86_64-apple.S
+[274/596] Compiling ghash-x86_64-linux.S
+[275/596] Compiling ghash-x86-linux.S
+[276/596] Compiling ghash-x86-apple.S
+[277/596] Compiling ghash-ssse3-x86_64-linux.S
+[278/596] Compiling ghash-ssse3-x86_64-apple.S
+[279/596] Compiling ghash-ssse3-x86-linux.S
+[280/596] Compiling ghash-ssse3-x86-apple.S
+[281/596] Compiling ghash-neon-armv8-win.S
+[282/596] Compiling ghash-neon-armv8-linux.S
+[283/596] Compiling co-586-linux.S
+[284/596] Compiling ghash-armv4-linux.S
+[285/596] Compiling ghash-neon-armv8-apple.S
+[286/596] Compiling co-586-apple.S
+[287/596] Compiling bsaes-armv7-linux.S
+[288/596] Compiling bn-armv8-win.S
+[289/596] Compiling bn-armv8-apple.S
+[290/596] Compiling bn-armv8-linux.S
+[291/596] Compiling bn-586-linux.S
+[292/596] Compiling bn-586-apple.S
+[293/596] Compiling armv8-mont-win.S
+[294/596] Compiling armv8-mont-linux.S
+[295/596] Compiling armv8-mont-apple.S
+[296/596] Compiling armv4-mont-linux.S
+[297/596] Compiling aesv8-gcm-armv8-win.S
+[298/596] Compiling aesv8-gcm-armv8-linux.S
+[299/596] Compiling aesv8-gcm-armv8-apple.S
+[300/596] Compiling aesv8-armv8-win.S
+[301/596] Compiling aesv8-armv8-linux.S
+[302/596] Compiling aesv8-armv8-apple.S
+[303/596] Compiling aesv8-armv7-linux.S
+[304/596] Compiling aesni-x86_64-apple.S
+[305/596] Compiling aesni-x86_64-linux.S
+[306/596] Compiling aesni-x86-linux.S
+[307/596] Compiling aesni-x86-apple.S
+[308/596] Compiling aesni-gcm-x86_64-linux.S
+[309/596] Compiling aes-gcm-avx2-x86_64-linux.S
+[310/596] Compiling aesni-gcm-x86_64-apple.S
+[311/596] Compiling aes-gcm-avx2-x86_64-apple.S
+[312/596] Compiling aes-gcm-avx10-x86_64-apple.S
+[313/596] Compiling aes-gcm-avx10-x86_64-linux.S
+[314/596] Compiling x_x509a.cc
+[315/596] Compiling x_x509.cc
+[316/596] Compiling x_sig.cc
+[317/596] Compiling x_val.cc
+[318/596] Compiling x_spki.cc
+[319/596] Compiling x_pubkey.cc
+[320/596] Compiling x_req.cc
+[321/596] Compiling x_exten.cc
+[322/596] Compiling x_name.cc
+[323/596] Compiling x_crl.cc
+[324/596] Compiling x509spki.cc
+[325/596] Compiling x_attrib.cc
+[326/596] Compiling x_algor.cc
+[327/596] Compiling x509rset.cc
+[328/596] Compiling x_all.cc
+[329/596] Compiling x509name.cc
+[330/596] Compiling x509cset.cc
+[331/596] Compiling x509_vpm.cc
+[332/596] Compiling x509_vfy.cc
+[333/596] Compiling x509_v3.cc
+[334/596] Compiling x509_txt.cc
+[335/596] Compiling x509_trs.cc
+[336/596] Compiling x509_set.cc
+[337/596] Compiling x509_req.cc
+[338/596] Compiling x509_obj.cc
+[339/596] Compiling x509_lu.cc
+[340/596] Compiling x509_def.cc
+[341/596] Compiling x509_ext.cc
+[342/596] Compiling x509_d2.cc
+[343/596] Compiling x509_cmp.cc
+[344/596] Compiling x509.cc
+[345/596] Compiling x509_att.cc
+[346/596] Compiling v3_utl.cc
+[347/596] Compiling v3_skey.cc
+[348/596] Compiling v3_purp.cc
+[349/596] Compiling v3_prn.cc
+[350/596] Compiling v3_pmaps.cc
+[351/596] Compiling v3_pcons.cc
+[352/596] Compiling v3_ocsp.cc
+[353/596] Compiling v3_ncons.cc
+[354/596] Compiling v3_lib.cc
+[355/596] Compiling v3_int.cc
+[356/596] Compiling v3_info.cc
+[357/596] Compiling v3_ia5.cc
+[358/596] Compiling v3_genn.cc
+[359/596] Compiling v3_extku.cc
+[360/596] Compiling v3_enum.cc
+[361/596] Compiling v3_cpols.cc
+[362/596] Compiling v3_crld.cc
+[363/596] Compiling v3_conf.cc
+[364/596] Compiling v3_bitst.cc
+[365/596] Compiling v3_alt.cc
+[366/596] Compiling v3_bcons.cc
+[367/596] Compiling v3_akeya.cc
+[368/596] Compiling v3_akey.cc
+[369/596] Compiling t_x509a.cc
+[370/596] Compiling t_x509.cc
+[371/596] Compiling t_req.cc
+[372/596] Compiling t_crl.cc
+[373/596] Compiling rsa_pss.cc
+[374/596] Compiling i2d_pr.cc
+[375/596] Compiling name_print.cc
+[376/596] Compiling policy.cc
+[377/596] Compiling by_file.cc
+[378/596] Compiling by_dir.cc
+[379/596] Compiling asn1_gen.cc
+[380/596] Compiling algorithm.cc
+[381/596] Compiling a_verify.cc
+[382/596] Compiling a_digest.cc
+[383/596] Compiling a_sign.cc
+[384/596] Compiling voprf.cc
+[385/596] Compiling trust_token.cc
+[386/596] Compiling thread_win.cc
+[387/596] Compiling pmbtoken.cc
+[388/596] Compiling thread_pthread.cc
+[389/596] Compiling thread_none.cc
+[390/596] Compiling thread.cc
+[391/596] Compiling stack.cc
+[392/596] Compiling slhdsa.cc
+[393/596] Compiling siphash.cc
+[394/596] Compiling sha512.cc
+[395/596] Compiling spake2plus.cc
+[396/596] Compiling sha256.cc
+[397/596] Compiling sha1.cc
+[398/596] Compiling rsa_extra.cc
+[399/596] Compiling rsa_print.cc
+[400/596] Compiling refcount.cc
+[401/596] Compiling rsa_crypt.cc
+[402/596] Compiling rsa_asn1.cc
+[403/596] Compiling rc4.cc
+[404/596] Compiling windows.cc
+[405/596] Compiling trusty.cc
+[406/596] Compiling rand.cc
+[407/596] Compiling urandom.cc
+[408/596] Compiling passive.cc
+[409/596] Compiling ios.cc
+[410/596] Compiling getentropy.cc
+[411/596] Compiling forkunsafe.cc
+[412/596] Compiling fork_detect.cc
+[413/596] Compiling deterministic.cc
+[414/596] Compiling poly1305_arm_asm.S
+[415/596] Compiling pool.cc
+[416/596] Compiling poly1305_vec.cc
+[417/596] Compiling poly1305.cc
+[418/596] Compiling poly1305_arm.cc
+[419/596] Compiling pkcs8_x509.cc
+[420/596] Compiling pkcs7.cc
+[421/596] Compiling pkcs8.cc
+[422/596] Compiling p5_pbev2.cc
+[423/596] Compiling pkcs7_x509.cc
+[424/596] Compiling pem_xaux.cc
+[425/596] Compiling pem_x509.cc
+[426/596] Compiling pem_pkey.cc
+[427/596] Compiling pem_pk8.cc
+[428/596] Compiling pem_oth.cc
+[429/596] Compiling obj_xref.cc
+[430/596] Compiling pem_all.cc
+[431/596] Compiling pem_info.cc
+[432/596] Compiling pem_lib.cc
+[433/596] Compiling obj.cc
+[434/596] Compiling mlkem.cc
+[435/596] Compiling mldsa.cc
+[436/596] Compiling md5.cc
+[437/596] Compiling mem.cc
+[438/596] Compiling lhash.cc
+[439/596] Compiling md4.cc
+[440/596] Compiling fips_shared_support.cc
+[441/596] Compiling poly_rq_mul.S
+[442/596] Compiling kyber.cc
+[443/596] Compiling hrss.cc
+[444/596] Compiling hpke.cc
+[445/596] Compiling ex_data.cc
+[446/596] Compiling sign.cc
+[447/596] Compiling scrypt.cc
+[448/596] Compiling pbkdf.cc
+[449/596] Compiling print.cc
+[450/596] Compiling p_x25519_asn1.cc
+[451/596] Compiling p_x25519.cc
+[452/596] Compiling p_rsa_asn1.cc
+[453/596] Compiling p_rsa.cc
+[454/596] Compiling p_hkdf.cc
+[455/596] Compiling p_ed25519_asn1.cc
+[456/596] Compiling p_ed25519.cc
+[457/596] Compiling p_ec_asn1.cc
+[458/596] Compiling p_ec.cc
+[459/596] Compiling p_dh_asn1.cc
+[460/596] Compiling p_dsa_asn1.cc
+[461/596] Compiling p_dh.cc
+[462/596] Compiling evp_ctx.cc
+[463/596] Compiling evp.cc
+[464/596] Compiling err.cc
+[465/596] Compiling evp_asn1.cc
+[466/596] Compiling engine.cc
+[467/596] Compiling bcm.cc
+[468/596] Compiling ecdh.cc
+[469/596] Compiling ecdsa_asn1.cc
+[470/596] Compiling hash_to_curve.cc
+[471/596] Compiling ec_derive.cc
+[472/596] Compiling ec_asn1.cc
+[473/596] Compiling dsa.cc
+[474/596] Compiling dsa_asn1.cc
+[475/596] Compiling digest_extra.cc
+[476/596] Compiling params.cc
+[477/596] Compiling dh_asn1.cc
+[478/596] Compiling spake25519.cc
+[479/596] Compiling des.cc
+[480/596] Compiling x25519-asm-arm.S
+[481/596] Compiling curve25519.cc
+[482/596] Compiling crypto.cc
+[483/596] Compiling cpu_intel.cc
+[484/596] Compiling cpu_arm_linux.cc
+[485/596] Compiling curve25519_64_adx.cc
+[486/596] Compiling cpu_aarch64_win.cc
+[487/596] Compiling cpu_arm_freebsd.cc
+[488/596] Compiling cpu_aarch64_openbsd.cc
+[489/596] Compiling cpu_aarch64_sysreg.cc
+[490/596] Compiling cpu_aarch64_linux.cc
+[491/596] Compiling cpu_aarch64_apple.cc
+[492/596] Compiling cpu_aarch64_fuchsia.cc
+[493/596] Compiling tls_cbc.cc
+[494/596] Compiling conf.cc
+[495/596] Compiling get_cipher.cc
+[496/596] Compiling e_rc4.cc
+[497/596] Compiling e_tls.cc
+[498/596] Compiling e_rc2.cc
+[499/596] Compiling e_null.cc
+[500/596] Compiling e_des.cc
+[501/596] Compiling e_aesgcmsiv.cc
+[502/596] Compiling e_chacha20poly1305.cc
+[503/596] Compiling derive_key.cc
+[504/596] Compiling e_aesctrhmac.cc
+[505/596] Compiling chacha.cc
+[506/596] Compiling unicode.cc
+[507/596] Compiling bn_asn1.cc
+[508/596] Compiling convert.cc
+[509/596] Compiling cbs.cc
+[510/596] Compiling blake2.cc
+[511/596] Compiling socket_helper.cc
+[512/596] Compiling printf.cc
+[513/596] Compiling socket.cc
+[514/596] Compiling pair.cc
+[515/596] Compiling hexdump.cc
+[516/596] Compiling file.cc
+[517/596] Compiling errno.cc
+[518/596] Compiling fd.cc
+[519/596] Compiling bio_mem.cc
+[520/596] Compiling connect.cc
+[521/596] Compiling bio.cc
+[522/596] Compiling base64.cc
+[523/596] Compiling tasn_utl.cc
+[524/596] Compiling tasn_typ.cc
+[525/596] Compiling tasn_new.cc
+[526/596] Compiling tasn_fre.cc
+[527/596] Compiling tasn_enc.cc
+[528/596] Compiling posix_time.cc
+[529/596] Compiling f_string.cc
+[530/596] Compiling tasn_dec.cc
+[531/596] Compiling f_int.cc
+[532/596] Compiling asn_pack.cc
+[533/596] Compiling asn1_par.cc
+[534/596] Compiling a_type.cc
+[535/596] Compiling a_utctm.cc
+[536/596] Compiling asn1_lib.cc
+[537/596] Compiling a_time.cc
+[538/596] Compiling a_strnid.cc
+[539/596] Compiling a_octet.cc
+[540/596] Compiling a_strex.cc
+[541/596] Compiling a_object.cc
+[542/596] Compiling a_mbstr.cc
+[543/596] Compiling a_i2d_fp.cc
+[544/596] Compiling a_int.cc
+[545/596] Compiling a_gentm.cc
+[546/596] Compiling a_dup.cc
+[547/596] Compiling a_d2i_fp.cc
+[548/596] Compiling CAsyncHTTPClient CAsyncHTTPClient.c
+[549/596] Write sources
+[551/596] Compiling a_bool.cc
+[552/596] Write sources
+[553/613] Compiling a_bitstr.cc
+[555/636] Compiling Algorithms MinMax.swift
+[556/636] Compiling Algorithms Partition.swift
+[557/636] Compiling Algorithms Permutations.swift
+[558/636] Compiling Algorithms AdjacentPairs.swift
+[559/639] Compiling Algorithms Indexed.swift
+[560/639] Compiling Algorithms Intersperse.swift
+[561/639] Compiling Algorithms Joined.swift
+[562/639] Compiling Algorithms Keyed.swift
+[563/639] Compiling Atomics UnsafeAtomicLazyReference.swift
+[564/639] Compiling Atomics IntegerOperations.swift
+[565/639] Compiling Atomics Unmanaged extensions.swift
+[566/639] Compiling Algorithms EitherSequence.swift
+[567/639] Compiling Algorithms FirstNonNil.swift
+[568/639] Compiling Algorithms FlattenCollection.swift
+[569/639] Compiling Algorithms Grouped.swift
+[572/644] Compiling Algorithms Chain.swift
+[573/644] Compiling Algorithms Chunked.swift
+[574/644] Compiling Algorithms Combinations.swift
+[575/644] Compiling Algorithms Compacted.swift
+[580/644] Emitting module Atomics
+[581/645] Compiling Algorithms Stride.swift
+[582/645] Compiling Algorithms Suffix.swift
+[583/645] Compiling Algorithms Trim.swift
+[584/645] Compiling Algorithms Unique.swift
+[585/645] Compiling Algorithms Windows.swift
+[586/645] Compiling c-nioatomics.c
+[587/645] Wrapping AST for Atomics for debugging
+[602/645] Compiling Algorithms Reductions.swift
+[603/645] Compiling Algorithms Rotate.swift
+[604/645] Compiling Algorithms Split.swift
+[605/645] Emitting module Algorithms
+[606/646] Compiling c-atomics.c
+[607/646] Wrapping AST for Algorithms for debugging
+[609/651] Compiling NIOConcurrencyHelpers NIOLock.swift
+[610/652] Compiling NIOConcurrencyHelpers NIOAtomic.swift
+[611/652] Emitting module NIOConcurrencyHelpers
+[612/652] Compiling NIOConcurrencyHelpers atomics.swift
+[613/652] Compiling NIOConcurrencyHelpers NIOLockedValueBox.swift
+[614/652] Compiling NIOConcurrencyHelpers lock.swift
+[615/653] Wrapping AST for NIOConcurrencyHelpers for debugging
+[617/709] Compiling NIOCore GlobalSingletons.swift
+[618/709] Compiling NIOCore IO.swift
+[619/709] Compiling NIOCore IOData.swift
+[620/709] Compiling NIOCore IPProtocol.swift
+[621/709] Compiling NIOCore IntegerBitPacking.swift
+[622/709] Compiling NIOCore IntegerTypes.swift
+[623/709] Compiling NIOCore Interfaces.swift
+[624/709] Compiling NIOCore Linux.swift
+[625/709] Compiling NIOCore MarkedCircularBuffer.swift
+[626/709] Compiling NIOCore MulticastChannel.swift
+[627/709] Compiling NIOCore NIOAny.swift
+[628/709] Compiling NIOCore NIOCloseOnErrorHandler.swift
+[629/709] Compiling NIOCore NIOCoreSendableMetatype.swift
+[630/722] Compiling NIOCore Codec.swift
+[631/722] Compiling NIOCore ConvenienceOptionSupport.swift
+[632/722] Compiling NIOCore DeadChannel.swift
+[633/722] Compiling NIOCore DispatchQueue+WithFuture.swift
+[634/722] Compiling NIOCore EventLoop+Deprecated.swift
+[635/722] Compiling NIOCore EventLoop+SerialExecutor.swift
+[636/722] Compiling NIOCore EventLoop.swift
+[637/722] Compiling NIOCore EventLoopFuture+AssumeIsolated.swift
+[638/722] Compiling NIOCore EventLoopFuture+Deprecated.swift
+[639/722] Compiling NIOCore EventLoopFuture+WithEventLoop.swift
+[640/722] Compiling NIOCore EventLoopFuture.swift
+[641/722] Compiling NIOCore FileDescriptor.swift
+[642/722] Compiling NIOCore FileHandle.swift
+[643/722] Compiling NIOCore FileRegion.swift
+[644/722] Compiling NIOCore AddressedEnvelope.swift
+[645/722] Compiling NIOCore AsyncAwaitSupport.swift
+[646/722] Compiling NIOCore AsyncChannel.swift
+[647/722] Compiling NIOCore AsyncChannelHandler.swift
+[648/722] Compiling NIOCore AsyncChannelInboundStream.swift
+[649/722] Compiling NIOCore AsyncChannelOutboundWriter.swift
+[650/722] Compiling NIOCore NIOAsyncSequenceProducer.swift
+[651/722] Compiling NIOCore NIOAsyncSequenceProducerStrategies.swift
+[652/722] Compiling NIOCore NIOAsyncWriter.swift
+[653/722] Compiling NIOCore NIOThrowingAsyncSequenceProducer.swift
+[654/722] Compiling NIOCore BSDSocketAPI.swift
+[655/722] Compiling NIOCore ByteBuffer-aux.swift
+[656/722] Compiling NIOCore ByteBuffer-binaryEncodedLengthPrefix.swift
+[657/722] Compiling NIOCore ByteBuffer-conversions.swift
+[658/722] Compiling NIOCore NIOLoopBound.swift
+[659/722] Compiling NIOCore NIOPooledRecvBufferAllocator.swift
+[660/722] Compiling NIOCore NIOScheduledCallback.swift
+[661/722] Compiling NIOCore NIOSendable.swift
+[662/722] Compiling NIOCore RecvByteBufferAllocator.swift
+[663/722] Compiling NIOCore SingleStepByteToMessageDecoder.swift
+[664/722] Compiling NIOCore SocketAddresses.swift
+[665/722] Compiling NIOCore SocketOptionProvider.swift
+[666/722] Compiling NIOCore SystemCallHelpers.swift
+[667/722] Compiling NIOCore TimeAmount+Duration.swift
+[668/722] Compiling NIOCore TypeAssistedChannelHandler.swift
+[669/722] Compiling NIOCore UniversalBootstrapSupport.swift
+[670/722] Compiling NIOCore Utilities.swift
+[671/722] Emitting module NIOCore
+[672/722] Compiling NIOCore ByteBuffer-core.swift
+[673/722] Compiling NIOCore ByteBuffer-hex.swift
+[674/722] Compiling NIOCore ByteBuffer-int.swift
+[675/722] Compiling NIOCore ByteBuffer-lengthPrefix.swift
+[676/722] Compiling NIOCore ByteBuffer-multi-int.swift
+[677/722] Compiling NIOCore ByteBuffer-quicBinaryEncodingStrategy.swift
+[678/722] Compiling NIOCore ByteBuffer-views.swift
+[679/722] Compiling NIOCore Channel.swift
+[680/722] Compiling NIOCore ChannelHandler.swift
+[681/722] Compiling NIOCore ChannelHandlers.swift
+[682/722] Compiling NIOCore ChannelInvoker.swift
+[683/722] Compiling NIOCore ChannelOption.swift
+[684/722] Compiling NIOCore ChannelPipeline.swift
+[685/722] Compiling NIOCore CircularBuffer.swift
+[686/727] Wrapping AST for NIOCore for debugging
+[688/771] Emitting module NIOEmbedded
+[689/771] Compiling NIOEmbedded AsyncTestingChannel.swift
+[690/771] Compiling NIOEmbedded AsyncTestingEventLoop.swift
+[691/771] Compiling NIOEmbedded Embedded.swift
+[692/772] Wrapping AST for NIOEmbedded for debugging
+[694/772] Compiling NIOPosix Selectable.swift
+[695/772] Compiling NIOPosix SelectableChannel.swift
+[696/772] Compiling NIOPosix SelectableEventLoop.swift
+[697/772] Compiling NIOPosix SelectorEpoll.swift
+[698/772] Compiling NIOPosix SelectorGeneric.swift
+[699/772] Compiling NIOPosix SelectorKqueue.swift
+[700/772] Compiling NIOPosix SelectorUring.swift
+[701/772] Compiling NIOPosix ServerSocket.swift
+[702/772] Compiling NIOPosix Socket.swift
+[703/772] Compiling NIOPosix SocketChannel.swift
+[704/782] Compiling NIOPosix FileDescriptor.swift
+[705/782] Compiling NIOPosix GetaddrinfoResolver.swift
+[706/782] Compiling NIOPosix HappyEyeballs.swift
+[707/782] Compiling NIOPosix IO.swift
+[708/782] Compiling NIOPosix IntegerBitPacking.swift
+[709/782] Compiling NIOPosix IntegerTypes.swift
+[710/782] Compiling NIOPosix Linux.swift
+[711/782] Compiling NIOPosix LinuxCPUSet.swift
+[712/782] Compiling NIOPosix LinuxUring.swift
+[713/782] Compiling NIOPosix MultiThreadedEventLoopGroup.swift
+[714/782] Compiling NIOPosix NIOPosixSendableMetatype.swift
+[715/782] Compiling NIOPosix NIOThreadPool.swift
+[716/782] Compiling NIOPosix NonBlockingFileIO.swift
+[717/782] Compiling NIOPosix PendingDatagramWritesManager.swift
+[718/782] Compiling NIOPosix PendingWritesManager.swift
+[719/782] Compiling NIOPosix PipeChannel.swift
+[720/782] Compiling NIOPosix PipePair.swift
+[721/782] Compiling NIOPosix Pool.swift
+[722/782] Compiling NIOPosix PosixSingletons+ConcurrencyTakeOver.swift
+[723/782] Compiling NIOPosix PosixSingletons.swift
+[724/782] Compiling NIOPosix RawSocketBootstrap.swift
+[725/782] Compiling NIOPosix Resolver.swift
+[726/782] Compiling NIOPosix BSDSocketAPICommon.swift
+[727/782] Compiling NIOPosix BSDSocketAPIPosix.swift
+[728/782] Compiling NIOPosix BSDSocketAPIWindows.swift
+[729/782] Compiling NIOPosix BaseSocket.swift
+[730/782] Compiling NIOPosix BaseSocketChannel+SocketOptionProvider.swift
+[731/782] Compiling NIOPosix BaseSocketChannel.swift
+[732/782] Compiling NIOPosix BaseStreamSocketChannel.swift
+[733/782] Compiling NIOPosix Bootstrap.swift
+[734/782] Compiling NIOPosix ControlMessage.swift
+[735/782] Compiling NIOPosix DatagramVectorReadManager.swift
+[736/782] Compiling NIOPosix Errors+Any.swift
+[737/782] Emitting module NIOPosix
+[738/782] Compiling NIOPosix SocketProtocols.swift
+[739/782] Compiling NIOPosix StructuredConcurrencyHelpers.swift
+[740/782] Compiling NIOPosix System.swift
+[741/782] Compiling NIOPosix Thread.swift
+[742/782] Compiling NIOPosix ThreadPosix.swift
+[743/782] Compiling NIOPosix ThreadWindows.swift
+[744/782] Compiling NIOPosix UnsafeTransfer.swift
+[745/782] Compiling NIOPosix Utilities.swift
+[746/782] Compiling NIOPosix VsockAddress.swift
+[747/782] Compiling NIOPosix VsockChannelEvents.swift
+[748/783] Wrapping AST for NIOPosix for debugging
+[750/785] Emitting module NIO
+[751/785] Compiling NIO Exports.swift
+[752/803] Wrapping AST for NIO for debugging
+[754/822] Compiling NIOTLS SNIHandler.swift
+[755/823] Compiling NIOTLS ApplicationProtocolNegotiationHandler.swift
+[756/823] Emitting module NIOSOCKS
+[757/825] Compiling NIOTLS NIOTypedApplicationProtocolNegotiationHandler.swift
+[758/825] Compiling NIOHTTP1 HTTPPipelineSetup.swift
+[759/825] Compiling NIOHTTP1 HTTPServerPipelineHandler.swift
+[760/825] Compiling NIOTLS ProtocolNegotiationHandlerStateMachine.swift
+[761/825] Emitting module NIOTLS
+[762/825] Compiling NIOHTTP1 HTTPServerProtocolErrorHandler.swift
+[763/825] Compiling NIOHTTP1 NIOHTTPClientUpgradeHandler.swift
+[764/825] Compiling NIOHTTP1 NIOHTTPObjectAggregator.swift
+[765/825] Compiling NIOHTTP1 HTTPHeaderValidator.swift
+[766/825] Compiling NIOHTTP1 HTTPHeaders+Validation.swift
+[767/825] Compiling NIOSOCKS ClientStateMachine.swift
+[768/825] Compiling NIOSOCKS ServerStateMachine.swift
+[769/825] Emitting module NIOHTTP1
+[770/828] Compiling NIOHTTP1 ByteCollectionUtils.swift
+[771/828] Compiling NIOHTTP1 HTTPDecoder.swift
+[772/828] Compiling NIOHTTP1 HTTPEncoder.swift
+[773/829] Compiling NIOTLS TLSEvents.swift
+[775/830] Wrapping AST for NIOSOCKS for debugging
+[776/830] Wrapping AST for NIOTLS for debugging
+[778/857] Compiling NIOSSL SSLConnection.swift
+[779/857] Compiling NIOSSL SSLContext.swift
+[780/857] Compiling NIOSSL SSLErrors.swift
+[781/857] Compiling NIOSSL LinuxCABundle.swift
+[782/857] Compiling NIOSSL NIOSSLClientHandler.swift
+[783/857] Compiling NIOSSL NIOSSLHandler+Configuration.swift
+[784/857] Compiling NIOSSL SSLCertificateName.swift
+[785/857] Compiling NIOSSL SSLInit.swift
+[786/857] Compiling NIOSSL SSLPKCS12Bundle.swift
+[787/857] Compiling NIOSSL SSLPrivateKey.swift
+[788/857] Compiling NIOSSL SSLPublicKey.swift
+[789/857] Compiling NIOSSL SecurityFrameworkCertificateVerification.swift
+[790/857] Compiling NIOSSL String+unsafeUninitializedCapacity.swift
+[791/857] Compiling NIOSSL AndroidCABundle.swift
+[792/857] Compiling NIOSSL ByteBufferBIO.swift
+[793/857] Compiling NIOSSL CustomPrivateKey.swift
+[794/857] Compiling NIOSSL IdentityVerification.swift
+[795/858] Compiling NIOFoundationCompat JSONSerialization+ByteBuffer.swift
+[796/858] Compiling NIOFoundationCompat Codable+ByteBuffer.swift
+[797/864] Wrapping AST for NIOHTTP1 for debugging
+[799/874] Emitting module NIOFoundationCompat
+[800/874] Compiling NIOFoundationCompat ByteBuffer-foundation.swift
+[801/874] Compiling NIOFoundationCompat WaitSpinningRunLoop.swift
+[802/875] Emitting module NIOHTTPCompression
+[804/876] Emitting module NIOSSL
+[805/882] Compiling NIOHTTPCompression HTTPResponseDecompressor.swift
+[806/882] Compiling NIOHTTPCompression HTTPResponseCompressor.swift
+[807/882] Compiling NIOHTTPCompression HTTPRequestDecompressor.swift
+[808/902] Compiling NIOHTTPCompression HTTPRequestCompressor.swift
+[809/902] Compiling NIOTransportServices NIOFilterEmptyWritesHandler.swift
+[810/902] Compiling NIOTransportServices NIOTSBootstraps.swift
+[810/903] Wrapping AST for NIOFoundationCompat for debugging
+[813/903] Compiling NIOTransportServices NIOTSNetworkEvents.swift
+[814/903] Compiling NIOTransportServices NIOTSSingletons.swift
+[815/903] Compiling NIOTransportServices SocketAddress+NWEndpoint.swift
+[816/903] Compiling NIOTransportServices StateManagedChannel.swift
+[819/907] Compiling NIOTransportServices NIOTSChannelOptions.swift
+[820/907] Compiling NIOTransportServices NIOTSConnectionBootstrap.swift
+[821/907] Compiling NIOTransportServices NIOTSConnectionChannel.swift
+[821/907] Wrapping AST for NIOHTTPCompression for debugging
+[823/907] Compiling NIOTransportServices StateManagedListenerChannel.swift
+[824/907] Compiling NIOTransportServices StateManagedNWConnectionChannel.swift
+[825/907] Compiling NIOTransportServices TCPOptions+SocketChannelOption.swift
+[826/907] Compiling NIOTransportServices UDPOptions+SocketChannelOption.swift
+[827/907] Emitting module NIOTransportServices
+[828/907] Compiling NIOTransportServices NIOTSErrors.swift
+[829/907] Compiling NIOTransportServices NIOTSEventLoop.swift
+[830/907] Compiling NIOTransportServices NIOTSEventLoopGroup.swift
+[831/907] Compiling NIOTransportServices NIOTSListenerBootstrap.swift
+[832/907] Compiling NIOTransportServices NIOTSListenerChannel.swift
+[833/907] Compiling NIOTransportServices AcceptHandler.swift
+[834/907] Compiling NIOTransportServices NIOTSDatagramConnectionBootstrap.swift
+[835/907] Compiling NIOTransportServices NIOTSDatagramConnectionChannel.swift
+[836/907] Compiling NIOTransportServices NIOTSDatagramListenerBootstrap.swift
+[837/907] Compiling NIOTransportServices NIOTSDatagramListenerChannel.swift
+[845/910] Emitting module NIOHPACK
+[849/910] Compiling NIOSSL RNG.swift
+[850/910] Compiling NIOSSL SafeCompare.swift
+[851/910] Compiling NIOSSL Zeroization.swift
+[852/910] Compiling NIOSSL TLSConfiguration.swift
+[853/910] Compiling NIOSSL UniversalBootstrapSupport.swift
+[854/910] Compiling NIOSSL UnsafeKeyAndChainTarget.swift
+[861/910] Wrapping AST for NIOTransportServices for debugging
+[873/910] Compiling NIOSSL SSLCallbacks.swift
+[874/910] Compiling NIOSSL SSLCertificate.swift
+[875/910] Compiling NIOSSL SSLCertificateExtensions.swift
+[878/910] Compiling NIOHPACK IntegerCoding.swift
+[879/910] Compiling NIOHPACK StaticHeaderTable.swift
+[885/912] Wrapping AST for NIOHPACK for debugging
+[886/912] Wrapping AST for NIOSSL for debugging
+[888/967] Compiling NIOHTTP2 SendingRstStreamState.swift
+[889/967] Compiling NIOHTTP2 SendingWindowUpdateState.swift
+[890/967] Compiling NIOHTTP2 HTTP2SettingsState.swift
+[891/967] Compiling NIOHTTP2 HasExtendedConnectSettings.swift
+[892/967] Compiling NIOHTTP2 HasFlowControlWindows.swift
+[893/967] Compiling NIOHTTP2 HasLocalSettings.swift
+[894/967] Compiling NIOHTTP2 HasRemoteSettings.swift
+[895/967] Compiling NIOHTTP2 LocallyQuiescingState.swift
+[896/967] Compiling NIOHTTP2 QuiescingState.swift
+[897/967] Compiling NIOHTTP2 RemotelyQuiescingState.swift
+[898/967] Compiling NIOHTTP2 SendAndReceiveGoawayState.swift
+[899/967] Compiling NIOHTTP2 StateMachineResult.swift
+[900/967] Compiling NIOHTTP2 ContentLengthVerifier.swift
+[901/967] Compiling NIOHTTP2 DOSHeuristics.swift
+[902/980] Emitting module NIOHTTP2
+[903/980] Compiling NIOHTTP2 ConnectionStateMachine.swift
+[904/980] Compiling NIOHTTP2 ConnectionStreamsState.swift
+[905/980] Compiling NIOHTTP2 MayReceiveFrames.swift
+[906/980] Compiling NIOHTTP2 ReceivingDataState.swift
+[907/980] Compiling NIOHTTP2 ReceivingGoAwayState.swift
+[908/980] Compiling NIOHTTP2 ReceivingHeadersState.swift
+[909/980] Compiling NIOHTTP2 ReceivingPushPromiseState.swift
+[910/980] Compiling NIOHTTP2 ReceivingRstStreamState.swift
+[911/980] Compiling NIOHTTP2 ReceivingWindowUpdateState.swift
+[912/980] Compiling NIOHTTP2 MaySendFrames.swift
+[913/980] Compiling NIOHTTP2 SendingDataState.swift
+[914/980] Compiling NIOHTTP2 SendingGoawayState.swift
+[915/980] Compiling NIOHTTP2 SendingHeadersState.swift
+[916/980] Compiling NIOHTTP2 SendingPushPromiseState.swift
+[917/980] Compiling NIOHTTP2 HTTP2StreamMultiplexer.swift
+[918/980] Compiling NIOHTTP2 HTTP2ToHTTP1Codec.swift
+[919/980] Compiling NIOHTTP2 HTTP2UserEvents.swift
+[920/980] Compiling NIOHTTP2 InboundEventBuffer.swift
+[921/980] Compiling NIOHTTP2 InboundWindowManager.swift
+[922/980] Compiling NIOHTTP2 MultiplexerAbstractChannel.swift
+[923/980] Compiling NIOHTTP2 NIOHTTP2FrameDelegate.swift
+[924/980] Compiling NIOHTTP2 StreamChannelFlowController.swift
+[925/980] Compiling NIOHTTP2 StreamChannelList.swift
+[926/980] Compiling NIOHTTP2 StreamMap.swift
+[927/980] Compiling NIOHTTP2 StreamStateMachine.swift
+[928/980] Compiling NIOHTTP2 UnsafeTransfer.swift
+[929/980] Compiling NIOHTTP2 WatermarkedFlowController.swift
+[930/980] Compiling NIOHTTP2 HTTP2ErrorCode.swift
+[931/980] Compiling NIOHTTP2 HTTP2FlowControlWindow.swift
+[932/980] Compiling NIOHTTP2 HTTP2Frame.swift
+[933/980] Compiling NIOHTTP2 HTTP2FrameEncoder.swift
+[934/980] Compiling NIOHTTP2 HTTP2FrameParser.swift
+[935/980] Compiling NIOHTTP2 HTTP2PingData.swift
+[936/980] Compiling NIOHTTP2 HTTP2PipelineHelpers.swift
+[937/980] Compiling NIOHTTP2 HTTP2Settings.swift
+[938/980] Compiling NIOHTTP2 HTTP2Stream.swift
+[939/980] Compiling NIOHTTP2 HTTP2StreamChannel+OutboundStreamMultiplexer.swift
+[940/980] Compiling NIOHTTP2 HTTP2StreamChannel.swift
+[941/980] Compiling NIOHTTP2 HTTP2StreamDelegate.swift
+[942/980] Compiling NIOHTTP2 HTTP2StreamID.swift
+[943/980] Compiling NIOHTTP2 Error+Any.swift
+[944/980] Compiling NIOHTTP2 ConcurrentStreamBuffer.swift
+[945/980] Compiling NIOHTTP2 ControlFrameBuffer.swift
+[946/980] Compiling NIOHTTP2 OutboundFlowControlBuffer.swift
+[947/980] Compiling NIOHTTP2 OutboundFrameBuffer.swift
+[948/980] Compiling NIOHTTP2 GlitchesMonitor.swift
+[949/980] Compiling NIOHTTP2 HPACKHeaders+Validation.swift
+[950/980] Compiling NIOHTTP2 HTTP2ChannelHandler+InboundStreamMultiplexer.swift
+[951/980] Compiling NIOHTTP2 HTTP2ChannelHandler+InlineStreamMultiplexer.swift
+[952/980] Compiling NIOHTTP2 HTTP2ChannelHandler.swift
+[953/980] Compiling NIOHTTP2 HTTP2CommonInboundStreamMultiplexer.swift
+[954/980] Compiling NIOHTTP2 HTTP2ConnectionStateChange.swift
+[955/980] Compiling NIOHTTP2 HTTP2Error.swift
+[956/981] Wrapping AST for NIOHTTP2 for debugging
+[958/1036] Emitting module AsyncHTTPClient
+[959/1049] Compiling AsyncHTTPClient AnyAsyncSequence.swift
+[960/1049] Compiling AsyncHTTPClient AnyAsyncSequenceProucerDelete.swift
+[961/1049] Compiling AsyncHTTPClient AsyncLazySequence.swift
+[962/1049] Compiling AsyncHTTPClient HTTPClient+execute.swift
+[963/1049] Compiling AsyncHTTPClient HTTPClient+shutdown.swift
+[964/1049] Compiling AsyncHTTPClient HTTPClientRequest+Prepared.swift
+[965/1049] Compiling AsyncHTTPClient HTTPClientRequest+auth.swift
+[966/1049] Compiling AsyncHTTPClient HTTPClientRequest.swift
+[967/1049] Compiling AsyncHTTPClient HTTPClientResponse.swift
+[968/1049] Compiling AsyncHTTPClient SingleIteratorPrecondition.swift
+[969/1049] Compiling AsyncHTTPClient Transaction+StateMachine.swift
+[970/1049] Compiling AsyncHTTPClient Transaction.swift
+[971/1049] Compiling AsyncHTTPClient Base64.swift
+[972/1049] Compiling AsyncHTTPClient BasicAuth.swift
+[973/1049] Compiling AsyncHTTPClient BestEffortHashableTLSConfiguration.swift
+[974/1049] Compiling AsyncHTTPClient Configuration+BrowserLike.swift
+[975/1049] Compiling AsyncHTTPClient ConnectionPool.swift
+[976/1049] Compiling AsyncHTTPClient HTTP1ProxyConnectHandler.swift
+[977/1049] Compiling AsyncHTTPClient SOCKSEventsHandler.swift
+[978/1049] Compiling AsyncHTTPClient TLSEventsHandler.swift
+[979/1049] Compiling AsyncHTTPClient HTTP1ClientChannelHandler.swift
+[980/1049] Compiling AsyncHTTPClient HTTP1Connection.swift
+[981/1049] Compiling AsyncHTTPClient HTTP1ConnectionStateMachine.swift
+[982/1049] Compiling AsyncHTTPClient HTTP2ClientRequestHandler.swift
+[983/1049] Compiling AsyncHTTPClient HTTP2Connection.swift
+[984/1049] Compiling AsyncHTTPClient HTTP2IdleHandler.swift
+[985/1049] Compiling AsyncHTTPClient HTTPConnectionEvent.swift
+[986/1049] Compiling AsyncHTTPClient HTTPConnectionPool+Factory.swift
+[987/1049] Compiling AsyncHTTPClient HTTPConnectionPool+Manager.swift
+[988/1049] Compiling AsyncHTTPClient HTTPConnectionPool.swift
+[989/1049] Compiling AsyncHTTPClient HTTPExecutableRequest.swift
+[990/1049] Compiling AsyncHTTPClient HTTPRequestStateMachine+Demand.swift
+[991/1049] Compiling AsyncHTTPClient HTTPRequestStateMachine.swift
+[992/1049] Compiling AsyncHTTPClient RequestBodyLength.swift
+[993/1049] Compiling AsyncHTTPClient RequestFramingMetadata.swift
+[994/1049] Compiling AsyncHTTPClient RequestOptions.swift
+[995/1049] Compiling AsyncHTTPClient HTTPConnectionPool+Backoff.swift
+[996/1049] Compiling AsyncHTTPClient HTTPConnectionPool+HTTP1Connections.swift
+[997/1049] Compiling AsyncHTTPClient HTTPConnectionPool+HTTP1StateMachine.swift
+[998/1049] Compiling AsyncHTTPClient HTTPConnectionPool+HTTP2Connections.swift
+[999/1049] Compiling AsyncHTTPClient HTTPConnectionPool+HTTP2StateMachine.swift
+[1000/1049] Compiling AsyncHTTPClient HTTPConnectionPool+RequestQueue.swift
+[1001/1049] Compiling AsyncHTTPClient HTTPConnectionPool+StateMachine.swift
+[1002/1049] Compiling AsyncHTTPClient ConnectionTarget.swift
+[1003/1049] Compiling AsyncHTTPClient DeconstructedURL.swift
+[1004/1049] Compiling AsyncHTTPClient FileDownloadDelegate.swift
+[1005/1049] Compiling AsyncHTTPClient FoundationExtensions.swift
+[1006/1049] Compiling AsyncHTTPClient HTTPClient+HTTPCookie.swift
+[1007/1049] Compiling AsyncHTTPClient HTTPClient+Proxy.swift
+[1008/1049] Compiling AsyncHTTPClient HTTPClient+StructuredConcurrency.swift
+[1009/1049] Compiling AsyncHTTPClient HTTPClient.swift
+[1010/1049] Compiling AsyncHTTPClient HTTPHandler.swift
+[1011/1049] Compiling AsyncHTTPClient LRUCache.swift
+[1012/1049] Compiling AsyncHTTPClient NIOLoopBound+Execute.swift
+[1013/1049] Compiling AsyncHTTPClient NWErrorHandler.swift
+[1014/1049] Compiling AsyncHTTPClient NWWaitingHandler.swift
+[1015/1049] Compiling AsyncHTTPClient TLSConfiguration.swift
+[1016/1049] Compiling AsyncHTTPClient RedirectState.swift
+[1017/1049] Compiling AsyncHTTPClient RequestBag+StateMachine.swift
+[1018/1049] Compiling AsyncHTTPClient RequestBag.swift
+[1019/1049] Compiling AsyncHTTPClient RequestValidation.swift
+[1020/1049] Compiling AsyncHTTPClient SSLContextCache.swift
+[1021/1049] Compiling AsyncHTTPClient Scheme.swift
+[1022/1049] Compiling AsyncHTTPClient Singleton.swift
+[1023/1049] Compiling AsyncHTTPClient StringConvertibleInstances.swift
+[1024/1049] Compiling AsyncHTTPClient StructuredConcurrencyHelpers.swift
+[1025/1049] Compiling AsyncHTTPClient Utils.swift
+[1026/1050] Wrapping AST for AsyncHTTPClient for debugging
+[1028/1063] Emitting module FountainCodex
+[1029/1066] Compiling FountainCodex HTTPResponse.swift
+[1030/1066] Compiling FountainCodex NIOHTTPServer.swift
+[1031/1066] Compiling FountainCodex URLSessionHTTPClient.swift
+[1032/1066] Compiling FountainCodex ClientGenerator.swift
+[1033/1066] Compiling FountainCodex GeneratorMain.swift
+[1034/1066] Compiling FountainCodex AsyncHTTPClientDriver.swift
+[1035/1066] Compiling FountainCodex SpecValidator.swift
+[1036/1066] Compiling FountainCodex ServerGenerator.swift
+[1037/1066] Compiling FountainCodex agent.swift
+[1038/1066] Compiling FountainCodex HTTPClientProtocol.swift
+[1039/1066] Compiling FountainCodex HTTPKernel.swift
+[1040/1066] Compiling FountainCodex HTTPRequest.swift
+[1041/1066] Compiling FountainCodex ModelEmitter.swift
+[1042/1066] Compiling FountainCodex OpenAPISpec.swift
+[1043/1066] Compiling FountainCodex SpecLoader.swift
+[1044/1067] Wrapping AST for FountainCodex for debugging
+[1046/1097] Emitting module clientgen_service
+[1047/1097] Compiling clientgen_service main.swift
+[1048/1097] Emitting module ClientGeneratorTests
+[1049/1098] Compiling PublishingFrontend DNSProvider.swift
+/workspace/codex-deployer/Tests/ClientGeneratorTests/ClientGeneratorTests.swift:52:28: warning: 'init(contentsOf:)' is deprecated: Use `init(contentsOf:encoding:)` instead
+50 |         try ClientGenerator.emitClient(from: spec, to: outDir)
+51 |         let requestFile = outDir.appendingPathComponent("Requests/GetZone.swift")
+52 |         let contents = try String(contentsOf: requestFile)
+   |                            `- warning: 'init(contentsOf:)' is deprecated: Use `init(contentsOf:encoding:)` instead
+53 |         XCTAssertTrue(contents.contains("detail"))
+54 |         XCTAssertTrue(contents.contains("query.append(\"detail"))
+[1050/1098] Compiling PublishingFrontend APIClient.swift
+/workspace/codex-deployer/Tests/ClientGeneratorTests/ClientGeneratorTests.swift:52:28: warning: 'init(contentsOf:)' is deprecated: Use `init(contentsOf:encoding:)` instead
+50 |         try ClientGenerator.emitClient(from: spec, to: outDir)
+51 |         let requestFile = outDir.appendingPathComponent("Requests/GetZone.swift")
+52 |         let contents = try String(contentsOf: requestFile)
+   |                            `- warning: 'init(contentsOf:)' is deprecated: Use `init(contentsOf:encoding:)` instead
+53 |         XCTAssertTrue(contents.contains("detail"))
+54 |         XCTAssertTrue(contents.contains("query.append(\"detail"))
+[1051/1098] Compiling ClientGeneratorTests SpecLoaderTests.swift
+/workspace/codex-deployer/Tests/ClientGeneratorTests/SpecLoaderTests.swift:28:29: warning: result of call to 'createFile(atPath:contents:attributes:)' is unused
+26 |     func testLoadThrowsForEmptyFile() {
+27 |         let url = FileManager.default.temporaryDirectory.appendingPathComponent("empty.yml")
+28 |         FileManager.default.createFile(atPath: url.path, contents: Data())
+   |                             `- warning: result of call to 'createFile(atPath:contents:attributes:)' is unused
+29 |         XCTAssertThrowsError(try SpecLoader.load(from: url))
+30 |     }
+
+/workspace/codex-deployer/Tests/ClientGeneratorTests/SpecLoaderTests.swift:37:29: warning: result of call to 'createFile(atPath:contents:attributes:)' is unused
+35 |         let bytes: [UInt8] = [0xFF]
+36 |         let data = Data(bytes)
+37 |         FileManager.default.createFile(atPath: url.path, contents: data)
+   |                             `- warning: result of call to 'createFile(atPath:contents:attributes:)' is unused
+38 |         XCTAssertThrowsError(try SpecLoader.load(from: url))
+39 |     }
+[1052/1098] Compiling PublishingFrontend APIRequest.swift
+[1053/1098] Compiling PublishingFrontend Models.swift
+[1054/1098] Compiling ClientGeneratorTests SpecValidatorTests.swift
+[1055/1099] Emitting module PublishingFrontend
+[1056/1104] Compiling PublishingFrontend DeleteRecord.swift
+[1057/1104] Compiling PublishingFrontend ListZones.swift
+[1058/1104] Compiling PublishingFrontend UpdateRecord.swift
+[1059/1104] Compiling PublishingFrontend bulkCreateRecords.swift
+[1060/1104] Compiling PublishingFrontend bulkUpdateRecords.swift
+[1061/1104] Compiling PublishingFrontend createPrimaryServer.swift
+[1062/1104] Compiling PublishingFrontend createZone.swift
+[1063/1104] Compiling PublishingFrontend deletePrimaryServer.swift
+[1064/1104] Compiling PublishingFrontend deleteZone.swift
+[1065/1104] Compiling PublishingFrontend exportZoneFile.swift
+[1067/1104] Compiling ClientGeneratorTests StringExtensionTests.swift
+[1068/1105] Compiling PublishingFrontend getPrimaryServer.swift
+[1069/1105] Compiling PublishingFrontend getRecord.swift
+[1070/1105] Compiling PublishingFrontend getZone.swift
+[1071/1105] Compiling PublishingFrontend importZoneFile.swift
+[1072/1105] Compiling PublishingFrontend listPrimaryServers.swift
+[1073/1105] Wrapping AST for clientgen-service for debugging
+[1074/1105] Write Objects.LinkFileList
+[1075/1105] Wrapping AST for ClientGeneratorTests for debugging
+[1077/1105] Compiling PublishingFrontend listRecords.swift
+[1078/1105] Compiling PublishingFrontend updatePrimaryServer.swift
+[1079/1105] Compiling PublishingFrontend updateZone.swift
+[1080/1105] Compiling PublishingFrontend validateZoneFile.swift
+[1081/1105] Compiling PublishingFrontend PublishingFrontend.swift
+[1086/1105] Compiling PublishingFrontend CreateRecord.swift
+[1088/1131] Emitting module DNSTests
+[1089/1133] Compiling PublishingFrontendTests Route53ClientTests.swift
+[1090/1133] Compiling gateway_server CertificateManager.swift
+[1091/1133] Compiling gateway_server GatewayPlugin.swift
+[1092/1133] Compiling DNSTests DeleteZoneRequestTests.swift
+[1093/1133] Emitting module gateway_server
+[1094/1134] Emitting module publishing_frontend
+[1095/1134] Compiling publishing_frontend main.swift
+[1096/1134] Compiling DNSTests ListRecordsRequestTests.swift
+[1097/1134] Compiling DNSTests UpdateRecordRequestTests.swift
+[1098/1134] Compiling gateway_server PublishingFrontendPlugin.swift
+[1099/1134] Compiling gateway_server LoggingPlugin.swift
+[1099/1135] Linking clientgen-service
+[1102/1135] Emitting module PublishingFrontendTests
+[1103/1135] Compiling PublishingFrontendTests HetznerDNSModelsTests.swift
+[1103/1135] Wrapping AST for PublishingFrontend for debugging
+[1107/1135] Compiling gateway_server GatewayServer.swift
+[1108/1135] Compiling DNSTests GetPrimaryServerRequestTests.swift
+[1109/1135] Compiling DNSTests GetRecordRequestTests.swift
+[1110/1135] Compiling DNSTests GetZoneRequestTests.swift
+[1111/1135] Compiling PublishingFrontendTests PublishingFrontendTests.swift
+/workspace/codex-deployer/Tests/PublishingFrontendTests/PublishingFrontendTests.swift:39:37: warning: result of call to 'changeCurrentDirectoryPath' is unused
+ 37 |         try yaml.write(to: fileURL, atomically: true, encoding: .utf8)
+ 38 |         let cwd = FileManager.default.currentDirectoryPath
+ 39 |         defer { FileManager.default.changeCurrentDirectoryPath(cwd) }
+    |                                     `- warning: result of call to 'changeCurrentDirectoryPath' is unused
+ 40 |         FileManager.default.changeCurrentDirectoryPath(dir.path)
+ 41 |         let config = try loadPublishingConfig()
+
+/workspace/codex-deployer/Tests/PublishingFrontendTests/PublishingFrontendTests.swift:40:29: warning: result of call to 'changeCurrentDirectoryPath' is unused
+ 38 |         let cwd = FileManager.default.currentDirectoryPath
+ 39 |         defer { FileManager.default.changeCurrentDirectoryPath(cwd) }
+ 40 |         FileManager.default.changeCurrentDirectoryPath(dir.path)
+    |                             `- warning: result of call to 'changeCurrentDirectoryPath' is unused
+ 41 |         let config = try loadPublishingConfig()
+ 42 |         XCTAssertEqual(config.port, 1234)
+
+/workspace/codex-deployer/Tests/PublishingFrontendTests/PublishingFrontendTests.swift:65:37: warning: result of call to 'changeCurrentDirectoryPath' is unused
+ 63 |         try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+ 64 |         let cwd = FileManager.default.currentDirectoryPath
+ 65 |         defer { FileManager.default.changeCurrentDirectoryPath(cwd) }
+    |                                     `- warning: result of call to 'changeCurrentDirectoryPath' is unused
+ 66 |         FileManager.default.changeCurrentDirectoryPath(dir.path)
+ 67 |         XCTAssertThrowsError(try loadPublishingConfig())
+
+/workspace/codex-deployer/Tests/PublishingFrontendTests/PublishingFrontendTests.swift:66:29: warning: result of call to 'changeCurrentDirectoryPath' is unused
+ 64 |         let cwd = FileManager.default.currentDirectoryPath
+ 65 |         defer { FileManager.default.changeCurrentDirectoryPath(cwd) }
+ 66 |         FileManager.default.changeCurrentDirectoryPath(dir.path)
+    |                             `- warning: result of call to 'changeCurrentDirectoryPath' is unused
+ 67 |         XCTAssertThrowsError(try loadPublishingConfig())
+ 68 |     }
+
+/workspace/codex-deployer/Tests/PublishingFrontendTests/PublishingFrontendTests.swift:79:37: warning: result of call to 'changeCurrentDirectoryPath' is unused
+ 77 |         try "port: [123".write(to: fileURL, atomically: true, encoding: .utf8)
+ 78 |         let cwd = FileManager.default.currentDirectoryPath
+ 79 |         defer { FileManager.default.changeCurrentDirectoryPath(cwd) }
+    |                                     `- warning: result of call to 'changeCurrentDirectoryPath' is unused
+ 80 |         FileManager.default.changeCurrentDirectoryPath(dir.path)
+ 81 |         XCTAssertThrowsError(try loadPublishingConfig())
+
+/workspace/codex-deployer/Tests/PublishingFrontendTests/PublishingFrontendTests.swift:80:29: warning: result of call to 'changeCurrentDirectoryPath' is unused
+ 78 |         let cwd = FileManager.default.currentDirectoryPath
+ 79 |         defer { FileManager.default.changeCurrentDirectoryPath(cwd) }
+ 80 |         FileManager.default.changeCurrentDirectoryPath(dir.path)
+    |                             `- warning: result of call to 'changeCurrentDirectoryPath' is unused
+ 81 |         XCTAssertThrowsError(try loadPublishingConfig())
+ 82 |     }
+
+/workspace/codex-deployer/Tests/PublishingFrontendTests/PublishingFrontendTests.swift:97:37: warning: result of call to 'changeCurrentDirectoryPath' is unused
+ 95 |         try yaml.write(to: fileURL, atomically: true, encoding: .utf8)
+ 96 |         let cwd = FileManager.default.currentDirectoryPath
+ 97 |         defer { FileManager.default.changeCurrentDirectoryPath(cwd) }
+    |                                     `- warning: result of call to 'changeCurrentDirectoryPath' is unused
+ 98 |         FileManager.default.changeCurrentDirectoryPath(dir.path)
+ 99 |         XCTAssertThrowsError(try loadPublishingConfig())
+
+/workspace/codex-deployer/Tests/PublishingFrontendTests/PublishingFrontendTests.swift:98:29: warning: result of call to 'changeCurrentDirectoryPath' is unused
+ 96 |         let cwd = FileManager.default.currentDirectoryPath
+ 97 |         defer { FileManager.default.changeCurrentDirectoryPath(cwd) }
+ 98 |         FileManager.default.changeCurrentDirectoryPath(dir.path)
+    |                             `- warning: result of call to 'changeCurrentDirectoryPath' is unused
+ 99 |         XCTAssertThrowsError(try loadPublishingConfig())
+100 |     }
+
+/workspace/codex-deployer/Tests/PublishingFrontendTests/PublishingFrontendTests.swift:114:37: warning: result of call to 'changeCurrentDirectoryPath' is unused
+112 |         try yaml.write(to: fileURL, atomically: true, encoding: .utf8)
+113 |         let cwd = FileManager.default.currentDirectoryPath
+114 |         defer { FileManager.default.changeCurrentDirectoryPath(cwd) }
+    |                                     `- warning: result of call to 'changeCurrentDirectoryPath' is unused
+115 |         FileManager.default.changeCurrentDirectoryPath(dir.path)
+116 |         let config = try loadPublishingConfig()
+
+/workspace/codex-deployer/Tests/PublishingFrontendTests/PublishingFrontendTests.swift:115:29: warning: result of call to 'changeCurrentDirectoryPath' is unused
+113 |         let cwd = FileManager.default.currentDirectoryPath
+114 |         defer { FileManager.default.changeCurrentDirectoryPath(cwd) }
+115 |         FileManager.default.changeCurrentDirectoryPath(dir.path)
+    |                             `- warning: result of call to 'changeCurrentDirectoryPath' is unused
+116 |         let config = try loadPublishingConfig()
+117 |         XCTAssertEqual(config.port, 1234)
+
+/workspace/codex-deployer/Tests/PublishingFrontendTests/PublishingFrontendTests.swift:133:37: warning: result of call to 'changeCurrentDirectoryPath' is unused
+131 |         try yaml.write(to: fileURL, atomically: true, encoding: .utf8)
+132 |         let cwd = FileManager.default.currentDirectoryPath
+133 |         defer { FileManager.default.changeCurrentDirectoryPath(cwd) }
+    |                                     `- warning: result of call to 'changeCurrentDirectoryPath' is unused
+134 |         FileManager.default.changeCurrentDirectoryPath(dir.path)
+135 |         let config = try loadPublishingConfig()
+
+/workspace/codex-deployer/Tests/PublishingFrontendTests/PublishingFrontendTests.swift:134:29: warning: result of call to 'changeCurrentDirectoryPath' is unused
+132 |         let cwd = FileManager.default.currentDirectoryPath
+133 |         defer { FileManager.default.changeCurrentDirectoryPath(cwd) }
+134 |         FileManager.default.changeCurrentDirectoryPath(dir.path)
+    |                             `- warning: result of call to 'changeCurrentDirectoryPath' is unused
+135 |         let config = try loadPublishingConfig()
+136 |         XCTAssertEqual(config.port, 8085)
+
+/workspace/codex-deployer/Tests/PublishingFrontendTests/PublishingFrontendTests.swift:221:37: warning: result of call to 'changeCurrentDirectoryPath' is unused
+219 |         try "".write(to: fileURL, atomically: true, encoding: .utf8)
+220 |         let cwd = FileManager.default.currentDirectoryPath
+221 |         defer { FileManager.default.changeCurrentDirectoryPath(cwd) }
+    |                                     `- warning: result of call to 'changeCurrentDirectoryPath' is unused
+222 |         FileManager.default.changeCurrentDirectoryPath(dir.path)
+223 |         let config = try loadPublishingConfig()
+
+/workspace/codex-deployer/Tests/PublishingFrontendTests/PublishingFrontendTests.swift:222:29: warning: result of call to 'changeCurrentDirectoryPath' is unused
+220 |         let cwd = FileManager.default.currentDirectoryPath
+221 |         defer { FileManager.default.changeCurrentDirectoryPath(cwd) }
+222 |         FileManager.default.changeCurrentDirectoryPath(dir.path)
+    |                             `- warning: result of call to 'changeCurrentDirectoryPath' is unused
+223 |         let config = try loadPublishingConfig()
+224 |         XCTAssertEqual(config.port, 8085)
+[1112/1135] Compiling PublishingFrontendTests HetznerDNSRequestTests.swift
+[1113/1136] Compiling DNSTests HetznerDNSClientTests.swift
+[1114/1136] Compiling DNSTests ListPrimaryServersRequestTests.swift
+[1115/1136] Compiling DNSTests APIClientTests.swift
+[1116/1136] Compiling DNSTests CreatePrimaryServerRequestTests.swift
+[1117/1136] Compiling DNSTests DNSClientTests.swift
+[1117/1137] Wrapping AST for publishing-frontend for debugging
+[1118/1137] Write Objects.LinkFileList
+[1122/1137] Compiling gateway_server main.swift
+[1123/1138] Wrapping AST for PublishingFrontendTests for debugging
+[1124/1138] Wrapping AST for DNSTests for debugging
+[1125/1138] Wrapping AST for gateway-server for debugging
+[1126/1138] Write Objects.LinkFileList
+[1127/1138] Linking publishing-frontend
+[1128/1138] Linking gateway-server
+[1130/1148] Emitting module IntegrationRuntimeTests
+[1131/1150] Compiling IntegrationRuntimeTests LoggingPluginTests.swift
+[1132/1150] Compiling IntegrationRuntimeTests NIOHTTPServerTests.swift
+[1133/1150] Compiling IntegrationRuntimeTests HTTPRequestTests.swift
+[1134/1150] Compiling IntegrationRuntimeTests HTTPResponseDefaultsTests.swift
+[1135/1150] Compiling IntegrationRuntimeTests AsyncHTTPClientDriverTests.swift
+[1136/1150] Compiling IntegrationRuntimeTests CertificateManagerTests.swift
+[1137/1150] Compiling IntegrationRuntimeTests GatewayPluginTests.swift
+[1138/1150] Compiling IntegrationRuntimeTests GatewayServerTests.swift
+[1139/1150] Compiling IntegrationRuntimeTests HTTPKernelTests.swift
+[1140/1150] Compiling IntegrationRuntimeTests PublishingFrontendPluginTests.swift
+[1141/1150] Compiling IntegrationRuntimeTests URLSessionHTTPClientTests.swift
+[1142/1151] /workspace/codex-deployer/.build/x86_64-unknown-linux-gnu/debug/FountainCoachPackageDiscoveredTests.derived/all-discovered-tests.swift
+[1143/1151] Write sources
+[1144/1151] Wrapping AST for IntegrationRuntimeTests for debugging
+[1146/1157] Compiling FountainCoachPackageDiscoveredTests PublishingFrontendTests.swift
+[1147/1157] Compiling FountainCoachPackageDiscoveredTests FountainCoreTests.swift
+[1148/1157] Emitting module FountainCoachPackageDiscoveredTests
+[1149/1157] Compiling FountainCoachPackageDiscoveredTests IntegrationRuntimeTests.swift
+[1150/1157] Compiling FountainCoachPackageDiscoveredTests ClientGeneratorTests.swift
+[1151/1157] Compiling FountainCoachPackageDiscoveredTests DNSTests.swift
+[1152/1158] Compiling FountainCoachPackageDiscoveredTests all-discovered-tests.swift
+[1153/1159] /workspace/codex-deployer/.build/x86_64-unknown-linux-gnu/debug/FountainCoachPackageTests.derived/runner.swift
+[1154/1159] Write sources
+[1155/1159] Wrapping AST for FountainCoachPackageDiscoveredTests for debugging
+[1157/1161] Emitting module FountainCoachPackageTests
+[1158/1161] Compiling FountainCoachPackageTests runner.swift
+[1159/1162] Wrapping AST for FountainCoachPackageTests for debugging
+[1160/1162] Write Objects.LinkFileList
+[1161/1162] Linking FountainCoachPackageTests.xctest
+Build complete! (239.45s)
+Test Suite 'All tests' started at 2025-08-04 19:27:24.754
+Test Suite 'debug.xctest' started at 2025-08-04 19:27:24.773
+Test Suite 'HetznerDNSModelsTests' started at 2025-08-04 19:27:24.773
+Test Case 'HetznerDNSModelsTests.testBulkRecordsCreateRequestCodable' started at 2025-08-04 19:27:24.773
+Test Case 'HetznerDNSModelsTests.testBulkRecordsCreateRequestCodable' passed (0.01 seconds)
+Test Case 'HetznerDNSModelsTests.testBulkRecordsUpdateRequestCodable' started at 2025-08-04 19:27:24.784
+Test Case 'HetznerDNSModelsTests.testBulkRecordsUpdateRequestCodable' passed (0.102 seconds)
+Test Case 'HetznerDNSModelsTests.testPrimaryServerCreateCodable' started at 2025-08-04 19:27:24.886
+Test Case 'HetznerDNSModelsTests.testPrimaryServerCreateCodable' passed (0.001 seconds)
+Test Case 'HetznerDNSModelsTests.testPrimaryServersResponseDecodes' started at 2025-08-04 19:27:24.887
+Test Case 'HetznerDNSModelsTests.testPrimaryServersResponseDecodes' passed (0.001 seconds)
+Test Case 'HetznerDNSModelsTests.testRecordResponseDecodes' started at 2025-08-04 19:27:24.888
+Test Case 'HetznerDNSModelsTests.testRecordResponseDecodes' passed (0.001 seconds)
+Test Case 'HetznerDNSModelsTests.testValidateZoneFileResponseDecodes' started at 2025-08-04 19:27:24.889
+Test Case 'HetznerDNSModelsTests.testValidateZoneFileResponseDecodes' passed (0.001 seconds)
+Test Case 'HetznerDNSModelsTests.testZoneCreateRequestCodable' started at 2025-08-04 19:27:24.890
+Test Case 'HetznerDNSModelsTests.testZoneCreateRequestCodable' passed (0.001 seconds)
+Test Case 'HetznerDNSModelsTests.testZoneResponseDecoding' started at 2025-08-04 19:27:24.890
+Test Case 'HetznerDNSModelsTests.testZoneResponseDecoding' passed (0.001 seconds)
+Test Case 'HetznerDNSModelsTests.testZoneUpdateRequestCodable' started at 2025-08-04 19:27:24.892
+Test Case 'HetznerDNSModelsTests.testZoneUpdateRequestCodable' passed (0.101 seconds)
+Test Case 'HetznerDNSModelsTests.testZonesResponseDecodes' started at 2025-08-04 19:27:24.993
+Test Case 'HetznerDNSModelsTests.testZonesResponseDecodes' passed (0.001 seconds)
+Test Suite 'HetznerDNSModelsTests' passed at 2025-08-04 19:27:24.994
+	 Executed 10 tests, with 0 failures (0 unexpected) in 0.22 (0.22) seconds
+Test Suite 'HetznerDNSRequestTests' started at 2025-08-04 19:27:24.994
+Test Case 'HetznerDNSRequestTests.testBulkCreateRecordsMethodIsPost' started at 2025-08-04 19:27:24.994
+Test Case 'HetznerDNSRequestTests.testBulkCreateRecordsMethodIsPost' passed (0.0 seconds)
+Test Case 'HetznerDNSRequestTests.testBulkCreateRecordsPath' started at 2025-08-04 19:27:24.994
+Test Case 'HetznerDNSRequestTests.testBulkCreateRecordsPath' passed (0.0 seconds)
+Test Case 'HetznerDNSRequestTests.testBulkUpdateRecordsMethodIsPut' started at 2025-08-04 19:27:24.994
+Test Case 'HetznerDNSRequestTests.testBulkUpdateRecordsMethodIsPut' passed (0.0 seconds)
+Test Case 'HetznerDNSRequestTests.testBulkUpdateRecordsPath' started at 2025-08-04 19:27:24.995
+Test Case 'HetznerDNSRequestTests.testBulkUpdateRecordsPath' passed (0.0 seconds)
+Test Case 'HetznerDNSRequestTests.testCreateZoneMethodIsPost' started at 2025-08-04 19:27:24.995
+Test Case 'HetznerDNSRequestTests.testCreateZoneMethodIsPost' passed (0.0 seconds)
+Test Case 'HetznerDNSRequestTests.testCreateZonePath' started at 2025-08-04 19:27:24.995
+Test Case 'HetznerDNSRequestTests.testCreateZonePath' passed (0.0 seconds)
+Test Case 'HetznerDNSRequestTests.testExportZoneFileMethodIsGet' started at 2025-08-04 19:27:24.995
+Test Case 'HetznerDNSRequestTests.testExportZoneFileMethodIsGet' passed (0.0 seconds)
+Test Case 'HetznerDNSRequestTests.testExportZoneFilePathIncludesZoneID' started at 2025-08-04 19:27:24.995
+Test Case 'HetznerDNSRequestTests.testExportZoneFilePathIncludesZoneID' passed (0.002 seconds)
+Test Case 'HetznerDNSRequestTests.testImportZoneFileMethodIsPost' started at 2025-08-04 19:27:24.997
+Test Case 'HetznerDNSRequestTests.testImportZoneFileMethodIsPost' passed (0.0 seconds)
+Test Case 'HetznerDNSRequestTests.testImportZoneFilePathIncludesZoneID' started at 2025-08-04 19:27:24.997
+Test Case 'HetznerDNSRequestTests.testImportZoneFilePathIncludesZoneID' passed (0.0 seconds)
+Test Case 'HetznerDNSRequestTests.testUpdatePrimaryServerMethodIsPut' started at 2025-08-04 19:27:24.998
+Test Case 'HetznerDNSRequestTests.testUpdatePrimaryServerMethodIsPut' passed (0.0 seconds)
+Test Case 'HetznerDNSRequestTests.testUpdatePrimaryServerPathIncludesID' started at 2025-08-04 19:27:24.998
+Test Case 'HetznerDNSRequestTests.testUpdatePrimaryServerPathIncludesID' passed (0.0 seconds)
+Test Case 'HetznerDNSRequestTests.testUpdateZoneMethodIsPut' started at 2025-08-04 19:27:24.999
+Test Case 'HetznerDNSRequestTests.testUpdateZoneMethodIsPut' passed (0.0 seconds)
+Test Case 'HetznerDNSRequestTests.testUpdateZonePathIncludesID' started at 2025-08-04 19:27:24.999
+Test Case 'HetznerDNSRequestTests.testUpdateZonePathIncludesID' passed (0.0 seconds)
+Test Case 'HetznerDNSRequestTests.testValidateZoneFileMethodIsPost' started at 2025-08-04 19:27:24.999
+Test Case 'HetznerDNSRequestTests.testValidateZoneFileMethodIsPost' passed (0.001 seconds)
+Test Case 'HetznerDNSRequestTests.testValidateZoneFilePath' started at 2025-08-04 19:27:25.000
+Test Case 'HetznerDNSRequestTests.testValidateZoneFilePath' passed (0.0 seconds)
+Test Suite 'HetznerDNSRequestTests' passed at 2025-08-04 19:27:25.000
+	 Executed 16 tests, with 0 failures (0 unexpected) in 0.006 (0.006) seconds
+Test Suite 'PublishingFrontendTests' started at 2025-08-04 19:27:25.000
+Test Case 'PublishingFrontendTests.testLoadPublishingConfigFailsForInvalidYAML' started at 2025-08-04 19:27:25.000
+Test Case 'PublishingFrontendTests.testLoadPublishingConfigFailsForInvalidYAML' passed (0.01 seconds)
+Test Case 'PublishingFrontendTests.testLoadPublishingConfigFailsForMissingFile' started at 2025-08-04 19:27:25.011
+Test Case 'PublishingFrontendTests.testLoadPublishingConfigFailsForMissingFile' passed (0.001 seconds)
+Test Case 'PublishingFrontendTests.testLoadPublishingConfigFailsForNonNumericPort' started at 2025-08-04 19:27:25.011
+Test Case 'PublishingFrontendTests.testLoadPublishingConfigFailsForNonNumericPort' passed (0.005 seconds)
+Test Case 'PublishingFrontendTests.testLoadPublishingConfigParsesYaml' started at 2025-08-04 19:27:25.017
+Test Case 'PublishingFrontendTests.testLoadPublishingConfigParsesYaml' passed (0.004 seconds)
+Test Case 'PublishingFrontendTests.testLoadPublishingConfigUsesDefaultPortWhenMissing' started at 2025-08-04 19:27:25.020
+Test Case 'PublishingFrontendTests.testLoadPublishingConfigUsesDefaultPortWhenMissing' passed (0.003 seconds)
+Test Case 'PublishingFrontendTests.testLoadPublishingConfigUsesDefaultRootPathWhenMissing' started at 2025-08-04 19:27:25.023
+Test Case 'PublishingFrontendTests.testLoadPublishingConfigUsesDefaultRootPathWhenMissing' passed (0.002 seconds)
+Test Case 'PublishingFrontendTests.testLoadPublishingConfigUsesDefaultsWhenFileEmpty' started at 2025-08-04 19:27:25.025
+Test Case 'PublishingFrontendTests.testLoadPublishingConfigUsesDefaultsWhenFileEmpty' passed (0.001 seconds)
+Test Case 'PublishingFrontendTests.testPublishingConfigCustomValues' started at 2025-08-04 19:27:25.026
+Test Case 'PublishingFrontendTests.testPublishingConfigCustomValues' passed (0.0 seconds)
+Test Case 'PublishingFrontendTests.testPublishingConfigDefaultValues' started at 2025-08-04 19:27:25.026
+Test Case 'PublishingFrontendTests.testPublishingConfigDefaultValues' passed (0.0 seconds)
+Test Case 'PublishingFrontendTests.testServerRejectsNonGetRequests' started at 2025-08-04 19:27:25.027
+Test Case 'PublishingFrontendTests.testServerRejectsNonGetRequests' passed (0.032 seconds)
+Test Case 'PublishingFrontendTests.testServerReturns404ForMissingFile' started at 2025-08-04 19:27:25.058
+Test Case 'PublishingFrontendTests.testServerReturns404ForMissingFile' passed (0.005 seconds)
+Test Case 'PublishingFrontendTests.testServerServesIndex' started at 2025-08-04 19:27:25.064
+Test Case 'PublishingFrontendTests.testServerServesIndex' passed (0.008 seconds)
+Test Case 'PublishingFrontendTests.testServerServesNestedFile' started at 2025-08-04 19:27:25.071
+Test Case 'PublishingFrontendTests.testServerServesNestedFile' passed (0.006 seconds)
+Test Case 'PublishingFrontendTests.testServerSetsContentTypeHeader' started at 2025-08-04 19:27:25.077
+Test Case 'PublishingFrontendTests.testServerSetsContentTypeHeader' passed (0.007 seconds)
+Test Suite 'PublishingFrontendTests' passed at 2025-08-04 19:27:25.084
+	 Executed 14 tests, with 0 failures (0 unexpected) in 0.083 (0.083) seconds
+Test Suite 'Route53ClientTests' started at 2025-08-04 19:27:25.084
+Test Case 'Route53ClientTests.testCreateRecordThrows' started at 2025-08-04 19:27:25.084
+Test Case 'Route53ClientTests.testCreateRecordThrows' passed (0.001 seconds)
+Test Case 'Route53ClientTests.testDeleteRecordThrows' started at 2025-08-04 19:27:25.085
+Test Case 'Route53ClientTests.testDeleteRecordThrows' passed (0.0 seconds)
+Test Case 'Route53ClientTests.testListZonesThrows' started at 2025-08-04 19:27:25.085
+Test Case 'Route53ClientTests.testListZonesThrows' passed (0.0 seconds)
+Test Case 'Route53ClientTests.testUpdateRecordThrows' started at 2025-08-04 19:27:25.086
+Test Case 'Route53ClientTests.testUpdateRecordThrows' passed (0.0 seconds)
+Test Suite 'Route53ClientTests' passed at 2025-08-04 19:27:25.086
+	 Executed 4 tests, with 0 failures (0 unexpected) in 0.002 (0.002) seconds
+Test Suite 'AsyncHTTPClientDriverTests' started at 2025-08-04 19:27:25.086
+Test Case 'AsyncHTTPClientDriverTests.testExecuteFailsForUnreachableHost' started at 2025-08-04 19:27:25.086
+Test Case 'AsyncHTTPClientDriverTests.testExecuteFailsForUnreachableHost' passed (5.006 seconds)
+Test Case 'AsyncHTTPClientDriverTests.testExecutePerformsRequest' started at 2025-08-04 19:27:30.092
+Test Case 'AsyncHTTPClientDriverTests.testExecutePerformsRequest' passed (0.013 seconds)
+Test Case 'AsyncHTTPClientDriverTests.testExecuteSendsBody' started at 2025-08-04 19:27:30.105
+Test Case 'AsyncHTTPClientDriverTests.testExecuteSendsBody' passed (0.106 seconds)
+Test Suite 'AsyncHTTPClientDriverTests' passed at 2025-08-04 19:27:30.211
+	 Executed 3 tests, with 0 failures (0 unexpected) in 5.125 (5.125) seconds
+Test Suite 'CertificateManagerTests' started at 2025-08-04 19:27:30.211
+Test Case 'CertificateManagerTests.testStartSchedulesRepeatedRuns' started at 2025-08-04 19:27:30.211
+Test Case 'CertificateManagerTests.testStartSchedulesRepeatedRuns' passed (1.067 seconds)
+Test Case 'CertificateManagerTests.testStopCancelsFutureRuns' started at 2025-08-04 19:27:31.279
+Test Case 'CertificateManagerTests.testStopCancelsFutureRuns' passed (3.04 seconds)
+Test Case 'CertificateManagerTests.testTriggerNowRunsScript' started at 2025-08-04 19:27:34.318
+Test Case 'CertificateManagerTests.testTriggerNowRunsScript' passed (1.004 seconds)
+Test Suite 'CertificateManagerTests' passed at 2025-08-04 19:27:35.323
+	 Executed 3 tests, with 0 failures (0 unexpected) in 5.111 (5.111) seconds
+Test Suite 'GatewayPluginTests' started at 2025-08-04 19:27:35.323
+Test Case 'GatewayPluginTests.testDefaultPrepareReturnsSameRequest' started at 2025-08-04 19:27:35.323
+Test Case 'GatewayPluginTests.testDefaultPrepareReturnsSameRequest' passed (0.001 seconds)
+Test Case 'GatewayPluginTests.testDefaultRespondReturnsSameResponse' started at 2025-08-04 19:27:35.323
+Test Case 'GatewayPluginTests.testDefaultRespondReturnsSameResponse' passed (0.001 seconds)
+Test Suite 'GatewayPluginTests' passed at 2025-08-04 19:27:35.324
+	 Executed 2 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
+Test Suite 'GatewayServerTests' started at 2025-08-04 19:27:35.324
+Test Case 'GatewayServerTests.testHealthEndpointResponds' started at 2025-08-04 19:27:35.324
+Test Case 'GatewayServerTests.testHealthEndpointResponds' passed (0.107 seconds)
+Test Case 'GatewayServerTests.testHealthEndpointSetsJSONContentType' started at 2025-08-04 19:27:35.431
+Test Case 'GatewayServerTests.testHealthEndpointSetsJSONContentType' passed (0.106 seconds)
+Test Case 'GatewayServerTests.testMetricsEndpointResponds' started at 2025-08-04 19:27:35.537
+Test Case 'GatewayServerTests.testMetricsEndpointResponds' passed (0.106 seconds)
+Test Case 'GatewayServerTests.testMetricsEndpointReturnsEmptyArray' started at 2025-08-04 19:27:35.643
+Test Case 'GatewayServerTests.testMetricsEndpointReturnsEmptyArray' passed (0.105 seconds)
+Test Case 'GatewayServerTests.testMetricsEndpointSetsJSONContentType' started at 2025-08-04 19:27:35.748
+Test Case 'GatewayServerTests.testMetricsEndpointSetsJSONContentType' passed (0.107 seconds)
+Test Case 'GatewayServerTests.testPluginCanRewriteRequestAndResponse' started at 2025-08-04 19:27:35.854
+Test Case 'GatewayServerTests.testPluginCanRewriteRequestAndResponse' passed (0.106 seconds)
+Test Case 'GatewayServerTests.testPluginsPrepareInRegistrationOrder' started at 2025-08-04 19:27:35.960
+Test Case 'GatewayServerTests.testPluginsPrepareInRegistrationOrder' passed (0.105 seconds)
+Test Case 'GatewayServerTests.testPluginsRespondInReverseOrder' started at 2025-08-04 19:27:36.066
+Test Case 'GatewayServerTests.testPluginsRespondInReverseOrder' passed (0.106 seconds)
+Test Case 'GatewayServerTests.testUnknownPathReturns404' started at 2025-08-04 19:27:36.171
+Test Case 'GatewayServerTests.testUnknownPathReturns404' passed (0.105 seconds)
+Test Suite 'GatewayServerTests' passed at 2025-08-04 19:27:36.276
+	 Executed 9 tests, with 0 failures (0 unexpected) in 0.952 (0.952) seconds
+Test Suite 'HTTPKernelTests' started at 2025-08-04 19:27:36.276
+Test Case 'HTTPKernelTests.testKernelPropagatesErrors' started at 2025-08-04 19:27:36.276
+Test Case 'HTTPKernelTests.testKernelPropagatesErrors' passed (0.0 seconds)
+Test Case 'HTTPKernelTests.testKernelRoutesRequest' started at 2025-08-04 19:27:36.277
+Test Case 'HTTPKernelTests.testKernelRoutesRequest' passed (0.0 seconds)
+Test Suite 'HTTPKernelTests' passed at 2025-08-04 19:27:36.277
+	 Executed 2 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
+Test Suite 'HTTPRequestTests' started at 2025-08-04 19:27:36.277
+Test Case 'HTTPRequestTests.testRequestDefaults' started at 2025-08-04 19:27:36.277
+Test Case 'HTTPRequestTests.testRequestDefaults' passed (0.0 seconds)
+Test Case 'HTTPRequestTests.testRequestInitializerStoresValues' started at 2025-08-04 19:27:36.278
+Test Case 'HTTPRequestTests.testRequestInitializerStoresValues' passed (0.0 seconds)
+Test Case 'HTTPRequestTests.testRequestMutation' started at 2025-08-04 19:27:36.278
+Test Case 'HTTPRequestTests.testRequestMutation' passed (0.0 seconds)
+Test Suite 'HTTPRequestTests' passed at 2025-08-04 19:27:36.278
+	 Executed 3 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
+Test Suite 'HTTPResponseDefaultsTests' started at 2025-08-04 19:27:36.278
+Test Case 'HTTPResponseDefaultsTests.testNoBodyCodable' started at 2025-08-04 19:27:36.278
+Test Case 'HTTPResponseDefaultsTests.testNoBodyCodable' passed (0.001 seconds)
+Test Case 'HTTPResponseDefaultsTests.testResponseBodyMutation' started at 2025-08-04 19:27:36.279
+Test Case 'HTTPResponseDefaultsTests.testResponseBodyMutation' passed (0.0 seconds)
+Test Case 'HTTPResponseDefaultsTests.testResponseDefaults' started at 2025-08-04 19:27:36.279
+Test Case 'HTTPResponseDefaultsTests.testResponseDefaults' passed (0.0 seconds)
+Test Case 'HTTPResponseDefaultsTests.testResponseHeadersMutation' started at 2025-08-04 19:27:36.279
+Test Case 'HTTPResponseDefaultsTests.testResponseHeadersMutation' passed (0.0 seconds)
+Test Case 'HTTPResponseDefaultsTests.testResponseInitializerStoresValues' started at 2025-08-04 19:27:36.280
+Test Case 'HTTPResponseDefaultsTests.testResponseInitializerStoresValues' passed (0.0 seconds)
+Test Case 'HTTPResponseDefaultsTests.testResponseStatusMutation' started at 2025-08-04 19:27:36.280
+Test Case 'HTTPResponseDefaultsTests.testResponseStatusMutation' passed (0.0 seconds)
+Test Suite 'HTTPResponseDefaultsTests' passed at 2025-08-04 19:27:36.280
+	 Executed 6 tests, with 0 failures (0 unexpected) in 0.002 (0.002) seconds
+Test Suite 'LoggingPluginTests' started at 2025-08-04 19:27:36.280
+Test Case 'LoggingPluginTests.testLoggingPluginPassThrough' started at 2025-08-04 19:27:36.280
+-> GET /
+<- 200 for /
+Test Case 'LoggingPluginTests.testLoggingPluginPassThrough' passed (0.0 seconds)
+Test Case 'LoggingPluginTests.testPreparePreservesHeadersAndBody' started at 2025-08-04 19:27:36.280
+-> POST /data
+Test Case 'LoggingPluginTests.testPreparePreservesHeadersAndBody' passed (0.0 seconds)
+Test Case 'LoggingPluginTests.testRespondPreservesHeadersAndBody' started at 2025-08-04 19:27:36.281
+<- 201 for /
+Test Case 'LoggingPluginTests.testRespondPreservesHeadersAndBody' passed (0.001 seconds)
+Test Suite 'LoggingPluginTests' passed at 2025-08-04 19:27:36.282
+	 Executed 3 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
+Test Suite 'NIOHTTPServerTests' started at 2025-08-04 19:27:36.282
+Test Case 'NIOHTTPServerTests.testServerHandlesConcurrentRequests' started at 2025-08-04 19:27:36.282
+Test Case 'NIOHTTPServerTests.testServerHandlesConcurrentRequests' passed (0.005 seconds)
+Test Case 'NIOHTTPServerTests.testServerReleasesPortOnStop' started at 2025-08-04 19:27:36.287
+Test Case 'NIOHTTPServerTests.testServerReleasesPortOnStop' passed (0.003 seconds)
+Test Case 'NIOHTTPServerTests.testServerResponds' started at 2025-08-04 19:27:36.290
+Test Case 'NIOHTTPServerTests.testServerResponds' passed (0.004 seconds)
+Test Suite 'NIOHTTPServerTests' passed at 2025-08-04 19:27:36.294
+	 Executed 3 tests, with 0 failures (0 unexpected) in 0.012 (0.012) seconds
+Test Suite 'PublishingFrontendPluginTests' started at 2025-08-04 19:27:36.294
+Test Case 'PublishingFrontendPluginTests.testPluginIgnoresNonGETRequests' started at 2025-08-04 19:27:36.294
+Test Case 'PublishingFrontendPluginTests.testPluginIgnoresNonGETRequests' passed (0.026 seconds)
+Test Case 'PublishingFrontendPluginTests.testPluginPassThroughWhenFileMissing' started at 2025-08-04 19:27:36.320
+Test Case 'PublishingFrontendPluginTests.testPluginPassThroughWhenFileMissing' passed (0.0 seconds)
+Test Case 'PublishingFrontendPluginTests.testPluginPreservesHeadersOnPassThrough' started at 2025-08-04 19:27:36.321
+Test Case 'PublishingFrontendPluginTests.testPluginPreservesHeadersOnPassThrough' passed (0.0 seconds)
+Test Case 'PublishingFrontendPluginTests.testPluginServesFile' started at 2025-08-04 19:27:36.321
+Test Case 'PublishingFrontendPluginTests.testPluginServesFile' passed (0.003 seconds)
+Test Case 'PublishingFrontendPluginTests.testPluginServesNestedFile' started at 2025-08-04 19:27:36.324
+Test Case 'PublishingFrontendPluginTests.testPluginServesNestedFile' passed (0.002 seconds)
+Test Case 'PublishingFrontendPluginTests.testPluginSetsContentTypeHeader' started at 2025-08-04 19:27:36.326
+Test Case 'PublishingFrontendPluginTests.testPluginSetsContentTypeHeader' passed (0.002 seconds)
+Test Suite 'PublishingFrontendPluginTests' passed at 2025-08-04 19:27:36.328
+	 Executed 6 tests, with 0 failures (0 unexpected) in 0.034 (0.034) seconds
+Test Suite 'URLSessionHTTPClientTests' started at 2025-08-04 19:27:36.328
+Test Case 'URLSessionHTTPClientTests.testExecuteCollectsMultipleHeaders' started at 2025-08-04 19:27:36.328
+Test Case 'URLSessionHTTPClientTests.testExecuteCollectsMultipleHeaders' passed (0.001 seconds)
+Test Case 'URLSessionHTTPClientTests.testExecuteHandlesEmptyBody' started at 2025-08-04 19:27:36.329
+Test Case 'URLSessionHTTPClientTests.testExecuteHandlesEmptyBody' passed (0.001 seconds)
+Test Case 'URLSessionHTTPClientTests.testExecutePerformsRequest' started at 2025-08-04 19:27:36.331
+Test Case 'URLSessionHTTPClientTests.testExecutePerformsRequest' passed (0.001 seconds)
+Test Suite 'URLSessionHTTPClientTests' passed at 2025-08-04 19:27:36.332
+	 Executed 3 tests, with 0 failures (0 unexpected) in 0.004 (0.004) seconds
+Test Suite 'ClientGeneratorTests' started at 2025-08-04 19:27:36.332
+Test Case 'ClientGeneratorTests.testClientFilesGenerated' started at 2025-08-04 19:27:36.332
+Test Case 'ClientGeneratorTests.testClientFilesGenerated' passed (0.007 seconds)
+Test Case 'ClientGeneratorTests.testEmitRequestGeneratesQueryParameter' started at 2025-08-04 19:27:36.339
+Test Case 'ClientGeneratorTests.testEmitRequestGeneratesQueryParameter' passed (0.007 seconds)
+Test Suite 'ClientGeneratorTests' passed at 2025-08-04 19:27:36.346
+	 Executed 2 tests, with 0 failures (0 unexpected) in 0.014 (0.014) seconds
+Test Suite 'OpenAPIParameterTests' started at 2025-08-04 19:27:36.346
+Test Case 'OpenAPIParameterTests.testSwiftNameReplacesHyphenWithUnderscore' started at 2025-08-04 19:27:36.346
+Test Case 'OpenAPIParameterTests.testSwiftNameReplacesHyphenWithUnderscore' passed (0.0 seconds)
+Test Case 'OpenAPIParameterTests.testSwiftTypeUsesSchemaOrDefaultsToString' started at 2025-08-04 19:27:36.347
+Test Case 'OpenAPIParameterTests.testSwiftTypeUsesSchemaOrDefaultsToString' passed (0.0 seconds)
+Test Suite 'OpenAPIParameterTests' passed at 2025-08-04 19:27:36.347
+	 Executed 2 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
+Test Suite 'OpenAPISwiftTypeTests' started at 2025-08-04 19:27:36.347
+Test Case 'OpenAPISwiftTypeTests.testSchemaPropertyObjectSwiftType' started at 2025-08-04 19:27:36.347
+Test Case 'OpenAPISwiftTypeTests.testSchemaPropertyObjectSwiftType' passed (0.0 seconds)
+Test Case 'OpenAPISwiftTypeTests.testSchemaPropertySwiftType' started at 2025-08-04 19:27:36.347
+Test Case 'OpenAPISwiftTypeTests.testSchemaPropertySwiftType' passed (0.0 seconds)
+Test Case 'OpenAPISwiftTypeTests.testSchemaPropertyUnknownTypeDefaultsToString' started at 2025-08-04 19:27:36.348
+Test Case 'OpenAPISwiftTypeTests.testSchemaPropertyUnknownTypeDefaultsToString' passed (0.0 seconds)
+Test Case 'OpenAPISwiftTypeTests.testSchemaRefSwiftType' started at 2025-08-04 19:27:36.348
+Test Case 'OpenAPISwiftTypeTests.testSchemaRefSwiftType' passed (0.0 seconds)
+Test Suite 'OpenAPISwiftTypeTests' passed at 2025-08-04 19:27:36.348
+	 Executed 4 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
+Test Suite 'SecurityRequirementTests' started at 2025-08-04 19:27:36.348
+Test Case 'SecurityRequirementTests.testDecodesSchemesFromJSON' started at 2025-08-04 19:27:36.348
+Test Case 'SecurityRequirementTests.testDecodesSchemesFromJSON' passed (0.001 seconds)
+Test Case 'SecurityRequirementTests.testEncodesSchemesToJSON' started at 2025-08-04 19:27:36.349
+Test Case 'SecurityRequirementTests.testEncodesSchemesToJSON' passed (0.001 seconds)
+Test Suite 'SecurityRequirementTests' passed at 2025-08-04 19:27:36.350
+	 Executed 2 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
+Test Suite 'SpecLoaderTests' started at 2025-08-04 19:27:36.350
+Test Case 'SpecLoaderTests.testLoadThrowsForEmptyFile' started at 2025-08-04 19:27:36.350
+Test Case 'SpecLoaderTests.testLoadThrowsForEmptyFile' passed (0.001 seconds)
+Test Case 'SpecLoaderTests.testLoadThrowsForInvalidUTF8' started at 2025-08-04 19:27:36.350
+Test Case 'SpecLoaderTests.testLoadThrowsForInvalidUTF8' passed (0.002 seconds)
+Test Case 'SpecLoaderTests.testLoadsJSONRemovingCopyright' started at 2025-08-04 19:27:36.352
+Test Case 'SpecLoaderTests.testLoadsJSONRemovingCopyright' passed (0.003 seconds)
+Test Case 'SpecLoaderTests.testLoadsYAMLAndNormalizesInfoTitle' started at 2025-08-04 19:27:36.356
+Test Case 'SpecLoaderTests.testLoadsYAMLAndNormalizesInfoTitle' passed (0.002 seconds)
+Test Suite 'SpecLoaderTests' passed at 2025-08-04 19:27:36.358
+	 Executed 4 tests, with 0 failures (0 unexpected) in 0.008 (0.008) seconds
+Test Suite 'SpecValidatorTests' started at 2025-08-04 19:27:36.358
+Test Case 'SpecValidatorTests.testDuplicateOperationIdThrows' started at 2025-08-04 19:27:36.358
+Test Case 'SpecValidatorTests.testDuplicateOperationIdThrows' passed (0.0 seconds)
+Test Case 'SpecValidatorTests.testEmptyParameterLocationThrows' started at 2025-08-04 19:27:36.358
+Test Case 'SpecValidatorTests.testEmptyParameterLocationThrows' passed (0.0 seconds)
+Test Case 'SpecValidatorTests.testEmptyParameterNameThrows' started at 2025-08-04 19:27:36.359
+Test Case 'SpecValidatorTests.testEmptyParameterNameThrows' passed (0.0 seconds)
+Test Case 'SpecValidatorTests.testEmptyTitleThrows' started at 2025-08-04 19:27:36.359
+Test Case 'SpecValidatorTests.testEmptyTitleThrows' passed (0.0 seconds)
+Test Case 'SpecValidatorTests.testMissingPathParameterThrows' started at 2025-08-04 19:27:36.359
+Test Case 'SpecValidatorTests.testMissingPathParameterThrows' passed (0.0 seconds)
+Test Case 'SpecValidatorTests.testPathParameterMustBeRequired' started at 2025-08-04 19:27:36.360
+Test Case 'SpecValidatorTests.testPathParameterMustBeRequired' passed (0.0 seconds)
+Test Case 'SpecValidatorTests.testUnknownSecuritySchemeThrows' started at 2025-08-04 19:27:36.360
+Test Case 'SpecValidatorTests.testUnknownSecuritySchemeThrows' passed (0.001 seconds)
+Test Case 'SpecValidatorTests.testUnresolvedSchemaReferenceThrows' started at 2025-08-04 19:27:36.360
+Test Case 'SpecValidatorTests.testUnresolvedSchemaReferenceThrows' passed (0.0 seconds)
+Test Suite 'SpecValidatorTests' passed at 2025-08-04 19:27:36.361
+	 Executed 8 tests, with 0 failures (0 unexpected) in 0.003 (0.003) seconds
+Test Suite 'StringExtensionTests' started at 2025-08-04 19:27:36.361
+Test Case 'StringExtensionTests.testCamelCased' started at 2025-08-04 19:27:36.361
+Test Case 'StringExtensionTests.testCamelCased' passed (0.0 seconds)
+Test Case 'StringExtensionTests.testCamelCasedEmptyString' started at 2025-08-04 19:27:36.361
+Test Case 'StringExtensionTests.testCamelCasedEmptyString' passed (0.001 seconds)
+Test Case 'StringExtensionTests.testCamelCasedLeadingUnderscore' started at 2025-08-04 19:27:36.362
+Test Case 'StringExtensionTests.testCamelCasedLeadingUnderscore' passed (0.0 seconds)
+Test Case 'StringExtensionTests.testCamelCasedMultipleUnderscores' started at 2025-08-04 19:27:36.362
+Test Case 'StringExtensionTests.testCamelCasedMultipleUnderscores' passed (0.0 seconds)
+Test Case 'StringExtensionTests.testCamelCasedNumbers' started at 2025-08-04 19:27:36.362
+Test Case 'StringExtensionTests.testCamelCasedNumbers' passed (0.0 seconds)
+Test Case 'StringExtensionTests.testCamelCasedTrailingUnderscore' started at 2025-08-04 19:27:36.362
+Test Case 'StringExtensionTests.testCamelCasedTrailingUnderscore' passed (0.0 seconds)
+Test Case 'StringExtensionTests.testCamelCasedUppercaseInput' started at 2025-08-04 19:27:36.363
+Test Case 'StringExtensionTests.testCamelCasedUppercaseInput' passed (0.0 seconds)
+Test Suite 'StringExtensionTests' passed at 2025-08-04 19:27:36.363
+	 Executed 7 tests, with 0 failures (0 unexpected) in 0.002 (0.002) seconds
+Test Suite 'FountainCoreTests' started at 2025-08-04 19:27:36.363
+Test Case 'FountainCoreTests.testTodoDecoding' started at 2025-08-04 19:27:36.363
+Test Case 'FountainCoreTests.testTodoDecoding' passed (0.0 seconds)
+Test Case 'FountainCoreTests.testTodoDecodingFailsForMissingID' started at 2025-08-04 19:27:36.364
+Test Case 'FountainCoreTests.testTodoDecodingFailsForMissingID' passed (0.0 seconds)
+Test Case 'FountainCoreTests.testTodoDecodingFailsForMissingName' started at 2025-08-04 19:27:36.364
+Test Case 'FountainCoreTests.testTodoDecodingFailsForMissingName' passed (0.0 seconds)
+Test Case 'FountainCoreTests.testTodoEncodingProducesExpectedJSON' started at 2025-08-04 19:27:36.364
+Test Case 'FountainCoreTests.testTodoEncodingProducesExpectedJSON' passed (0.0 seconds)
+Test Case 'FountainCoreTests.testTodoEncodingRoundTrip' started at 2025-08-04 19:27:36.364
+Test Case 'FountainCoreTests.testTodoEncodingRoundTrip' passed (0.0 seconds)
+Test Case 'FountainCoreTests.testTodoEquality' started at 2025-08-04 19:27:36.365
+Test Case 'FountainCoreTests.testTodoEquality' passed (0.0 seconds)
+Test Case 'FountainCoreTests.testTodosNotEqualWithDifferentID' started at 2025-08-04 19:27:36.365
+Test Case 'FountainCoreTests.testTodosNotEqualWithDifferentID' passed (0.0 seconds)
+Test Case 'FountainCoreTests.testTodosNotEqualWithDifferentName' started at 2025-08-04 19:27:36.365
+Test Case 'FountainCoreTests.testTodosNotEqualWithDifferentName' passed (0.0 seconds)
+Test Suite 'FountainCoreTests' passed at 2025-08-04 19:27:36.365
+	 Executed 8 tests, with 0 failures (0 unexpected) in 0.002 (0.002) seconds
+Test Suite 'APIClientTests' started at 2025-08-04 19:27:36.365
+Test Case 'APIClientTests.testBearerInitializerSetsHeader' started at 2025-08-04 19:27:36.365
+Test Case 'APIClientTests.testBearerInitializerSetsHeader' passed (0.0 seconds)
+Test Case 'APIClientTests.testNoBodyResponseReturnsInstance' started at 2025-08-04 19:27:36.366
+Test Case 'APIClientTests.testNoBodyResponseReturnsInstance' passed (0.0 seconds)
+Test Case 'APIClientTests.testRawDataResponse' started at 2025-08-04 19:27:36.366
+Test Case 'APIClientTests.testRawDataResponse' passed (0.001 seconds)
+Test Case 'APIClientTests.testRequestWithoutBodyOmitsContentType' started at 2025-08-04 19:27:36.367
+Test Case 'APIClientTests.testRequestWithoutBodyOmitsContentType' passed (0.0 seconds)
+Test Case 'APIClientTests.testSendDecodesResponse' started at 2025-08-04 19:27:36.368
+Test Case 'APIClientTests.testSendDecodesResponse' passed (0.001 seconds)
+Test Suite 'APIClientTests' passed at 2025-08-04 19:27:36.368
+	 Executed 5 tests, with 0 failures (0 unexpected) in 0.003 (0.003) seconds
+Test Suite 'CreatePrimaryServerRequestTests' started at 2025-08-04 19:27:36.368
+Test Case 'CreatePrimaryServerRequestTests.testMethodIsPOST' started at 2025-08-04 19:27:36.368
+Test Case 'CreatePrimaryServerRequestTests.testMethodIsPOST' passed (0.0 seconds)
+Test Case 'CreatePrimaryServerRequestTests.testPathIsCorrect' started at 2025-08-04 19:27:36.368
+Test Case 'CreatePrimaryServerRequestTests.testPathIsCorrect' passed (0.0 seconds)
+Test Suite 'CreatePrimaryServerRequestTests' passed at 2025-08-04 19:27:36.369
+	 Executed 2 tests, with 0 failures (0 unexpected) in 0.0 (0.0) seconds
+Test Suite 'DNSClientTests' started at 2025-08-04 19:27:36.369
+Test Case 'DNSClientTests.testRoute53CreateRecordErrorDetails' started at 2025-08-04 19:27:36.369
+Test Case 'DNSClientTests.testRoute53CreateRecordErrorDetails' passed (0.0 seconds)
+Test Case 'DNSClientTests.testRoute53CreateRecordStub' started at 2025-08-04 19:27:36.369
+Test Case 'DNSClientTests.testRoute53CreateRecordStub' passed (0.0 seconds)
+Test Case 'DNSClientTests.testRoute53DeleteRecordErrorDetails' started at 2025-08-04 19:27:36.369
+Test Case 'DNSClientTests.testRoute53DeleteRecordErrorDetails' passed (0.0 seconds)
+Test Case 'DNSClientTests.testRoute53DeleteRecordStub' started at 2025-08-04 19:27:36.370
+Test Case 'DNSClientTests.testRoute53DeleteRecordStub' passed (0.0 seconds)
+Test Case 'DNSClientTests.testRoute53ListZonesErrorDetails' started at 2025-08-04 19:27:36.370
+Test Case 'DNSClientTests.testRoute53ListZonesErrorDetails' passed (0.0 seconds)
+Test Case 'DNSClientTests.testRoute53Stub' started at 2025-08-04 19:27:36.370
+Test Case 'DNSClientTests.testRoute53Stub' passed (0.0 seconds)
+Test Case 'DNSClientTests.testRoute53UpdateRecordErrorDetails' started at 2025-08-04 19:27:36.370
+Test Case 'DNSClientTests.testRoute53UpdateRecordErrorDetails' passed (0.0 seconds)
+Test Case 'DNSClientTests.testRoute53UpdateRecordStub' started at 2025-08-04 19:27:36.371
+Test Case 'DNSClientTests.testRoute53UpdateRecordStub' passed (0.0 seconds)
+Test Suite 'DNSClientTests' passed at 2025-08-04 19:27:36.371
+	 Executed 8 tests, with 0 failures (0 unexpected) in 0.002 (0.002) seconds
+Test Suite 'DeletePrimaryServerRequestTests' started at 2025-08-04 19:27:36.371
+Test Case 'DeletePrimaryServerRequestTests.testMethodIsDELETE' started at 2025-08-04 19:27:36.371
+Test Case 'DeletePrimaryServerRequestTests.testMethodIsDELETE' passed (0.0 seconds)
+Test Case 'DeletePrimaryServerRequestTests.testPathIsCorrect' started at 2025-08-04 19:27:36.371
+Test Case 'DeletePrimaryServerRequestTests.testPathIsCorrect' passed (0.0 seconds)
+Test Suite 'DeletePrimaryServerRequestTests' passed at 2025-08-04 19:27:36.371
+	 Executed 2 tests, with 0 failures (0 unexpected) in 0.0 (0.0) seconds
+Test Suite 'DeleteRecordRequestTests' started at 2025-08-04 19:27:36.371
+Test Case 'DeleteRecordRequestTests.testDeleteRecordBuildsPathAndMethod' started at 2025-08-04 19:27:36.371
+Test Case 'DeleteRecordRequestTests.testDeleteRecordBuildsPathAndMethod' passed (0.0 seconds)
+Test Suite 'DeleteRecordRequestTests' passed at 2025-08-04 19:27:36.372
+	 Executed 1 test, with 0 failures (0 unexpected) in 0.0 (0.0) seconds
+Test Suite 'DeleteZoneRequestTests' started at 2025-08-04 19:27:36.372
+Test Case 'DeleteZoneRequestTests.testPathBuilderEncodesZoneId' started at 2025-08-04 19:27:36.372
+Test Case 'DeleteZoneRequestTests.testPathBuilderEncodesZoneId' passed (0.0 seconds)
+Test Suite 'DeleteZoneRequestTests' passed at 2025-08-04 19:27:36.372
+	 Executed 1 test, with 0 failures (0 unexpected) in 0.0 (0.0) seconds
+Test Suite 'GetPrimaryServerRequestTests' started at 2025-08-04 19:27:36.372
+Test Case 'GetPrimaryServerRequestTests.testMethodIsGET' started at 2025-08-04 19:27:36.372
+Test Case 'GetPrimaryServerRequestTests.testMethodIsGET' passed (0.001 seconds)
+Test Case 'GetPrimaryServerRequestTests.testPathBuilderReplacesId' started at 2025-08-04 19:27:36.373
+Test Case 'GetPrimaryServerRequestTests.testPathBuilderReplacesId' passed (0.0 seconds)
+Test Suite 'GetPrimaryServerRequestTests' passed at 2025-08-04 19:27:36.373
+	 Executed 2 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
+Test Suite 'GetRecordRequestTests' started at 2025-08-04 19:27:36.373
+Test Case 'GetRecordRequestTests.testPathBuilderReplacesRecordId' started at 2025-08-04 19:27:36.373
+Test Case 'GetRecordRequestTests.testPathBuilderReplacesRecordId' passed (0.0 seconds)
+Test Suite 'GetRecordRequestTests' passed at 2025-08-04 19:27:36.373
+	 Executed 1 test, with 0 failures (0 unexpected) in 0.0 (0.0) seconds
+Test Suite 'GetZoneRequestTests' started at 2025-08-04 19:27:36.373
+Test Case 'GetZoneRequestTests.testPathBuilderReplacesZoneId' started at 2025-08-04 19:27:36.373
+Test Case 'GetZoneRequestTests.testPathBuilderReplacesZoneId' passed (0.0 seconds)
+Test Suite 'GetZoneRequestTests' passed at 2025-08-04 19:27:36.374
+	 Executed 1 test, with 0 failures (0 unexpected) in 0.0 (0.0) seconds
+Test Suite 'HetznerDNSClientTests' started at 2025-08-04 19:27:36.374
+Test Case 'HetznerDNSClientTests.testCreateRecordEncodesBody' started at 2025-08-04 19:27:36.374
+Test Case 'HetznerDNSClientTests.testCreateRecordEncodesBody' passed (0.001 seconds)
+Test Case 'HetznerDNSClientTests.testCreateRecordRequest' started at 2025-08-04 19:27:36.375
+Test Case 'HetznerDNSClientTests.testCreateRecordRequest' passed (0.0 seconds)
+Test Case 'HetznerDNSClientTests.testCreateRecordSetsContentTypeHeader' started at 2025-08-04 19:27:36.375
+Test Case 'HetznerDNSClientTests.testCreateRecordSetsContentTypeHeader' passed (0.0 seconds)
+Test Case 'HetznerDNSClientTests.testDeleteRecordRequest' started at 2025-08-04 19:27:36.375
+Test Case 'HetznerDNSClientTests.testDeleteRecordRequest' passed (0.0 seconds)
+Test Case 'HetznerDNSClientTests.testDeleteRecordSetsAuthHeader' started at 2025-08-04 19:27:36.376
+Test Case 'HetznerDNSClientTests.testDeleteRecordSetsAuthHeader' passed (0.0 seconds)
+Test Case 'HetznerDNSClientTests.testListZonesPathBuilder' started at 2025-08-04 19:27:36.376
+Test Case 'HetznerDNSClientTests.testListZonesPathBuilder' passed (0.0 seconds)
+Test Case 'HetznerDNSClientTests.testListZonesReturnsIDs' started at 2025-08-04 19:27:36.376
+Test Case 'HetznerDNSClientTests.testListZonesReturnsIDs' passed (0.001 seconds)
+Test Case 'HetznerDNSClientTests.testListZonesSetsAuthHeader' started at 2025-08-04 19:27:36.377
+Test Case 'HetznerDNSClientTests.testListZonesSetsAuthHeader' passed (0.0 seconds)
+Test Case 'HetznerDNSClientTests.testUpdateRecordRequest' started at 2025-08-04 19:27:36.378
+Test Case 'HetznerDNSClientTests.testUpdateRecordRequest' passed (0.001 seconds)
+Test Case 'HetznerDNSClientTests.testUpdateRecordSetsAuthHeader' started at 2025-08-04 19:27:36.378
+Test Case 'HetznerDNSClientTests.testUpdateRecordSetsAuthHeader' passed (0.0 seconds)
+Test Suite 'HetznerDNSClientTests' passed at 2025-08-04 19:27:36.379
+	 Executed 10 tests, with 0 failures (0 unexpected) in 0.004 (0.004) seconds
+Test Suite 'ListPrimaryServersRequestTests' started at 2025-08-04 19:27:36.379
+Test Case 'ListPrimaryServersRequestTests.testPathBuilderAddsZoneIdQueryWhenProvided' started at 2025-08-04 19:27:36.379
+Test Case 'ListPrimaryServersRequestTests.testPathBuilderAddsZoneIdQueryWhenProvided' passed (0.0 seconds)
+Test Case 'ListPrimaryServersRequestTests.testPathBuilderWithoutZoneIdHasNoQuery' started at 2025-08-04 19:27:36.379
+Test Case 'ListPrimaryServersRequestTests.testPathBuilderWithoutZoneIdHasNoQuery' passed (0.0 seconds)
+Test Suite 'ListPrimaryServersRequestTests' passed at 2025-08-04 19:27:36.379
+	 Executed 2 tests, with 0 failures (0 unexpected) in 0.0 (0.0) seconds
+Test Suite 'ListRecordsRequestTests' started at 2025-08-04 19:27:36.379
+Test Case 'ListRecordsRequestTests.testPathBuilderEncodesQuery' started at 2025-08-04 19:27:36.379
+Test Case 'ListRecordsRequestTests.testPathBuilderEncodesQuery' passed (0.001 seconds)
+Test Suite 'ListRecordsRequestTests' passed at 2025-08-04 19:27:36.380
+	 Executed 1 test, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
+Test Suite 'UpdateRecordRequestTests' started at 2025-08-04 19:27:36.380
+Test Case 'UpdateRecordRequestTests.testUpdateRecordBuildsPathAndMethod' started at 2025-08-04 19:27:36.380
+Test Case 'UpdateRecordRequestTests.testUpdateRecordBuildsPathAndMethod' passed (0.0 seconds)
+Test Case 'UpdateRecordRequestTests.testUpdateRecordStoresBody' started at 2025-08-04 19:27:36.381
+Test Case 'UpdateRecordRequestTests.testUpdateRecordStoresBody' passed (0.0 seconds)
+Test Suite 'UpdateRecordRequestTests' passed at 2025-08-04 19:27:36.381
+	 Executed 2 tests, with 0 failures (0 unexpected) in 0.0 (0.0) seconds
+Test Suite 'debug.xctest' passed at 2025-08-04 19:27:36.381
+	 Executed 162 tests, with 0 failures (0 unexpected) in 11.598 (11.598) seconds
+Test Suite 'All tests' passed at 2025-08-04 19:27:36.381
+	 Executed 162 tests, with 0 failures (0 unexpected) in 11.598 (11.598) seconds
+◇ Test run started.
+↳ Testing Library Version: 6.1 (43b6f88e2f2712e)
+↳ Target Platform: x86_64-unknown-linux-gnu
+✔ Test run with 0 tests passed after 0.001 seconds.
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- document Prometheus metrics endpoints across FountainOps services
- add missing history streaming endpoint to baseline awareness spec
- mark OpenAPI spec task as complete in agent manifest

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68910701cbb4832582278f125e021888