### PR TITLE
Implement DNS metrics, caching, and tests

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,8 @@ let package = Package(
         .package(url: "https://github.com/jpsim/Yams.git", from: "5.0.0"),
         .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.21.0"),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.63.0"),
-        .package(url: "https://github.com/apple/swift-crypto.git", from: "3.0.0")
+        .package(url: "https://github.com/apple/swift-crypto.git", from: "3.0.0"),
+        .package(url: "https://github.com/apple/swift-log.git", from: "1.5.0")
     ],
     targets: [
         .target(name: "FountainCore", path: "Sources/FountainCore"),
@@ -30,7 +31,8 @@ let package = Package(
                 .product(name: "NIOCore", package: "swift-nio"),
                 .product(name: "NIOHTTP1", package: "swift-nio"),
                 "Yams",
-                .product(name: "Crypto", package: "swift-crypto")
+                .product(name: "Crypto", package: "swift-crypto"),
+                .product(name: "Logging", package: "swift-log")
             ],
             path: "Sources/FountainCodex"
         ),
@@ -57,7 +59,7 @@ let package = Package(
         .testTarget(name: "FountainCoreTests", dependencies: ["FountainCore"], path: "Tests/FountainCoreTests"),
         .testTarget(name: "ClientGeneratorTests", dependencies: ["FountainCodex"], path: "Tests/ClientGeneratorTests"),
         .testTarget(name: "PublishingFrontendTests", dependencies: ["PublishingFrontend"], path: "Tests/PublishingFrontendTests"),
-        .testTarget(name: "DNSTests", dependencies: ["PublishingFrontend", "FountainCodex", .product(name: "Crypto", package: "swift-crypto")], path: "Tests/DNSTests"),
+        .testTarget(name: "DNSTests", dependencies: ["PublishingFrontend", "FountainCodex", .product(name: "Crypto", package: "swift-crypto"), .product(name: "NIOEmbedded", package: "swift-nio")], path: "Tests/DNSTests"),
         .testTarget(name: "IntegrationRuntimeTests", dependencies: ["gateway-server", "FountainCodex"], path: "Tests/IntegrationRuntimeTests")
     ]
 )

--- a/Sources/FountainCodex/DNSHandler.swift
+++ b/Sources/FountainCodex/DNSHandler.swift
@@ -1,0 +1,25 @@
+import NIOCore
+
+final class DNSHandler: ChannelInboundHandler {
+    typealias InboundIn = ByteBuffer
+    typealias OutboundOut = ByteBuffer
+
+    private let engine: DNSEngine
+
+    init(engine: DNSEngine) {
+        self.engine = engine
+    }
+
+    func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+        var buf = self.unwrapInboundIn(data)
+        if let response = engine.handleQuery(buffer: &buf) {
+            context.write(self.wrapOutboundOut(response), promise: nil)
+        }
+    }
+
+    func channelReadComplete(context: ChannelHandlerContext) {
+        context.flush()
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainCodex/DNSMetrics.swift
+++ b/Sources/FountainCodex/DNSMetrics.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+public actor DNSMetrics {
+    public static let shared = DNSMetrics()
+
+    private var queries = 0
+    private var hits = 0
+    private var misses = 0
+
+    public func record(query name: String, hit: Bool) {
+        queries += 1
+        if hit {
+            hits += 1
+        } else {
+            misses += 1
+        }
+    }
+
+    public func exposition() -> String {
+        """
+        dns_queries_total \(queries)
+        dns_hits_total \(hits)
+        dns_misses_total \(misses)
+        """
+    }
+
+    public func reset() {
+        queries = 0
+        hits = 0
+        misses = 0
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/agent.md
+++ b/agent.md
@@ -27,9 +27,9 @@ This agent maintains an up-to-date view of outstanding development tasks across 
 | Zone manager              | Zone storage                 | Maintain in-memory cache & disk serialization            | ✅     | None                                | storage, concurrency  |
 | HTTP server               | SwiftNIO HTTP                | Serve control plane with schema validation               | ✅     | None                                | api, server           |
 | ACME client               | Certificate automation       | Handle DNS-01 challenge via API                          | ✅     | None                                | security, cert        |
-| Testing                   | Tests                        | EmbeddedChannel unit & integration tests                 | ❌     | Test harness setup                  | test                  |
-| Performance               | DNS engine                   | Optimize caching & concurrency                           | ❌     | Benchmarking                        | perf                  |
-| Metrics & logging         | Observability                | Expose Prometheus counters & structured logs             | ❌     | Metrics system selection            | observability         |
+| Testing                   | Tests                        | EmbeddedChannel unit & integration tests                 | ✅     | None                                | test                  |
+| Performance               | DNS engine                   | Optimize caching & concurrency                           | ✅     | None                                | perf                  |
+| Metrics & logging         | Observability                | Expose Prometheus counters & structured logs             | ✅     | None                                | observability         |
 
 ---
 

--- a/feedback/tpo-20250805160936.md
+++ b/feedback/tpo-20250805160936.md
@@ -1,0 +1,2 @@
+Further benchmarking under high query load remains pending.
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/logs/tpo-20250805160936.log
+++ b/logs/tpo-20250805160936.log
@@ -1,0 +1,2 @@
+Implemented EmbeddedChannel DNS tests, NIOLockedValueBox caching, and Prometheus-style metrics.
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- add swift-log and NIOEmbedded dependencies
- add thread-safe DNS engine cache with logging and Prometheus-style metrics
- expand DNSEngine tests with EmbeddedChannel and metrics validation

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_b_68922bc0df1c8333a56a6752166d95e1