### PR TITLE
fix: correct Typesense spec typo

### DIFF
--- a/Sources/FountainOps/FountainAi/openAPI/typesense.yml
+++ b/Sources/FountainOps/FountainAi/openAPI/typesense.yml
@@ -20,7 +20,7 @@ servers:
         default: "8108"
         description: The port of your Typesense server
 externalDocs:
-  description: Find out more about Typsesense
+  description: Find out more about Typesense
   url: https://typesense.org
 security:
   - api_key_header: []


### PR DESCRIPTION
## Summary
- fix Typesense openAPI description typo

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_b_68919d4cb1fc83339ee60ebcfa65be79