### PR TITLE
feat: add zone manager with YAML persistence

### DIFF
--- a/Sources/FountainCodex/ZoneManager.swift
+++ b/Sources/FountainCodex/ZoneManager.swift
@@ -1,0 +1,49 @@
+import Foundation
+import Yams
+
+/// Actor responsible for managing DNS zone records with persistent YAML storage.
+public actor ZoneManager {
+    private var cache: [String: String]
+    private let fileURL: URL
+
+    /// Loads the zone cache from the provided YAML file if it exists.
+    /// - Parameter fileURL: Location of the YAML zone file on disk.
+    public init(fileURL: URL) throws {
+        self.fileURL = fileURL
+        if let data = try? Data(contentsOf: fileURL),
+           let string = String(data: data, encoding: .utf8),
+           let loaded = try Yams.load(yaml: string) as? [String: String] {
+            self.cache = loaded
+        } else {
+            self.cache = [:]
+        }
+    }
+
+    /// Returns the IPv4 address associated with the given domain name.
+    /// - Parameter name: Fully qualified domain name.
+    /// - Returns: The IPv4 address string if present.
+    public func ip(for name: String) -> String? {
+        cache[name]
+    }
+
+    /// Updates or inserts a DNS record and persists it to disk.
+    /// - Parameters:
+    ///   - name: Fully qualified domain name.
+    ///   - ip: IPv4 address string.
+    public func set(name: String, ip: String) throws {
+        cache[name] = ip
+        try persist()
+    }
+
+    /// Returns the current in-memory zone cache.
+    public func allRecords() -> [String: String] {
+        cache
+    }
+
+    private func persist() throws {
+        let yaml = try Yams.dump(object: cache)
+        try yaml.write(to: fileURL, atomically: true, encoding: .utf8)
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Tests/DNSTests/ZoneManagerTests.swift
+++ b/Tests/DNSTests/ZoneManagerTests.swift
@@ -1,0 +1,44 @@
+import XCTest
+@testable import FountainCodex
+import Yams
+
+final class ZoneManagerTests: XCTestCase {
+    func temporaryFile() -> URL {
+        let dir = FileManager.default.temporaryDirectory
+        return dir.appendingPathComponent(UUID().uuidString)
+    }
+
+    func testLoadsExistingZonesFromDisk() async throws {
+        let file = temporaryFile()
+        try "example.com: 1.2.3.4\n".write(to: file, atomically: true, encoding: .utf8)
+        let manager = try ZoneManager(fileURL: file)
+        let ip = await manager.ip(for: "example.com")
+        XCTAssertEqual(ip, "1.2.3.4")
+    }
+
+    func testPersistsUpdatesToDisk() async throws {
+        let file = temporaryFile()
+        let manager = try ZoneManager(fileURL: file)
+        try await manager.set(name: "example.com", ip: "5.6.7.8")
+        let contents = try String(contentsOf: file, encoding: .utf8)
+        let yaml = try Yams.load(yaml: contents) as? [String: String]
+        XCTAssertEqual(yaml?["example.com"], "5.6.7.8")
+    }
+
+    func testConcurrentUpdatesAreSerialized() async throws {
+        let file = temporaryFile()
+        let manager = try ZoneManager(fileURL: file)
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            for i in 0..<10 {
+                group.addTask {
+                    try await manager.set(name: "host\(i).test", ip: "1.1.1.\(i)")
+                }
+            }
+            try await group.waitForAll()
+        }
+        let records = await manager.allRecords()
+        XCTAssertEqual(records.count, 10)
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/agent.md
+++ b/agent.md
@@ -24,7 +24,7 @@ This agent maintains an up-to-date view of outstanding development tasks across 
 | OpenAPI spec              | API spec                     | Ship full OpenAPI 3.1 definition                         | ✅     | None                                | docs, api             |
 | DNSSEC (optional)         | DNS engine                   | Sign internal zones with DNSSEC                          | ❌     | Crypto library selection            | security, dns         |
 | DNS engine                | SwiftNIO UDP/TCP             | Parse queries and respond from zone cache                | ✅     | None                                | swift, networking     |
-| Zone manager              | Zone storage                 | Maintain in-memory cache & disk serialization            | ❌     | Yams integration                    | storage, concurrency  |
+| Zone manager              | Zone storage                 | Maintain in-memory cache & disk serialization            | ✅     | None                                | storage, concurrency  |
 | HTTP server               | SwiftNIO HTTP                | Serve control plane with schema validation               | ✅     | None                                | api, server           |
 | ACME client               | Certificate automation       | Handle DNS-01 challenge via API                          | ❌     | Choose ACME client                  | security, cert        |
 | Testing                   | Tests                        | EmbeddedChannel unit & integration tests                 | ❌     | Test harness setup                  | test                  |

--- a/logs/zone-manager-20250805.log
+++ b/logs/zone-manager-20250805.log
@@ -1,0 +1,5 @@
+[2025-08-05] Implemented actor-based ZoneManager with YAML persistence.
+Tags: storage, concurrency
+Tests: swift test
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- add actor-based zone manager with YAML disk persistence
- verify zone manager loading, persistence, and concurrency via tests
- mark zone manager task complete in agent manifest

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_b_6891ec54447c83339e61a2b897167a5b