### PR TITLE
Handle invalid URL in URLSessionHTTPClient

### DIFF
--- a/Sources/FountainCodex/IntegrationRuntime/URLSessionHTTPClient.swift
+++ b/Sources/FountainCodex/IntegrationRuntime/URLSessionHTTPClient.swift
@@ -24,7 +24,10 @@ public struct URLSessionHTTPClient: HTTPClientProtocol {
     ///   - body: Optional request payload.
     /// - Returns: A tuple of response body and headers.
     public func execute(method: HTTPMethod, url: String, headers: HTTPHeaders = HTTPHeaders(), body: ByteBuffer?) async throws -> (ByteBuffer, HTTPHeaders) {
-        var request = URLRequest(url: URL(string: url)!)
+        guard let requestURL = URL(string: url), requestURL.scheme != nil else {
+            throw URLError(.badURL)
+        }
+        var request = URLRequest(url: requestURL)
         request.httpMethod = method.rawValue
         for header in headers {
             request.addValue(header.value, forHTTPHeaderField: header.name)

--- a/Tests/IntegrationRuntimeTests/URLSessionHTTPClientTests.swift
+++ b/Tests/IntegrationRuntimeTests/URLSessionHTTPClientTests.swift
@@ -71,6 +71,18 @@ final class URLSessionHTTPClientTests: XCTestCase {
         XCTAssertEqual(headers.first(name: "X-A"), "a")
         XCTAssertEqual(headers.first(name: "X-B"), "b")
     }
+
+    func testExecuteThrowsOnInvalidURL() async {
+        let client = URLSessionHTTPClient()
+        do {
+            _ = try await client.execute(method: .GET, url: "not a url", body: nil)
+            XCTFail("Expected to throw")
+        } catch let error as URLError {
+            XCTAssertEqual(error.code, .badURL)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
 }
 
 // © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/agent.md
+++ b/agent.md
@@ -21,7 +21,7 @@ This agent maintains an up-to-date view of outstanding development tasks across 
 | Supervisor binary paths | `FountainAiLauncher`                   | Document required external binaries for supervisor     | ✅     | None                                   | deployment, docs  |
 | Linter configuration   | root                                     | Introduce SwiftLint setup                 | ✅     | None                                     | ci, linter        |
 | CI pipeline            | root                                     | Add CI workflow to run tests and coverage       | ✅     | None                                      | ci, test          |
-| Test coverage          | various                                  | Added Service defaults test; continue expanding coverage | ⚠️     | More modules remain untested                     | test              |
+| Test coverage          | various                                  | Added invalid URL test for `URLSessionHTTPClient`; continue expanding coverage | ⚠️     | More modules remain untested                     | test              |
 | Documentation sync     | `docs` vs `code`                         | Update developer docs with actual CLI entrypoints and generators | ✅     | None                                   | docs, cli         |
 | OpenAPI specs          | `Sources/FountainOps/FountainAi/openAPI`| Ensure specs reflect implemented endpoints                       | ✅     | None           | parser, docs      |
 

--- a/logs/test-20250805062332.log
+++ b/logs/test-20250805062332.log
@@ -1,0 +1,468 @@
+[0/1] Planning build
+Building for debugging...
+[0/6] Write sources
+[1/6] Write swift-version--4EAD98957C2213E4.txt
+[3/8] Emitting module FountainCodex
+[4/8] Compiling FountainCodex URLSessionHTTPClient.swift
+[5/13] Write Objects.LinkFileList
+[8/13] Linking clientgen-service
+[9/13] Linking publishing-frontend
+[10/13] Linking gateway-server
+[12/14] Emitting module IntegrationRuntimeTests
+[13/15] Write Objects.LinkFileList
+[14/15] Linking FountainCoachPackageTests.xctest
+Build complete! (21.60s)
+Test Suite 'All tests' started at 2025-08-05 06:23:03.322
+Test Suite 'debug.xctest' started at 2025-08-05 06:23:03.330
+Test Suite 'HetznerDNSModelsTests' started at 2025-08-05 06:23:03.330
+Test Case 'HetznerDNSModelsTests.testBulkRecordsCreateRequestCodable' started at 2025-08-05 06:23:03.330
+Test Case 'HetznerDNSModelsTests.testBulkRecordsCreateRequestCodable' passed (0.009 seconds)
+Test Case 'HetznerDNSModelsTests.testBulkRecordsUpdateRequestCodable' started at 2025-08-05 06:23:03.339
+Test Case 'HetznerDNSModelsTests.testBulkRecordsUpdateRequestCodable' passed (0.002 seconds)
+Test Case 'HetznerDNSModelsTests.testPrimaryServerCreateCodable' started at 2025-08-05 06:23:03.342
+Test Case 'HetznerDNSModelsTests.testPrimaryServerCreateCodable' passed (0.001 seconds)
+Test Case 'HetznerDNSModelsTests.testPrimaryServersResponseDecodes' started at 2025-08-05 06:23:03.343
+Test Case 'HetznerDNSModelsTests.testPrimaryServersResponseDecodes' passed (0.002 seconds)
+Test Case 'HetznerDNSModelsTests.testRecordResponseDecodes' started at 2025-08-05 06:23:03.345
+Test Case 'HetznerDNSModelsTests.testRecordResponseDecodes' passed (0.002 seconds)
+Test Case 'HetznerDNSModelsTests.testValidateZoneFileResponseDecodes' started at 2025-08-05 06:23:03.346
+Test Case 'HetznerDNSModelsTests.testValidateZoneFileResponseDecodes' passed (0.001 seconds)
+Test Case 'HetznerDNSModelsTests.testZoneCreateRequestCodable' started at 2025-08-05 06:23:03.348
+Test Case 'HetznerDNSModelsTests.testZoneCreateRequestCodable' passed (0.001 seconds)
+Test Case 'HetznerDNSModelsTests.testZoneResponseDecoding' started at 2025-08-05 06:23:03.349
+Test Case 'HetznerDNSModelsTests.testZoneResponseDecoding' passed (0.003 seconds)
+Test Case 'HetznerDNSModelsTests.testZoneUpdateRequestCodable' started at 2025-08-05 06:23:03.352
+Test Case 'HetznerDNSModelsTests.testZoneUpdateRequestCodable' passed (0.001 seconds)
+Test Case 'HetznerDNSModelsTests.testZonesResponseDecodes' started at 2025-08-05 06:23:03.353
+Test Case 'HetznerDNSModelsTests.testZonesResponseDecodes' passed (0.001 seconds)
+Test Suite 'HetznerDNSModelsTests' passed at 2025-08-05 06:23:03.354
+	 Executed 10 tests, with 0 failures (0 unexpected) in 0.023 (0.023) seconds
+Test Suite 'HetznerDNSRequestTests' started at 2025-08-05 06:23:03.354
+Test Case 'HetznerDNSRequestTests.testBulkCreateRecordsMethodIsPost' started at 2025-08-05 06:23:03.354
+Test Case 'HetznerDNSRequestTests.testBulkCreateRecordsMethodIsPost' passed (0.0 seconds)
+Test Case 'HetznerDNSRequestTests.testBulkCreateRecordsPath' started at 2025-08-05 06:23:03.354
+Test Case 'HetznerDNSRequestTests.testBulkCreateRecordsPath' passed (0.0 seconds)
+Test Case 'HetznerDNSRequestTests.testBulkUpdateRecordsMethodIsPut' started at 2025-08-05 06:23:03.355
+Test Case 'HetznerDNSRequestTests.testBulkUpdateRecordsMethodIsPut' passed (0.0 seconds)
+Test Case 'HetznerDNSRequestTests.testBulkUpdateRecordsPath' started at 2025-08-05 06:23:03.355
+Test Case 'HetznerDNSRequestTests.testBulkUpdateRecordsPath' passed (0.001 seconds)
+Test Case 'HetznerDNSRequestTests.testCreateZoneMethodIsPost' started at 2025-08-05 06:23:03.355
+Test Case 'HetznerDNSRequestTests.testCreateZoneMethodIsPost' passed (0.0 seconds)
+Test Case 'HetznerDNSRequestTests.testCreateZonePath' started at 2025-08-05 06:23:03.356
+Test Case 'HetznerDNSRequestTests.testCreateZonePath' passed (0.0 seconds)
+Test Case 'HetznerDNSRequestTests.testExportZoneFileMethodIsGet' started at 2025-08-05 06:23:03.356
+Test Case 'HetznerDNSRequestTests.testExportZoneFileMethodIsGet' passed (0.0 seconds)
+Test Case 'HetznerDNSRequestTests.testExportZoneFilePathIncludesZoneID' started at 2025-08-05 06:23:03.357
+Test Case 'HetznerDNSRequestTests.testExportZoneFilePathIncludesZoneID' passed (0.003 seconds)
+Test Case 'HetznerDNSRequestTests.testImportZoneFileMethodIsPost' started at 2025-08-05 06:23:03.359
+Test Case 'HetznerDNSRequestTests.testImportZoneFileMethodIsPost' passed (0.0 seconds)
+Test Case 'HetznerDNSRequestTests.testImportZoneFilePathIncludesZoneID' started at 2025-08-05 06:23:03.360
+Test Case 'HetznerDNSRequestTests.testImportZoneFilePathIncludesZoneID' passed (0.001 seconds)
+Test Case 'HetznerDNSRequestTests.testUpdatePrimaryServerMethodIsPut' started at 2025-08-05 06:23:03.360
+Test Case 'HetznerDNSRequestTests.testUpdatePrimaryServerMethodIsPut' passed (0.001 seconds)
+Test Case 'HetznerDNSRequestTests.testUpdatePrimaryServerPathIncludesID' started at 2025-08-05 06:23:03.362
+Test Case 'HetznerDNSRequestTests.testUpdatePrimaryServerPathIncludesID' passed (0.001 seconds)
+Test Case 'HetznerDNSRequestTests.testUpdateZoneMethodIsPut' started at 2025-08-05 06:23:03.362
+Test Case 'HetznerDNSRequestTests.testUpdateZoneMethodIsPut' passed (0.0 seconds)
+Test Case 'HetznerDNSRequestTests.testUpdateZonePathIncludesID' started at 2025-08-05 06:23:03.363
+Test Case 'HetznerDNSRequestTests.testUpdateZonePathIncludesID' passed (0.002 seconds)
+Test Case 'HetznerDNSRequestTests.testValidateZoneFileMethodIsPost' started at 2025-08-05 06:23:03.364
+Test Case 'HetznerDNSRequestTests.testValidateZoneFileMethodIsPost' passed (0.0 seconds)
+Test Case 'HetznerDNSRequestTests.testValidateZoneFilePath' started at 2025-08-05 06:23:03.365
+Test Case 'HetznerDNSRequestTests.testValidateZoneFilePath' passed (0.0 seconds)
+Test Suite 'HetznerDNSRequestTests' passed at 2025-08-05 06:23:03.365
+	 Executed 16 tests, with 0 failures (0 unexpected) in 0.011 (0.011) seconds
+Test Suite 'PublishingFrontendTests' started at 2025-08-05 06:23:03.365
+Test Case 'PublishingFrontendTests.testLoadPublishingConfigFailsForInvalidYAML' started at 2025-08-05 06:23:03.365
+Test Case 'PublishingFrontendTests.testLoadPublishingConfigFailsForInvalidYAML' passed (0.013 seconds)
+Test Case 'PublishingFrontendTests.testLoadPublishingConfigFailsForMissingFile' started at 2025-08-05 06:23:03.379
+Test Case 'PublishingFrontendTests.testLoadPublishingConfigFailsForMissingFile' passed (0.001 seconds)
+Test Case 'PublishingFrontendTests.testLoadPublishingConfigFailsForNonNumericPort' started at 2025-08-05 06:23:03.379
+Test Case 'PublishingFrontendTests.testLoadPublishingConfigFailsForNonNumericPort' passed (0.007 seconds)
+Test Case 'PublishingFrontendTests.testLoadPublishingConfigParsesYaml' started at 2025-08-05 06:23:03.387
+Test Case 'PublishingFrontendTests.testLoadPublishingConfigParsesYaml' passed (0.006 seconds)
+Test Case 'PublishingFrontendTests.testLoadPublishingConfigUsesDefaultPortWhenMissing' started at 2025-08-05 06:23:03.393
+Test Case 'PublishingFrontendTests.testLoadPublishingConfigUsesDefaultPortWhenMissing' passed (0.004 seconds)
+Test Case 'PublishingFrontendTests.testLoadPublishingConfigUsesDefaultRootPathWhenMissing' started at 2025-08-05 06:23:03.397
+Test Case 'PublishingFrontendTests.testLoadPublishingConfigUsesDefaultRootPathWhenMissing' passed (0.007 seconds)
+Test Case 'PublishingFrontendTests.testLoadPublishingConfigUsesDefaultsWhenFileEmpty' started at 2025-08-05 06:23:03.404
+Test Case 'PublishingFrontendTests.testLoadPublishingConfigUsesDefaultsWhenFileEmpty' passed (0.001 seconds)
+Test Case 'PublishingFrontendTests.testPublishingConfigCustomValues' started at 2025-08-05 06:23:03.405
+Test Case 'PublishingFrontendTests.testPublishingConfigCustomValues' passed (0.0 seconds)
+Test Case 'PublishingFrontendTests.testPublishingConfigDefaultValues' started at 2025-08-05 06:23:03.405
+Test Case 'PublishingFrontendTests.testPublishingConfigDefaultValues' passed (0.0 seconds)
+Test Case 'PublishingFrontendTests.testServerRejectsNonGetRequests' started at 2025-08-05 06:23:03.405
+Test Case 'PublishingFrontendTests.testServerRejectsNonGetRequests' passed (0.043 seconds)
+Test Case 'PublishingFrontendTests.testServerReturns404ForMissingFile' started at 2025-08-05 06:23:03.448
+Test Case 'PublishingFrontendTests.testServerReturns404ForMissingFile' passed (0.007 seconds)
+Test Case 'PublishingFrontendTests.testServerServesIndex' started at 2025-08-05 06:23:03.456
+Test Case 'PublishingFrontendTests.testServerServesIndex' passed (0.011 seconds)
+Test Case 'PublishingFrontendTests.testServerServesNestedFile' started at 2025-08-05 06:23:03.467
+Test Case 'PublishingFrontendTests.testServerServesNestedFile' passed (0.01 seconds)
+Test Case 'PublishingFrontendTests.testServerSetsContentTypeHeader' started at 2025-08-05 06:23:03.477
+Test Case 'PublishingFrontendTests.testServerSetsContentTypeHeader' passed (0.011 seconds)
+Test Suite 'PublishingFrontendTests' passed at 2025-08-05 06:23:03.488
+	 Executed 14 tests, with 0 failures (0 unexpected) in 0.122 (0.122) seconds
+Test Suite 'Route53ClientTests' started at 2025-08-05 06:23:03.488
+Test Case 'Route53ClientTests.testCreateRecordThrows' started at 2025-08-05 06:23:03.488
+Test Case 'Route53ClientTests.testCreateRecordThrows' passed (0.001 seconds)
+Test Case 'Route53ClientTests.testDeleteRecordThrows' started at 2025-08-05 06:23:03.489
+Test Case 'Route53ClientTests.testDeleteRecordThrows' passed (0.0 seconds)
+Test Case 'Route53ClientTests.testErrorProvidesDetails' started at 2025-08-05 06:23:03.490
+Test Case 'Route53ClientTests.testErrorProvidesDetails' passed (0.0 seconds)
+Test Case 'Route53ClientTests.testListZonesThrows' started at 2025-08-05 06:23:03.490
+Test Case 'Route53ClientTests.testListZonesThrows' passed (0.0 seconds)
+Test Case 'Route53ClientTests.testUpdateRecordThrows' started at 2025-08-05 06:23:03.490
+Test Case 'Route53ClientTests.testUpdateRecordThrows' passed (0.101 seconds)
+Test Suite 'Route53ClientTests' passed at 2025-08-05 06:23:03.592
+	 Executed 5 tests, with 0 failures (0 unexpected) in 0.103 (0.103) seconds
+Test Suite 'FountainCoreTests' started at 2025-08-05 06:23:03.592
+Test Case 'FountainCoreTests.testTodoDecoding' started at 2025-08-05 06:23:03.592
+Test Case 'FountainCoreTests.testTodoDecoding' passed (0.001 seconds)
+Test Case 'FountainCoreTests.testTodoDecodingFailsForMissingID' started at 2025-08-05 06:23:03.593
+Test Case 'FountainCoreTests.testTodoDecodingFailsForMissingID' passed (0.001 seconds)
+Test Case 'FountainCoreTests.testTodoDecodingFailsForMissingName' started at 2025-08-05 06:23:03.593
+Test Case 'FountainCoreTests.testTodoDecodingFailsForMissingName' passed (0.0 seconds)
+Test Case 'FountainCoreTests.testTodoEncodingProducesExpectedJSON' started at 2025-08-05 06:23:03.594
+Test Case 'FountainCoreTests.testTodoEncodingProducesExpectedJSON' passed (0.001 seconds)
+Test Case 'FountainCoreTests.testTodoEncodingRoundTrip' started at 2025-08-05 06:23:03.594
+Test Case 'FountainCoreTests.testTodoEncodingRoundTrip' passed (0.001 seconds)
+Test Case 'FountainCoreTests.testTodoEquality' started at 2025-08-05 06:23:03.595
+Test Case 'FountainCoreTests.testTodoEquality' passed (0.001 seconds)
+Test Case 'FountainCoreTests.testTodosNotEqualWithDifferentID' started at 2025-08-05 06:23:03.596
+Test Case 'FountainCoreTests.testTodosNotEqualWithDifferentID' passed (0.0 seconds)
+Test Case 'FountainCoreTests.testTodosNotEqualWithDifferentName' started at 2025-08-05 06:23:03.596
+Test Case 'FountainCoreTests.testTodosNotEqualWithDifferentName' passed (0.0 seconds)
+Test Suite 'FountainCoreTests' passed at 2025-08-05 06:23:03.596
+	 Executed 8 tests, with 0 failures (0 unexpected) in 0.004 (0.004) seconds
+Test Suite 'ClientGeneratorTests' started at 2025-08-05 06:23:03.596
+Test Case 'ClientGeneratorTests.testClientFilesGenerated' started at 2025-08-05 06:23:03.596
+Test Case 'ClientGeneratorTests.testClientFilesGenerated' passed (0.016 seconds)
+Test Case 'ClientGeneratorTests.testEmitRequestGeneratesQueryParameter' started at 2025-08-05 06:23:03.612
+Test Case 'ClientGeneratorTests.testEmitRequestGeneratesQueryParameter' passed (0.017 seconds)
+Test Suite 'ClientGeneratorTests' passed at 2025-08-05 06:23:03.629
+	 Executed 2 tests, with 0 failures (0 unexpected) in 0.033 (0.033) seconds
+Test Suite 'OpenAPIParameterTests' started at 2025-08-05 06:23:03.629
+Test Case 'OpenAPIParameterTests.testSwiftNameReplacesHyphenWithUnderscore' started at 2025-08-05 06:23:03.629
+Test Case 'OpenAPIParameterTests.testSwiftNameReplacesHyphenWithUnderscore' passed (0.0 seconds)
+Test Case 'OpenAPIParameterTests.testSwiftTypeUsesSchemaOrDefaultsToString' started at 2025-08-05 06:23:03.630
+Test Case 'OpenAPIParameterTests.testSwiftTypeUsesSchemaOrDefaultsToString' passed (0.0 seconds)
+Test Suite 'OpenAPIParameterTests' passed at 2025-08-05 06:23:03.630
+	 Executed 2 tests, with 0 failures (0 unexpected) in 0.0 (0.0) seconds
+Test Suite 'OpenAPISwiftTypeTests' started at 2025-08-05 06:23:03.630
+Test Case 'OpenAPISwiftTypeTests.testSchemaPropertyObjectSwiftType' started at 2025-08-05 06:23:03.630
+Test Case 'OpenAPISwiftTypeTests.testSchemaPropertyObjectSwiftType' passed (0.0 seconds)
+Test Case 'OpenAPISwiftTypeTests.testSchemaPropertySwiftType' started at 2025-08-05 06:23:03.630
+Test Case 'OpenAPISwiftTypeTests.testSchemaPropertySwiftType' passed (0.0 seconds)
+Test Case 'OpenAPISwiftTypeTests.testSchemaPropertyUnknownTypeDefaultsToString' started at 2025-08-05 06:23:03.631
+Test Case 'OpenAPISwiftTypeTests.testSchemaPropertyUnknownTypeDefaultsToString' passed (0.0 seconds)
+Test Case 'OpenAPISwiftTypeTests.testSchemaRefSwiftType' started at 2025-08-05 06:23:03.631
+Test Case 'OpenAPISwiftTypeTests.testSchemaRefSwiftType' passed (0.0 seconds)
+Test Suite 'OpenAPISwiftTypeTests' passed at 2025-08-05 06:23:03.631
+	 Executed 4 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
+Test Suite 'SecurityRequirementTests' started at 2025-08-05 06:23:03.631
+Test Case 'SecurityRequirementTests.testDecodesSchemesFromJSON' started at 2025-08-05 06:23:03.631
+Test Case 'SecurityRequirementTests.testDecodesSchemesFromJSON' passed (0.001 seconds)
+Test Case 'SecurityRequirementTests.testEncodesSchemesToJSON' started at 2025-08-05 06:23:03.633
+Test Case 'SecurityRequirementTests.testEncodesSchemesToJSON' passed (0.001 seconds)
+Test Suite 'SecurityRequirementTests' passed at 2025-08-05 06:23:03.634
+	 Executed 2 tests, with 0 failures (0 unexpected) in 0.002 (0.002) seconds
+Test Suite 'SpecLoaderTests' started at 2025-08-05 06:23:03.634
+Test Case 'SpecLoaderTests.testLoadThrowsForEmptyFile' started at 2025-08-05 06:23:03.634
+Test Case 'SpecLoaderTests.testLoadThrowsForEmptyFile' passed (0.001 seconds)
+Test Case 'SpecLoaderTests.testLoadThrowsForInvalidUTF8' started at 2025-08-05 06:23:03.634
+Test Case 'SpecLoaderTests.testLoadThrowsForInvalidUTF8' passed (0.003 seconds)
+Test Case 'SpecLoaderTests.testLoadsJSONRemovingCopyright' started at 2025-08-05 06:23:03.638
+Test Case 'SpecLoaderTests.testLoadsJSONRemovingCopyright' passed (0.003 seconds)
+Test Case 'SpecLoaderTests.testLoadsYAMLAndNormalizesInfoTitle' started at 2025-08-05 06:23:03.641
+Test Case 'SpecLoaderTests.testLoadsYAMLAndNormalizesInfoTitle' passed (0.004 seconds)
+Test Suite 'SpecLoaderTests' passed at 2025-08-05 06:23:03.645
+	 Executed 4 tests, with 0 failures (0 unexpected) in 0.011 (0.011) seconds
+Test Suite 'SpecValidatorTests' started at 2025-08-05 06:23:03.645
+Test Case 'SpecValidatorTests.testDuplicateOperationIdThrows' started at 2025-08-05 06:23:03.645
+Test Case 'SpecValidatorTests.testDuplicateOperationIdThrows' passed (0.001 seconds)
+Test Case 'SpecValidatorTests.testEmptyParameterLocationThrows' started at 2025-08-05 06:23:03.645
+Test Case 'SpecValidatorTests.testEmptyParameterLocationThrows' passed (0.001 seconds)
+Test Case 'SpecValidatorTests.testEmptyParameterNameThrows' started at 2025-08-05 06:23:03.646
+Test Case 'SpecValidatorTests.testEmptyParameterNameThrows' passed (0.0 seconds)
+Test Case 'SpecValidatorTests.testEmptyTitleThrows' started at 2025-08-05 06:23:03.646
+Test Case 'SpecValidatorTests.testEmptyTitleThrows' passed (0.0 seconds)
+Test Case 'SpecValidatorTests.testMissingPathParameterThrows' started at 2025-08-05 06:23:03.647
+Test Case 'SpecValidatorTests.testMissingPathParameterThrows' passed (0.0 seconds)
+Test Case 'SpecValidatorTests.testPathParameterMustBeRequired' started at 2025-08-05 06:23:03.647
+Test Case 'SpecValidatorTests.testPathParameterMustBeRequired' passed (0.0 seconds)
+Test Case 'SpecValidatorTests.testUnknownSecuritySchemeThrows' started at 2025-08-05 06:23:03.647
+Test Case 'SpecValidatorTests.testUnknownSecuritySchemeThrows' passed (0.001 seconds)
+Test Case 'SpecValidatorTests.testUnresolvedSchemaReferenceThrows' started at 2025-08-05 06:23:03.648
+Test Case 'SpecValidatorTests.testUnresolvedSchemaReferenceThrows' passed (0.001 seconds)
+Test Suite 'SpecValidatorTests' passed at 2025-08-05 06:23:03.649
+	 Executed 8 tests, with 0 failures (0 unexpected) in 0.004 (0.004) seconds
+Test Suite 'StringExtensionTests' started at 2025-08-05 06:23:03.649
+Test Case 'StringExtensionTests.testCamelCased' started at 2025-08-05 06:23:03.649
+Test Case 'StringExtensionTests.testCamelCased' passed (0.001 seconds)
+Test Case 'StringExtensionTests.testCamelCasedEmptyString' started at 2025-08-05 06:23:03.649
+Test Case 'StringExtensionTests.testCamelCasedEmptyString' passed (0.001 seconds)
+Test Case 'StringExtensionTests.testCamelCasedLeadingUnderscore' started at 2025-08-05 06:23:03.650
+Test Case 'StringExtensionTests.testCamelCasedLeadingUnderscore' passed (0.001 seconds)
+Test Case 'StringExtensionTests.testCamelCasedMultipleUnderscores' started at 2025-08-05 06:23:03.651
+Test Case 'StringExtensionTests.testCamelCasedMultipleUnderscores' passed (0.001 seconds)
+Test Case 'StringExtensionTests.testCamelCasedNumbers' started at 2025-08-05 06:23:03.652
+Test Case 'StringExtensionTests.testCamelCasedNumbers' passed (0.001 seconds)
+Test Case 'StringExtensionTests.testCamelCasedTrailingUnderscore' started at 2025-08-05 06:23:03.653
+Test Case 'StringExtensionTests.testCamelCasedTrailingUnderscore' passed (0.101 seconds)
+Test Case 'StringExtensionTests.testCamelCasedUppercaseInput' started at 2025-08-05 06:23:03.754
+Test Case 'StringExtensionTests.testCamelCasedUppercaseInput' passed (0.0 seconds)
+Test Suite 'StringExtensionTests' passed at 2025-08-05 06:23:03.754
+	 Executed 7 tests, with 0 failures (0 unexpected) in 0.105 (0.105) seconds
+Test Suite 'APIClientTests' started at 2025-08-05 06:23:03.754
+Test Case 'APIClientTests.testBearerInitializerSetsHeader' started at 2025-08-05 06:23:03.754
+Test Case 'APIClientTests.testBearerInitializerSetsHeader' passed (0.001 seconds)
+Test Case 'APIClientTests.testNoBodyResponseReturnsInstance' started at 2025-08-05 06:23:03.756
+Test Case 'APIClientTests.testNoBodyResponseReturnsInstance' passed (0.001 seconds)
+Test Case 'APIClientTests.testRawDataResponse' started at 2025-08-05 06:23:03.756
+Test Case 'APIClientTests.testRawDataResponse' passed (0.001 seconds)
+Test Case 'APIClientTests.testRequestWithoutBodyOmitsContentType' started at 2025-08-05 06:23:03.758
+Test Case 'APIClientTests.testRequestWithoutBodyOmitsContentType' passed (0.0 seconds)
+Test Case 'APIClientTests.testSendDecodesResponse' started at 2025-08-05 06:23:03.758
+Test Case 'APIClientTests.testSendDecodesResponse' passed (0.0 seconds)
+Test Suite 'APIClientTests' passed at 2025-08-05 06:23:03.759
+	 Executed 5 tests, with 0 failures (0 unexpected) in 0.004 (0.004) seconds
+Test Suite 'CreatePrimaryServerRequestTests' started at 2025-08-05 06:23:03.759
+Test Case 'CreatePrimaryServerRequestTests.testMethodIsPOST' started at 2025-08-05 06:23:03.759
+Test Case 'CreatePrimaryServerRequestTests.testMethodIsPOST' passed (0.0 seconds)
+Test Case 'CreatePrimaryServerRequestTests.testPathIsCorrect' started at 2025-08-05 06:23:03.759
+Test Case 'CreatePrimaryServerRequestTests.testPathIsCorrect' passed (0.101 seconds)
+Test Suite 'CreatePrimaryServerRequestTests' passed at 2025-08-05 06:23:03.860
+	 Executed 2 tests, with 0 failures (0 unexpected) in 0.101 (0.101) seconds
+Test Suite 'DNSClientTests' started at 2025-08-05 06:23:03.860
+Test Case 'DNSClientTests.testRoute53CreateRecordErrorDetails' started at 2025-08-05 06:23:03.860
+Test Case 'DNSClientTests.testRoute53CreateRecordErrorDetails' passed (0.001 seconds)
+Test Case 'DNSClientTests.testRoute53CreateRecordStub' started at 2025-08-05 06:23:03.861
+Test Case 'DNSClientTests.testRoute53CreateRecordStub' passed (0.001 seconds)
+Test Case 'DNSClientTests.testRoute53DeleteRecordErrorDescription' started at 2025-08-05 06:23:03.862
+Test Case 'DNSClientTests.testRoute53DeleteRecordErrorDescription' passed (0.0 seconds)
+Test Case 'DNSClientTests.testRoute53DeleteRecordErrorDetails' started at 2025-08-05 06:23:03.862
+Test Case 'DNSClientTests.testRoute53DeleteRecordErrorDetails' passed (0.0 seconds)
+Test Case 'DNSClientTests.testRoute53DeleteRecordStub' started at 2025-08-05 06:23:03.862
+Test Case 'DNSClientTests.testRoute53DeleteRecordStub' passed (0.001 seconds)
+Test Case 'DNSClientTests.testRoute53ListZonesErrorDetails' started at 2025-08-05 06:23:03.863
+Test Case 'DNSClientTests.testRoute53ListZonesErrorDetails' passed (0.001 seconds)
+Test Case 'DNSClientTests.testRoute53Stub' started at 2025-08-05 06:23:03.865
+Test Case 'DNSClientTests.testRoute53Stub' passed (0.001 seconds)
+Test Case 'DNSClientTests.testRoute53UpdateRecordErrorDetails' started at 2025-08-05 06:23:03.865
+Test Case 'DNSClientTests.testRoute53UpdateRecordErrorDetails' passed (0.001 seconds)
+Test Case 'DNSClientTests.testRoute53UpdateRecordStub' started at 2025-08-05 06:23:03.866
+Test Case 'DNSClientTests.testRoute53UpdateRecordStub' passed (0.001 seconds)
+Test Suite 'DNSClientTests' passed at 2025-08-05 06:23:03.867
+	 Executed 9 tests, with 0 failures (0 unexpected) in 0.006 (0.006) seconds
+Test Suite 'DeletePrimaryServerRequestTests' started at 2025-08-05 06:23:03.867
+Test Case 'DeletePrimaryServerRequestTests.testMethodIsDELETE' started at 2025-08-05 06:23:03.867
+Test Case 'DeletePrimaryServerRequestTests.testMethodIsDELETE' passed (0.0 seconds)
+Test Case 'DeletePrimaryServerRequestTests.testPathIsCorrect' started at 2025-08-05 06:23:03.867
+Test Case 'DeletePrimaryServerRequestTests.testPathIsCorrect' passed (0.001 seconds)
+Test Suite 'DeletePrimaryServerRequestTests' passed at 2025-08-05 06:23:03.868
+	 Executed 2 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
+Test Suite 'DeleteRecordRequestTests' started at 2025-08-05 06:23:03.868
+Test Case 'DeleteRecordRequestTests.testDeleteRecordBuildsPathAndMethod' started at 2025-08-05 06:23:03.868
+Test Case 'DeleteRecordRequestTests.testDeleteRecordBuildsPathAndMethod' passed (0.0 seconds)
+Test Suite 'DeleteRecordRequestTests' passed at 2025-08-05 06:23:03.868
+	 Executed 1 test, with 0 failures (0 unexpected) in 0.0 (0.0) seconds
+Test Suite 'DeleteZoneRequestTests' started at 2025-08-05 06:23:03.868
+Test Case 'DeleteZoneRequestTests.testPathBuilderEncodesZoneId' started at 2025-08-05 06:23:03.868
+Test Case 'DeleteZoneRequestTests.testPathBuilderEncodesZoneId' passed (0.0 seconds)
+Test Suite 'DeleteZoneRequestTests' passed at 2025-08-05 06:23:03.869
+	 Executed 1 test, with 0 failures (0 unexpected) in 0.0 (0.0) seconds
+Test Suite 'GetPrimaryServerRequestTests' started at 2025-08-05 06:23:03.869
+Test Case 'GetPrimaryServerRequestTests.testMethodIsGET' started at 2025-08-05 06:23:03.869
+Test Case 'GetPrimaryServerRequestTests.testMethodIsGET' passed (0.0 seconds)
+Test Case 'GetPrimaryServerRequestTests.testPathBuilderReplacesId' started at 2025-08-05 06:23:03.869
+Test Case 'GetPrimaryServerRequestTests.testPathBuilderReplacesId' passed (0.0 seconds)
+Test Suite 'GetPrimaryServerRequestTests' passed at 2025-08-05 06:23:03.869
+	 Executed 2 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
+Test Suite 'GetRecordRequestTests' started at 2025-08-05 06:23:03.869
+Test Case 'GetRecordRequestTests.testPathBuilderReplacesRecordId' started at 2025-08-05 06:23:03.869
+Test Case 'GetRecordRequestTests.testPathBuilderReplacesRecordId' passed (0.0 seconds)
+Test Suite 'GetRecordRequestTests' passed at 2025-08-05 06:23:03.870
+	 Executed 1 test, with 0 failures (0 unexpected) in 0.0 (0.0) seconds
+Test Suite 'GetZoneRequestTests' started at 2025-08-05 06:23:03.870
+Test Case 'GetZoneRequestTests.testPathBuilderReplacesZoneId' started at 2025-08-05 06:23:03.870
+Test Case 'GetZoneRequestTests.testPathBuilderReplacesZoneId' passed (0.0 seconds)
+Test Suite 'GetZoneRequestTests' passed at 2025-08-05 06:23:03.870
+	 Executed 1 test, with 0 failures (0 unexpected) in 0.0 (0.0) seconds
+Test Suite 'HetznerDNSClientTests' started at 2025-08-05 06:23:03.870
+Test Case 'HetznerDNSClientTests.testCreateRecordEncodesBody' started at 2025-08-05 06:23:03.870
+Test Case 'HetznerDNSClientTests.testCreateRecordEncodesBody' passed (0.002 seconds)
+Test Case 'HetznerDNSClientTests.testCreateRecordRequest' started at 2025-08-05 06:23:03.872
+Test Case 'HetznerDNSClientTests.testCreateRecordRequest' passed (0.001 seconds)
+Test Case 'HetznerDNSClientTests.testCreateRecordSetsContentTypeHeader' started at 2025-08-05 06:23:03.872
+Test Case 'HetznerDNSClientTests.testCreateRecordSetsContentTypeHeader' passed (0.001 seconds)
+Test Case 'HetznerDNSClientTests.testDeleteRecordRequest' started at 2025-08-05 06:23:03.874
+Test Case 'HetznerDNSClientTests.testDeleteRecordRequest' passed (0.0 seconds)
+Test Case 'HetznerDNSClientTests.testDeleteRecordSetsAuthHeader' started at 2025-08-05 06:23:03.874
+Test Case 'HetznerDNSClientTests.testDeleteRecordSetsAuthHeader' passed (0.001 seconds)
+Test Case 'HetznerDNSClientTests.testListZonesPathBuilder' started at 2025-08-05 06:23:03.875
+Test Case 'HetznerDNSClientTests.testListZonesPathBuilder' passed (0.0 seconds)
+Test Case 'HetznerDNSClientTests.testListZonesReturnsIDs' started at 2025-08-05 06:23:03.876
+Test Case 'HetznerDNSClientTests.testListZonesReturnsIDs' passed (0.001 seconds)
+Test Case 'HetznerDNSClientTests.testListZonesSetsAuthHeader' started at 2025-08-05 06:23:03.877
+Test Case 'HetznerDNSClientTests.testListZonesSetsAuthHeader' passed (0.001 seconds)
+Test Case 'HetznerDNSClientTests.testUpdateRecordRequest' started at 2025-08-05 06:23:03.878
+Test Case 'HetznerDNSClientTests.testUpdateRecordRequest' passed (0.001 seconds)
+Test Case 'HetznerDNSClientTests.testUpdateRecordSetsAuthHeader' started at 2025-08-05 06:23:03.878
+Test Case 'HetznerDNSClientTests.testUpdateRecordSetsAuthHeader' passed (0.001 seconds)
+Test Suite 'HetznerDNSClientTests' passed at 2025-08-05 06:23:03.879
+	 Executed 10 tests, with 0 failures (0 unexpected) in 0.009 (0.009) seconds
+Test Suite 'ListPrimaryServersRequestTests' started at 2025-08-05 06:23:03.879
+Test Case 'ListPrimaryServersRequestTests.testPathBuilderAddsZoneIdQueryWhenProvided' started at 2025-08-05 06:23:03.879
+Test Case 'ListPrimaryServersRequestTests.testPathBuilderAddsZoneIdQueryWhenProvided' passed (0.0 seconds)
+Test Case 'ListPrimaryServersRequestTests.testPathBuilderWithoutZoneIdHasNoQuery' started at 2025-08-05 06:23:03.880
+Test Case 'ListPrimaryServersRequestTests.testPathBuilderWithoutZoneIdHasNoQuery' passed (0.0 seconds)
+Test Suite 'ListPrimaryServersRequestTests' passed at 2025-08-05 06:23:03.880
+	 Executed 2 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
+Test Suite 'ListRecordsRequestTests' started at 2025-08-05 06:23:03.880
+Test Case 'ListRecordsRequestTests.testPathBuilderEncodesQuery' started at 2025-08-05 06:23:03.880
+Test Case 'ListRecordsRequestTests.testPathBuilderEncodesQuery' passed (0.0 seconds)
+Test Suite 'ListRecordsRequestTests' passed at 2025-08-05 06:23:03.880
+	 Executed 1 test, with 0 failures (0 unexpected) in 0.0 (0.0) seconds
+Test Suite 'UpdateRecordRequestTests' started at 2025-08-05 06:23:03.880
+Test Case 'UpdateRecordRequestTests.testUpdateRecordBuildsPathAndMethod' started at 2025-08-05 06:23:03.880
+Test Case 'UpdateRecordRequestTests.testUpdateRecordBuildsPathAndMethod' passed (0.0 seconds)
+Test Case 'UpdateRecordRequestTests.testUpdateRecordStoresBody' started at 2025-08-05 06:23:03.881
+Test Case 'UpdateRecordRequestTests.testUpdateRecordStoresBody' passed (0.0 seconds)
+Test Suite 'UpdateRecordRequestTests' passed at 2025-08-05 06:23:03.881
+	 Executed 2 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
+Test Suite 'AsyncHTTPClientDriverTests' started at 2025-08-05 06:23:03.881
+Test Case 'AsyncHTTPClientDriverTests.testExecuteFailsForUnreachableHost' started at 2025-08-05 06:23:03.881
+Test Case 'AsyncHTTPClientDriverTests.testExecuteFailsForUnreachableHost' passed (5.012 seconds)
+Test Case 'AsyncHTTPClientDriverTests.testExecutePerformsRequest' started at 2025-08-05 06:23:08.893
+Test Case 'AsyncHTTPClientDriverTests.testExecutePerformsRequest' passed (0.022 seconds)
+Test Case 'AsyncHTTPClientDriverTests.testExecuteSendsBody' started at 2025-08-05 06:23:08.915
+Test Case 'AsyncHTTPClientDriverTests.testExecuteSendsBody' passed (0.12 seconds)
+Test Suite 'AsyncHTTPClientDriverTests' passed at 2025-08-05 06:23:09.036
+	 Executed 3 tests, with 0 failures (0 unexpected) in 5.154 (5.154) seconds
+Test Suite 'CertificateManagerTests' started at 2025-08-05 06:23:09.036
+Test Case 'CertificateManagerTests.testStartSchedulesRepeatedRuns' started at 2025-08-05 06:23:09.036
+Test Case 'CertificateManagerTests.testStartSchedulesRepeatedRuns' passed (1.305 seconds)
+Test Case 'CertificateManagerTests.testStopCancelsFutureRuns' started at 2025-08-05 06:23:10.341
+Test Case 'CertificateManagerTests.testStopCancelsFutureRuns' passed (3.018 seconds)
+Test Case 'CertificateManagerTests.testTriggerNowRunsScript' started at 2025-08-05 06:23:13.359
+Test Case 'CertificateManagerTests.testTriggerNowRunsScript' passed (1.248 seconds)
+Test Suite 'CertificateManagerTests' passed at 2025-08-05 06:23:14.606
+	 Executed 3 tests, with 0 failures (0 unexpected) in 5.57 (5.57) seconds
+Test Suite 'GatewayPluginTests' started at 2025-08-05 06:23:14.606
+Test Case 'GatewayPluginTests.testDefaultPrepareReturnsSameRequest' started at 2025-08-05 06:23:14.606
+Test Case 'GatewayPluginTests.testDefaultPrepareReturnsSameRequest' passed (0.0 seconds)
+Test Case 'GatewayPluginTests.testDefaultRespondReturnsSameResponse' started at 2025-08-05 06:23:14.607
+Test Case 'GatewayPluginTests.testDefaultRespondReturnsSameResponse' passed (0.001 seconds)
+Test Suite 'GatewayPluginTests' passed at 2025-08-05 06:23:14.608
+	 Executed 2 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
+Test Suite 'GatewayServerTests' started at 2025-08-05 06:23:14.608
+Test Case 'GatewayServerTests.testHealthEndpointResponds' started at 2025-08-05 06:23:14.608
+Test Case 'GatewayServerTests.testHealthEndpointResponds' passed (0.11 seconds)
+Test Case 'GatewayServerTests.testHealthEndpointSetsJSONContentType' started at 2025-08-05 06:23:14.718
+Test Case 'GatewayServerTests.testHealthEndpointSetsJSONContentType' passed (0.111 seconds)
+Test Case 'GatewayServerTests.testMetricsEndpointResponds' started at 2025-08-05 06:23:14.829
+Test Case 'GatewayServerTests.testMetricsEndpointResponds' passed (0.108 seconds)
+Test Case 'GatewayServerTests.testMetricsEndpointReturnsEmptyArray' started at 2025-08-05 06:23:14.937
+Test Case 'GatewayServerTests.testMetricsEndpointReturnsEmptyArray' passed (0.108 seconds)
+Test Case 'GatewayServerTests.testMetricsEndpointSetsJSONContentType' started at 2025-08-05 06:23:15.045
+Test Case 'GatewayServerTests.testMetricsEndpointSetsJSONContentType' passed (0.108 seconds)
+Test Case 'GatewayServerTests.testPluginCanRewriteRequestAndResponse' started at 2025-08-05 06:23:15.153
+Test Case 'GatewayServerTests.testPluginCanRewriteRequestAndResponse' passed (0.109 seconds)
+Test Case 'GatewayServerTests.testPluginsPrepareInRegistrationOrder' started at 2025-08-05 06:23:15.262
+Test Case 'GatewayServerTests.testPluginsPrepareInRegistrationOrder' passed (0.11 seconds)
+Test Case 'GatewayServerTests.testPluginsRespondInReverseOrder' started at 2025-08-05 06:23:15.372
+Test Case 'GatewayServerTests.testPluginsRespondInReverseOrder' passed (0.11 seconds)
+Test Case 'GatewayServerTests.testUnknownPathReturns404' started at 2025-08-05 06:23:15.483
+Test Case 'GatewayServerTests.testUnknownPathReturns404' passed (0.108 seconds)
+Test Suite 'GatewayServerTests' passed at 2025-08-05 06:23:15.590
+	 Executed 9 tests, with 0 failures (0 unexpected) in 0.982 (0.982) seconds
+Test Suite 'HTTPKernelTests' started at 2025-08-05 06:23:15.590
+Test Case 'HTTPKernelTests.testKernelPropagatesErrors' started at 2025-08-05 06:23:15.590
+Test Case 'HTTPKernelTests.testKernelPropagatesErrors' passed (0.001 seconds)
+Test Case 'HTTPKernelTests.testKernelRoutesRequest' started at 2025-08-05 06:23:15.591
+Test Case 'HTTPKernelTests.testKernelRoutesRequest' passed (0.001 seconds)
+Test Suite 'HTTPKernelTests' passed at 2025-08-05 06:23:15.592
+	 Executed 2 tests, with 0 failures (0 unexpected) in 0.002 (0.002) seconds
+Test Suite 'HTTPRequestTests' started at 2025-08-05 06:23:15.592
+Test Case 'HTTPRequestTests.testRequestDefaults' started at 2025-08-05 06:23:15.592
+Test Case 'HTTPRequestTests.testRequestDefaults' passed (0.001 seconds)
+Test Case 'HTTPRequestTests.testRequestInitializerStoresValues' started at 2025-08-05 06:23:15.593
+Test Case 'HTTPRequestTests.testRequestInitializerStoresValues' passed (0.001 seconds)
+Test Case 'HTTPRequestTests.testRequestMutation' started at 2025-08-05 06:23:15.594
+Test Case 'HTTPRequestTests.testRequestMutation' passed (0.001 seconds)
+Test Suite 'HTTPRequestTests' passed at 2025-08-05 06:23:15.594
+	 Executed 3 tests, with 0 failures (0 unexpected) in 0.002 (0.002) seconds
+Test Suite 'HTTPResponseDefaultsTests' started at 2025-08-05 06:23:15.594
+Test Case 'HTTPResponseDefaultsTests.testNoBodyCodable' started at 2025-08-05 06:23:15.594
+Test Case 'HTTPResponseDefaultsTests.testNoBodyCodable' passed (0.004 seconds)
+Test Case 'HTTPResponseDefaultsTests.testResponseBodyMutation' started at 2025-08-05 06:23:15.598
+Test Case 'HTTPResponseDefaultsTests.testResponseBodyMutation' passed (0.001 seconds)
+Test Case 'HTTPResponseDefaultsTests.testResponseDefaults' started at 2025-08-05 06:23:15.599
+Test Case 'HTTPResponseDefaultsTests.testResponseDefaults' passed (0.001 seconds)
+Test Case 'HTTPResponseDefaultsTests.testResponseHeadersMutation' started at 2025-08-05 06:23:15.600
+Test Case 'HTTPResponseDefaultsTests.testResponseHeadersMutation' passed (0.001 seconds)
+Test Case 'HTTPResponseDefaultsTests.testResponseInitializerStoresValues' started at 2025-08-05 06:23:15.601
+Test Case 'HTTPResponseDefaultsTests.testResponseInitializerStoresValues' passed (0.0 seconds)
+Test Case 'HTTPResponseDefaultsTests.testResponseStatusMutation' started at 2025-08-05 06:23:15.601
+Test Case 'HTTPResponseDefaultsTests.testResponseStatusMutation' passed (0.001 seconds)
+Test Suite 'HTTPResponseDefaultsTests' passed at 2025-08-05 06:23:15.602
+	 Executed 6 tests, with 0 failures (0 unexpected) in 0.007 (0.007) seconds
+Test Suite 'LoggingPluginTests' started at 2025-08-05 06:23:15.602
+Test Case 'LoggingPluginTests.testLoggingPluginPassThrough' started at 2025-08-05 06:23:15.602
+-> GET /
+<- 200 for /
+Test Case 'LoggingPluginTests.testLoggingPluginPassThrough' passed (0.001 seconds)
+Test Case 'LoggingPluginTests.testPreparePreservesHeadersAndBody' started at 2025-08-05 06:23:15.602
+-> POST /data
+Test Case 'LoggingPluginTests.testPreparePreservesHeadersAndBody' passed (0.001 seconds)
+Test Case 'LoggingPluginTests.testRespondPreservesHeadersAndBody' started at 2025-08-05 06:23:15.603
+<- 201 for /
+Test Case 'LoggingPluginTests.testRespondPreservesHeadersAndBody' passed (0.001 seconds)
+Test Suite 'LoggingPluginTests' passed at 2025-08-05 06:23:15.604
+	 Executed 3 tests, with 0 failures (0 unexpected) in 0.002 (0.002) seconds
+Test Suite 'NIOHTTPServerTests' started at 2025-08-05 06:23:15.604
+Test Case 'NIOHTTPServerTests.testServerHandlesConcurrentRequests' started at 2025-08-05 06:23:15.604
+Test Case 'NIOHTTPServerTests.testServerHandlesConcurrentRequests' passed (0.009 seconds)
+Test Case 'NIOHTTPServerTests.testServerReleasesPortOnStop' started at 2025-08-05 06:23:15.613
+Test Case 'NIOHTTPServerTests.testServerReleasesPortOnStop' passed (0.005 seconds)
+Test Case 'NIOHTTPServerTests.testServerResponds' started at 2025-08-05 06:23:15.618
+Test Case 'NIOHTTPServerTests.testServerResponds' passed (0.007 seconds)
+Test Suite 'NIOHTTPServerTests' passed at 2025-08-05 06:23:15.626
+	 Executed 3 tests, with 0 failures (0 unexpected) in 0.022 (0.022) seconds
+Test Suite 'PublishingFrontendPluginTests' started at 2025-08-05 06:23:15.626
+Test Case 'PublishingFrontendPluginTests.testPluginIgnoresNonGETRequests' started at 2025-08-05 06:23:15.626
+Test Case 'PublishingFrontendPluginTests.testPluginIgnoresNonGETRequests' passed (0.008 seconds)
+Test Case 'PublishingFrontendPluginTests.testPluginPassThroughWhenFileMissing' started at 2025-08-05 06:23:15.634
+Test Case 'PublishingFrontendPluginTests.testPluginPassThroughWhenFileMissing' passed (0.001 seconds)
+Test Case 'PublishingFrontendPluginTests.testPluginPreservesHeadersOnPassThrough' started at 2025-08-05 06:23:15.635
+Test Case 'PublishingFrontendPluginTests.testPluginPreservesHeadersOnPassThrough' passed (0.001 seconds)
+Test Case 'PublishingFrontendPluginTests.testPluginServesFile' started at 2025-08-05 06:23:15.636
+Test Case 'PublishingFrontendPluginTests.testPluginServesFile' passed (0.008 seconds)
+Test Case 'PublishingFrontendPluginTests.testPluginServesNestedFile' started at 2025-08-05 06:23:15.644
+Test Case 'PublishingFrontendPluginTests.testPluginServesNestedFile' passed (0.004 seconds)
+Test Case 'PublishingFrontendPluginTests.testPluginSetsContentTypeHeader' started at 2025-08-05 06:23:15.648
+Test Case 'PublishingFrontendPluginTests.testPluginSetsContentTypeHeader' passed (0.004 seconds)
+Test Suite 'PublishingFrontendPluginTests' passed at 2025-08-05 06:23:15.652
+	 Executed 6 tests, with 0 failures (0 unexpected) in 0.026 (0.026) seconds
+Test Suite 'URLSessionHTTPClientTests' started at 2025-08-05 06:23:15.652
+Test Case 'URLSessionHTTPClientTests.testExecuteCollectsMultipleHeaders' started at 2025-08-05 06:23:15.652
+Test Case 'URLSessionHTTPClientTests.testExecuteCollectsMultipleHeaders' passed (0.002 seconds)
+Test Case 'URLSessionHTTPClientTests.testExecuteHandlesEmptyBody' started at 2025-08-05 06:23:15.655
+Test Case 'URLSessionHTTPClientTests.testExecuteHandlesEmptyBody' passed (0.002 seconds)
+Test Case 'URLSessionHTTPClientTests.testExecutePerformsRequest' started at 2025-08-05 06:23:15.657
+Test Case 'URLSessionHTTPClientTests.testExecutePerformsRequest' passed (0.003 seconds)
+Test Case 'URLSessionHTTPClientTests.testExecuteThrowsOnInvalidURL' started at 2025-08-05 06:23:15.660
+Test Case 'URLSessionHTTPClientTests.testExecuteThrowsOnInvalidURL' passed (0.001 seconds)
+Test Suite 'URLSessionHTTPClientTests' passed at 2025-08-05 06:23:15.661
+	 Executed 4 tests, with 0 failures (0 unexpected) in 0.009 (0.009) seconds
+Test Suite 'debug.xctest' passed at 2025-08-05 06:23:15.661
+	 Executed 165 tests, with 0 failures (0 unexpected) in 12.323 (12.323) seconds
+Test Suite 'All tests' passed at 2025-08-05 06:23:15.661
+	 Executed 165 tests, with 0 failures (0 unexpected) in 12.323 (12.323) seconds
+◇ Test run started.
+↳ Testing Library Version: 6.1 (43b6f88e2f2712e)
+↳ Target Platform: x86_64-unknown-linux-gnu
+✔ Test run with 0 tests passed after 0.001 seconds.
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- Validate URL strings in `URLSessionHTTPClient` by requiring a scheme and throwing `URLError(.badURL)` when missing
- Track expanded test coverage for invalid URLs in the repository agent manifest
- Record passing test run output in logs

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_b_68919f41e6ec8333965beb98e734795e