### PR TITLE
Add JWT-based auth tokens and management endpoint protection

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -43,7 +43,7 @@ let package = Package(
         ),
         .executableTarget(
             name: "gateway-server",
-            dependencies: ["FountainCodex", "PublishingFrontend"],
+            dependencies: ["FountainCodex", "PublishingFrontend", .product(name: "Crypto", package: "swift-crypto")],
             path: "Sources/GatewayApp"
         ),
         .target(

--- a/Sources/FountainOps/FountainAi/openAPI/v1/gateway.yml
+++ b/Sources/FountainOps/FountainAi/openAPI/v1/gateway.yml
@@ -35,6 +35,8 @@ paths:
                 type: object
                 additionalProperties:
                   type: integer
+      security:
+        - bearerAuth: []
   /auth/token:
     post:
       summary: Issue Authentication Token
@@ -61,6 +63,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+      security: []
   /certificates:
     get:
       summary: Certificate Info
@@ -73,6 +76,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CertificateInfo'
+      security:
+        - bearerAuth: []
   /certificates/renew:
     post:
       summary: Trigger certificate renewal
@@ -85,6 +90,8 @@ paths:
             application/json:
               schema:
                 type: object
+      security:
+        - bearerAuth: []
   /routes:
     get:
       summary: List Configured Routes
@@ -99,6 +106,8 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/RouteInfo'
+      security:
+        - bearerAuth: []
     post:
       summary: Add a new route
       operationId: createRoute
@@ -121,6 +130,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+      security:
+        - bearerAuth: []
   /routes/{routeId}:
     put:
       summary: Update an existing route
@@ -151,6 +162,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+      security:
+        - bearerAuth: []
     delete:
       summary: Delete a route
       operationId: deleteRoute
@@ -170,7 +183,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+      security:
+        - bearerAuth: []
 components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
   schemas:
     CredentialRequest:
       type: object

--- a/Sources/GatewayApp/AuthPlugin.swift
+++ b/Sources/GatewayApp/AuthPlugin.swift
@@ -1,0 +1,38 @@
+import Foundation
+import FountainCodex
+
+/// Error thrown when authorization fails.
+public struct UnauthorizedError: Error {}
+
+/// Plugin enforcing bearer token authorization on management endpoints.
+public struct AuthPlugin: GatewayPlugin {
+    private let store: CredentialStore
+    private let protected: [String]
+
+    /// Creates a new auth plugin.
+    /// - Parameters:
+    ///   - store: Credential store used to verify JWTs.
+    ///   - protected: Path prefixes requiring authorization.
+    public init(store: CredentialStore = CredentialStore(),
+                protected: [String] = ["/metrics", "/certificates", "/routes", "/zones"]) {
+        self.store = store
+        self.protected = protected
+    }
+
+    /// Validates `Authorization: Bearer` tokens for protected paths.
+    /// - Parameter request: Incoming HTTP request.
+    /// - Returns: The request when authorization succeeds.
+    public func prepare(_ request: HTTPRequest) async throws -> HTTPRequest {
+        guard protected.contains(where: { request.path.hasPrefix($0) }) else {
+            return request
+        }
+        guard let auth = request.headers["Authorization"], auth.hasPrefix("Bearer ") else {
+            throw UnauthorizedError()
+        }
+        let token = String(auth.dropFirst(7))
+        guard store.verify(jwt: token) else { throw UnauthorizedError() }
+        return request
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/GatewayApp/CredentialStore.swift
+++ b/Sources/GatewayApp/CredentialStore.swift
@@ -1,0 +1,78 @@
+import Foundation
+import Crypto
+
+/// Provides access to client credentials and JWT signing.
+public struct CredentialStore: @unchecked Sendable {
+    private let credentials: [String: String]
+    private let signingKey: SymmetricKey
+
+    /// Loads credentials and signing key from environment variables.
+    /// Expected format for credentials: `GATEWAY_CRED_<CLIENT_ID>`.
+    /// Signing key is read from `GATEWAY_JWT_SECRET`.
+    public init(environment: [String: String] = ProcessInfo.processInfo.environment) {
+        var map: [String: String] = [:]
+        for (key, value) in environment where key.hasPrefix("GATEWAY_CRED_") {
+            let id = String(key.dropFirst("GATEWAY_CRED_".count))
+            map[id] = value
+        }
+        self.credentials = map
+        let secret = environment["GATEWAY_JWT_SECRET"] ?? "secret"
+        self.signingKey = SymmetricKey(data: Data(secret.utf8))
+    }
+
+    /// Verifies a pair of client credentials against the store.
+    public func validate(clientId: String, clientSecret: String) -> Bool {
+        credentials[clientId] == clientSecret
+    }
+
+    /// Generates a signed JWT for the given subject with an expiry.
+    public func signJWT(subject: String, expiresAt: Date) throws -> String {
+        let header = JWTHeader()
+        let payload = JWTPayload(sub: subject, exp: Int(expiresAt.timeIntervalSince1970))
+        let headerData = try JSONEncoder().encode(header)
+        let payloadData = try JSONEncoder().encode(payload)
+        let header64 = headerData.base64URLEncodedString()
+        let payload64 = payloadData.base64URLEncodedString()
+        let signingInput = "\(header64).\(payload64)"
+        let signature = HMAC<SHA256>.authenticationCode(for: Data(signingInput.utf8), using: signingKey)
+        let signature64 = Data(signature).base64URLEncodedString()
+        return "\(signingInput).\(signature64)"
+    }
+
+    /// Validates a JWT signature and expiry.
+    public func verify(jwt: String) -> Bool {
+        let segments = jwt.split(separator: ".")
+        guard segments.count == 3 else { return false }
+        let signingInput = segments[0] + "." + segments[1]
+        guard let signatureData = Data(base64URLEncoded: String(segments[2])) else { return false }
+        let expected = HMAC<SHA256>.authenticationCode(for: Data(signingInput.utf8), using: signingKey)
+        guard Data(expected) == signatureData else { return false }
+        guard let payloadData = Data(base64URLEncoded: String(segments[1])),
+              let payload = try? JSONDecoder().decode(JWTPayload.self, from: payloadData) else { return false }
+        return payload.exp > Int(Date().timeIntervalSince1970)
+    }
+}
+
+private struct JWTHeader: Encodable { let alg = "HS256"; let typ = "JWT" }
+private struct JWTPayload: Codable { let sub: String; let exp: Int }
+
+private extension Data {
+    func base64URLEncodedString() -> String {
+        self.base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+
+    init?(base64URLEncoded input: String) {
+        var base64 = input
+            .replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+        let padding = 4 - base64.count % 4
+        if padding < 4 { base64 += String(repeating: "=", count: padding) }
+        guard let data = Data(base64Encoded: base64) else { return nil }
+        self = data
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- replace static credential check with credential store and signed JWT issuance
- secure gateway management endpoints via new AuthPlugin
- document bearer auth requirements in gateway spec and add coverage tests

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_b_6899bc9aa48483338a6eea2420017d8e