### PR TITLE
Fix PublishingFrontend event loop shutdown

### DIFF
--- a/Sources/PublishingFrontend/PublishingFrontend.swift
+++ b/Sources/PublishingFrontend/PublishingFrontend.swift
@@ -56,6 +56,7 @@ public final class PublishingFrontend {
     /// Stops the HTTP server and releases all resources.
     public func stop() async throws {
         try await server.stop()
+        try await group.shutdownGracefully()
     }
 }
 


### PR DESCRIPTION
## Summary
- ensure PublishingFrontend.stop() shuts down its NIO event loop group to avoid lingering threads

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_b_68919bc03db8833390f558694ebc024d