### PR TITLE
feat(sps): detect terms and messages

### DIFF
--- a/sps/Sources/SPSCLI/TableDetector.swift
+++ b/sps/Sources/SPSCLI/TableDetector.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+struct MatrixEntry: Codable {
+    var text: String
+    var page: Int
+    var x: Int
+    var y: Int
+}
+
+struct TableDetector {
+    static func detect(from index: IndexRoot) -> (messages: [MatrixEntry], terms: [MatrixEntry]) {
+        var messages: [MatrixEntry] = []
+        var terms: [MatrixEntry] = []
+        for doc in index.documents {
+            for page in doc.pages {
+                let lines = page.text.split(whereSeparator: \.isNewline)
+                for (i, lineSub) in lines.enumerated() {
+                    let line = String(lineSub)
+                    let entry = MatrixEntry(text: line, page: page.number, x: 0, y: i)
+                    let lower = line.lowercased()
+                    if lower.contains("message") {
+                        messages.append(entry)
+                    }
+                    if lower.contains("term") {
+                        terms.append(entry)
+                    }
+                }
+            }
+        }
+        return (messages, terms)
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/sps/openapi/sps.openapi.yml
+++ b/sps/openapi/sps.openapi.yml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: Semantic PDF Scanner (SPS)
-  version: 0.1.0
+  version: 0.1.1
   description: Swift CLI parity API for Fountain tools-factory integration.
 paths:
   /scan:
@@ -139,7 +139,22 @@ components:
       properties:
         messages:
           type: array
-          items: { type: object }
+          items:
+            $ref: '#/components/schemas/MatrixEntry'
         terms:
           type: array
-          items: { type: object }
+          items:
+            $ref: '#/components/schemas/MatrixEntry'
+    MatrixEntry:
+      type: object
+      required: [text, page, x, y]
+      properties:
+        text: { type: string }
+        page: { type: integer }
+        x:
+          type: integer
+          description: X coordinate (placeholder)
+        y:
+          type: integer
+          description: Y coordinate (placeholder)
+# © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- detect table-like lines in index pages to populate `messages` and `terms`
- document matrix entry fields in OpenAPI spec

## Testing
- `cd sps && swift test`


------
https://chatgpt.com/codex/tasks/task_b_68998a7d33548333b40867d886c72198