### PR TITLE
fix: align todo comments with property name

### DIFF
--- a/Sources/FountainCore/Models.swift
+++ b/Sources/FountainCore/Models.swift
@@ -1,11 +1,11 @@
 // Models for Sample API
 
 /// Simple task model used in unit tests.
-/// Represents an item with identifier and title.
+/// Represents an item with identifier and name.
 public struct Todo: Codable, Equatable {
     /// Unique identifier for the task.
     public let id: Int
-    /// Human-readable title for the task.
+    /// Human-readable name for the task.
     public let name: String
 }
 


### PR DESCRIPTION
## Summary
- use `name` terminology consistently in Todo model comments

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_b_6891a4155ea8833393f635f9cab58c7c