### PR TITLE
Serve gateway metrics as JSON

### DIFF
--- a/Sources/FountainOps/FountainAi/openAPI/v1/gateway.yml
+++ b/Sources/FountainOps/FountainAi/openAPI/v1/gateway.yml
@@ -24,7 +24,7 @@ paths:
   /metrics:
     get:
       summary: Metrics
-      description: Endpoint that serves Prometheus metrics.
+      description: Endpoint that serves runtime metrics encoded as JSON.
       operationId: gatewayMetrics
       responses:
         '200':
@@ -33,6 +33,8 @@ paths:
             application/json:
               schema:
                 type: object
+                additionalProperties:
+                  type: integer
   /auth/token:
     post:
       summary: Issue Authentication Token


### PR DESCRIPTION
## Summary
- return gateway metrics as JSON with appropriate content-type
- document JSON metrics response in the gateway OpenAPI spec
- adjust integration tests to expect JSON metrics and verify rate-limit counters

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_b_68999da81e5c83339a2eba905115c1f5