### PR TITLE
Remove public zone reload endpoint

### DIFF
--- a/Sources/GatewayApp/GatewayServer.swift
+++ b/Sources/GatewayApp/GatewayServer.swift
@@ -120,13 +120,6 @@ public final class GatewayServer {
                 }
             case ("POST", ["zones"]):
                 response = await self.createZone(request)
-            case ("POST", ["zones", "reload"]):
-                if let manager = zoneManager {
-                    await manager.reload()
-                    response = HTTPResponse(status: 204)
-                } else {
-                    response = HTTPResponse(status: 500)
-                }
             case ("DELETE", let seg) where seg.count == 2 && seg[0] == "zones":
                 let zoneId = String(seg[1])
                 response = await self.deleteZone(zoneId)

--- a/Tests/IntegrationRuntimeTests/GatewayServerTests.swift
+++ b/Tests/IntegrationRuntimeTests/GatewayServerTests.swift
@@ -369,26 +369,6 @@ aAhFmOl1mcUedOydNA87ZDbQXd7VqSw5mi4cqymNnbpPfjjsy9vG/+xqCMFdnFQd
     }
 
     @MainActor
-    func testReloadEndpointTriggersZoneManager() async throws {
-        let dir = FileManager.default.temporaryDirectory
-        let file = dir.appendingPathComponent(UUID().uuidString)
-        try "example.com: 1.1.1.1\n".write(to: file, atomically: true, encoding: .utf8)
-        let zoneManager = try ZoneManager(fileURL: file)
-        let manager = CertificateManager(scriptPath: "/usr/bin/true", interval: 3600)
-        let server = GatewayServer(manager: manager, plugins: [], zoneManager: zoneManager)
-        Task { try await server.start(port: 9112) }
-        try await Task.sleep(nanoseconds: 100_000_000)
-        try "example.com: 2.2.2.2\n".write(to: file, atomically: true, encoding: .utf8)
-        var request = URLRequest(url: URL(string: "http://127.0.0.1:9112/zones/reload")!)
-        request.httpMethod = "POST"
-        let (_, response) = try await URLSession.shared.data(for: request)
-        XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 204)
-        let ip = await zoneManager.ip(for: "example.com")
-        XCTAssertEqual(ip, "2.2.2.2")
-        try await server.stop()
-    }
-
-    @MainActor
     func testAuthTokenEndpointResponds() async throws {
         setenv("GATEWAY_CRED_admin", "s3cr3t", 1)
         setenv("GATEWAY_JWT_SECRET", "topsecret", 1)


### PR DESCRIPTION
## Summary
- drop `POST /zones/reload` from GatewayServer to keep zone reload private
- update integration tests to reflect absence of runtime zone reload endpoint

## Testing
- `swift test` *(fails: fatalError)*

------
https://chatgpt.com/codex/tasks/task_b_6899d23283e883338e589f10bbd4e0a4