### PR TITLE
feat: support AAAA and CNAME records

### DIFF
--- a/Sources/FountainCodex/DNSEngine.swift
+++ b/Sources/FountainCodex/DNSEngine.swift
@@ -2,22 +2,53 @@ import NIOCore
 import Logging
 import NIOConcurrencyHelpers
 import Foundation
+#if os(Linux)
+import Glibc
+#else
+import Darwin
+#endif
 
-/// Minimal DNS engine capable of parsing A record queries and responding from an in-memory zone cache.
+/// Minimal DNS engine capable of parsing A, AAAA and CNAME record queries and responding from an in-memory zone cache.
 public struct DNSEngine {
-    /// Thread-safe mapping of fully qualified domain names to IPv4 addresses.
-    private let zoneCache: NIOLockedValueBox<[String: String]>
+    public struct Record: Sendable {
+        public let name: String
+        public let type: String
+        public let value: String
+        public init(name: String, type: String, value: String) {
+            self.name = name
+            self.type = type
+            self.value = value
+        }
+    }
+
+    struct Key: Hashable {
+        let name: String
+        let type: String
+    }
+
+    /// Thread-safe mapping of fully qualified domain names and types to records.
+    private let zoneCache: NIOLockedValueBox<[Key: Record]>
     private let logger = Logger(label: "DNSEngine")
     /// Optional DNSSEC signer used for zone signing and verification.
     private let signer: DNSSECSigner?
 
-    /// Creates a new engine with the provided zone cache.
+    /// Creates a new engine with the provided records.
     /// - Parameters:
-    ///   - zoneCache: Dictionary of domain names to IPv4 addresses.
+    ///   - records: Array of ``Record`` entries.
     ///   - signer: Optional ``DNSSECSigner`` for zone signing.
-    public init(zoneCache: [String: String], signer: DNSSECSigner? = nil) {
-        self.zoneCache = NIOLockedValueBox(zoneCache)
+    public init(records: [Record], signer: DNSSECSigner? = nil) {
+        var map: [Key: Record] = [:]
+        for record in records {
+            map[Key(name: record.name, type: record.type)] = record
+        }
+        self.zoneCache = NIOLockedValueBox(map)
         self.signer = signer
+    }
+
+    /// Convenience initializer for legacy IPv4 caches.
+    public init(zoneCache: [String: String], signer: DNSSECSigner? = nil) {
+        let records = zoneCache.map { Record(name: $0.key, type: "A", value: $0.value) }
+        self.init(records: records, signer: signer)
     }
 
     /// Creates a new engine from a ``ZoneManager`` instance.
@@ -27,17 +58,17 @@ public struct DNSEngine {
     @MainActor
     public init(zoneManager: ZoneManager, signer: DNSSECSigner? = nil) async {
         let records = await zoneManager.allRecords()
-        var cache: [String: String] = [:]
-        for (name, record) in records where record.type == "A" {
-            cache[name] = record.value
+        var cache: [Key: Record] = [:]
+        for (key, record) in records {
+            cache[Key(name: key.name, type: key.type)] = Record(name: key.name, type: record.type, value: record.value)
         }
         self.zoneCache = NIOLockedValueBox(cache)
         self.signer = signer
     }
 
     /// Updates or inserts a record in the zone cache.
-    public func updateRecord(name: String, ip: String) {
-        zoneCache.withLockedValue { $0[name] = ip }
+    public func updateRecord(name: String, type: String, value: String) {
+        zoneCache.withLockedValue { $0[Key(name: name, type: type)] = Record(name: name, type: type, value: value) }
     }
 
     /// Generates a signature for the current zone if a signer is configured.
@@ -45,7 +76,7 @@ public struct DNSEngine {
     public func signZone() throws -> Data? {
         guard let signer else { return nil }
         let zone = zoneCache.withLockedValue { cache in
-            cache.map { "\($0.key) \($0.value)" }.sorted().joined(separator: "\n")
+            cache.map { "\($0.key.name) \($0.key.type) \($0.value.value)" }.sorted().joined(separator: "\n")
         }
         return try signer.sign(zone: zone)
     }
@@ -56,7 +87,7 @@ public struct DNSEngine {
     public func verifyZone(signature: Data) -> Bool? {
         guard let signer else { return nil }
         let zone = zoneCache.withLockedValue { cache in
-            cache.map { "\($0.key) \($0.value)" }.sorted().joined(separator: "\n")
+            cache.map { "\($0.key.name) \($0.key.type) \($0.value.value)" }.sorted().joined(separator: "\n")
         }
         return signer.verify(zone: zone, signature: signature)
     }
@@ -67,15 +98,15 @@ public struct DNSEngine {
     public func handleQuery(buffer: inout ByteBuffer) -> ByteBuffer? {
         guard let parser = DNSParser(buffer: &buffer) else {
             logger.warning("Failed to parse query")
-            Task { await DNSMetrics.shared.record(query: "invalid", hit: false) }
+            Task { await DNSMetrics.shared.record(query: "invalid", type: "invalid", hit: false) }
             return nil
         }
         let response = zoneCache.withLockedValue { cache -> ByteBuffer? in
-            guard let ip = cache[parser.name] else { return nil }
-            return parser.makeResponse(ip: ip)
+            guard let record = cache[Key(name: parser.name, type: parser.typeName)] else { return nil }
+            return parser.makeResponse(record: record)
         }
-        Task { await DNSMetrics.shared.record(query: parser.name, hit: response != nil) }
-        logger.info("dns_query", metadata: ["name": .string(parser.name), "hit": .string(String(response != nil))])
+        Task { await DNSMetrics.shared.record(query: parser.name, type: parser.typeName, hit: response != nil) }
+        logger.info("dns_query", metadata: ["name": .string(parser.name), "type": .string(parser.typeName), "hit": .string(String(response != nil))])
         return response
     }
 }
@@ -84,6 +115,7 @@ public struct DNSEngine {
 struct DNSParser {
     let id: UInt16
     let name: String
+    let qtype: UInt16
 
     init?(buffer: inout ByteBuffer) {
         guard buffer.readableBytes >= 12,
@@ -99,13 +131,22 @@ struct DNSParser {
             }
             labels.append(label)
         }
-        // Skip QTYPE and QCLASS
-        guard buffer.readInteger(as: UInt16.self) != nil,
+        guard let qtype: UInt16 = buffer.readInteger(as: UInt16.self),
               buffer.readInteger(as: UInt16.self) != nil else { return nil }
+        self.qtype = qtype
         self.name = labels.joined(separator: ".")
     }
 
-    func makeResponse(ip: String) -> ByteBuffer? {
+    var typeName: String {
+        switch qtype {
+        case 1: return "A"
+        case 5: return "CNAME"
+        case 28: return "AAAA"
+        default: return "UNKNOWN"
+        }
+    }
+
+    func makeResponse(record: DNSEngine.Record) -> ByteBuffer? {
         var buf = ByteBufferAllocator().buffer(capacity: 512)
         buf.writeInteger(id, as: UInt16.self)
         buf.writeInteger(UInt16(0x8180), as: UInt16.self) // standard response
@@ -121,19 +162,43 @@ struct DNSParser {
             buf.writeBytes(bytes)
         }
         buf.writeInteger(UInt8(0), as: UInt8.self)
-        buf.writeInteger(UInt16(1), as: UInt16.self) // QTYPE A
+        buf.writeInteger(qtype, as: UInt16.self)
         buf.writeInteger(UInt16(1), as: UInt16.self) // QCLASS IN
 
         // answer section
         buf.writeInteger(UInt16(0xC00C), as: UInt16.self) // pointer to name at offset 12
-        buf.writeInteger(UInt16(1), as: UInt16.self) // TYPE A
+        let typeCode = qtype
+        buf.writeInteger(typeCode, as: UInt16.self)
         buf.writeInteger(UInt16(1), as: UInt16.self) // CLASS IN
         buf.writeInteger(UInt32(300), as: UInt32.self) // TTL
-        buf.writeInteger(UInt16(4), as: UInt16.self) // RDLENGTH
 
-        let octets = ip.split(separator: ".").compactMap { UInt8($0) }
-        guard octets.count == 4 else { return nil }
-        buf.writeBytes(octets)
+        switch record.type {
+        case "A":
+            let octets = record.value.split(separator: ".").compactMap { UInt8($0) }
+            guard octets.count == 4 else { return nil }
+            buf.writeInteger(UInt16(4), as: UInt16.self)
+            buf.writeBytes(octets)
+        case "AAAA":
+            var addr = in6_addr()
+            let res = record.value.withCString { inet_pton(AF_INET6, $0, &addr) }
+            guard res == 1 else { return nil }
+            let bytes = withUnsafeBytes(of: &addr) { Array($0) }
+            buf.writeInteger(UInt16(bytes.count), as: UInt16.self)
+            buf.writeBytes(bytes)
+        case "CNAME":
+            var rdata = ByteBufferAllocator().buffer(capacity: 256)
+            for label in record.value.split(separator: ".") {
+                let bytes = Array(label.utf8)
+                rdata.writeInteger(UInt8(bytes.count), as: UInt8.self)
+                rdata.writeBytes(bytes)
+            }
+            rdata.writeInteger(UInt8(0), as: UInt8.self)
+            buf.writeInteger(UInt16(rdata.readableBytes), as: UInt16.self)
+            buf.writeBuffer(&rdata)
+        default:
+            return nil
+        }
+
         return buf
     }
 }

--- a/Sources/FountainCodex/DNSMetrics.swift
+++ b/Sources/FountainCodex/DNSMetrics.swift
@@ -8,11 +8,15 @@ public actor DNSMetrics {
     private var misses = 0
     private var rateLimitAllowed = 0
     private var rateLimitThrottled = 0
+    private var queriesByType: [String: Int] = [:]
+    private var hitsByType: [String: Int] = [:]
 
-    public func record(query name: String, hit: Bool) {
+    public func record(query name: String, type: String, hit: Bool) {
         queries += 1
+        queriesByType[type, default: 0] += 1
         if hit {
             hits += 1
+            hitsByType[type, default: 0] += 1
         } else {
             misses += 1
         }
@@ -27,13 +31,18 @@ public actor DNSMetrics {
     }
 
     public func exposition() -> String {
-        """
-        dns_queries_total \(queries)
-        dns_hits_total \(hits)
-        dns_misses_total \(misses)
-        gateway_rate_limit_allowed_total \(rateLimitAllowed)
-        gateway_rate_limit_throttled_total \(rateLimitThrottled)
-        """
+        var lines = [
+            "dns_queries_total \(queries)",
+            "dns_hits_total \(hits)",
+            "dns_misses_total \(misses)",
+            "gateway_rate_limit_allowed_total \(rateLimitAllowed)",
+            "gateway_rate_limit_throttled_total \(rateLimitThrottled)"
+        ]
+        for key in queriesByType.keys.sorted() {
+            lines.append("dns_queries_type_\(key)_total \(queriesByType[key] ?? 0)")
+            lines.append("dns_hits_type_\(key)_total \(hitsByType[key] ?? 0)")
+        }
+        return lines.joined(separator: "\n")
     }
 
     public func reset() {
@@ -42,6 +51,8 @@ public actor DNSMetrics {
         misses = 0
         rateLimitAllowed = 0
         rateLimitThrottled = 0
+        queriesByType = [:]
+        hitsByType = [:]
     }
 }
 

--- a/Sources/FountainCodex/ZoneManager.swift
+++ b/Sources/FountainCodex/ZoneManager.swift
@@ -16,6 +16,15 @@ public actor ZoneManager {
         public var value: String
     }
 
+    public struct RecordKey: Hashable, Sendable {
+        public let name: String
+        public let type: String
+        public init(name: String, type: String) {
+            self.name = name
+            self.type = type
+        }
+    }
+
     public struct Zone: Codable, Sendable {
         public let id: UUID
         public var name: String
@@ -97,23 +106,18 @@ public actor ZoneManager {
         return true
     }
 
-    /// Returns the IPv4 address associated with the given domain name.
-    /// - Parameter name: Fully qualified domain name.
-    /// - Returns: The IPv4 address string if present.
-    public func ip(for name: String) -> String? {
-        if let record = allRecords()[name], record.type == "A" {
-            return record.value
-        }
-        return nil
+    /// Retrieves a record for the given fully qualified name and type.
+    public func record(name: String, type: String) -> Record? {
+        allRecords()[RecordKey(name: name, type: type)]
     }
 
-    /// Returns the current in-memory zone cache as a flattened map keyed by FQDN.
-    public func allRecords() -> [String: Record] {
-        var map: [String: Record] = [:]
+    /// Returns the current in-memory zone cache as a flattened map keyed by name and type.
+    public func allRecords() -> [RecordKey: Record] {
+        var map: [RecordKey: Record] = [:]
         for zone in zones.values {
             for record in zone.records.values {
                 let fqdn = record.name.isEmpty ? zone.name : "\(record.name).\(zone.name)"
-                map[fqdn] = record
+                map[RecordKey(name: fqdn, type: record.type)] = record
             }
         }
         return map

--- a/Tests/DNSTests/DNSEngineTests.swift
+++ b/Tests/DNSTests/DNSEngineTests.swift
@@ -4,7 +4,7 @@ import NIOEmbedded
 @testable import FountainCodex
 
 final class DNSEngineTests: XCTestCase {
-    func makeQuery(name: String) -> ByteBuffer {
+    func makeQuery(name: String, type: UInt16) -> ByteBuffer {
         var buf = ByteBufferAllocator().buffer(capacity: 512)
         buf.writeInteger(UInt16(0x1234), as: UInt16.self)
         buf.writeInteger(UInt16(0), as: UInt16.self)
@@ -18,14 +18,14 @@ final class DNSEngineTests: XCTestCase {
             buf.writeBytes(bytes)
         }
         buf.writeInteger(UInt8(0), as: UInt8.self)
-        buf.writeInteger(UInt16(1), as: UInt16.self)
+        buf.writeInteger(type, as: UInt16.self)
         buf.writeInteger(UInt16(1), as: UInt16.self)
         return buf
     }
 
     func testRespondsWithARecordFromCache() {
-        var query = makeQuery(name: "example.com")
-        let engine = DNSEngine(zoneCache: ["example.com": "1.2.3.4"])
+        var query = makeQuery(name: "example.com", type: 1)
+        let engine = DNSEngine(records: [.init(name: "example.com", type: "A", value: "1.2.3.4")])
         guard var response = engine.handleQuery(buffer: &query) else {
             XCTFail("Expected response")
             return
@@ -38,30 +38,65 @@ final class DNSEngineTests: XCTestCase {
         XCTAssertEqual([ip1, ip2, ip3, ip4], [1, 2, 3, 4])
     }
 
+    func testRespondsWithAAAARecordFromCache() {
+        var query = makeQuery(name: "ipv6.com", type: 28)
+        let engine = DNSEngine(records: [.init(name: "ipv6.com", type: "AAAA", value: "2001:db8::1")])
+        guard var response = engine.handleQuery(buffer: &query) else {
+            XCTFail("Expected response")
+            return
+        }
+        response.moveReaderIndex(forwardBy: response.readableBytes - 16)
+        var bytes: [UInt8] = []
+        for _ in 0..<16 { bytes.append(response.readInteger(as: UInt8.self)!) }
+        XCTAssertEqual(bytes.count, 16)
+    }
+
+    func testRespondsWithCNAMERecordFromCache() {
+        var query = makeQuery(name: "alias.com", type: 5)
+        let engine = DNSEngine(records: [.init(name: "alias.com", type: "CNAME", value: "target.com")])
+        guard var response = engine.handleQuery(buffer: &query) else {
+            XCTFail("Expected response")
+            return
+        }
+        let data = response.readBytes(length: response.readableBytes) ?? []
+        let target = Array("target".utf8)
+        let hasTarget = data.windows(ofCount: target.count).contains { Array($0) == target }
+        XCTAssertTrue(hasTarget)
+    }
+
     func testUnknownRecordReturnsNil() {
-        var query = makeQuery(name: "unknown.com")
-        let engine = DNSEngine(zoneCache: ["example.com": "1.2.3.4"])
+        var query = makeQuery(name: "unknown.com", type: 1)
+        let engine = DNSEngine(records: [.init(name: "example.com", type: "A", value: "1.2.3.4")])
         XCTAssertNil(engine.handleQuery(buffer: &query))
     }
 
     func testHandlerResolvesViaEmbeddedChannel() throws {
-        let engine = DNSEngine(zoneCache: ["example.com": "1.2.3.4"])
+        let engine = DNSEngine(records: [.init(name: "example.com", type: "A", value: "1.2.3.4")])
         let channel = EmbeddedChannel(handler: DNSHandler(engine: engine))
-        let query = makeQuery(name: "example.com")
+        let query = makeQuery(name: "example.com", type: 1)
         try channel.writeInbound(query)
         let response: ByteBuffer? = try channel.readOutbound()
         XCTAssertNotNil(response)
     }
 
-    func testMetricsRecorded() async throws {
+    func testMetricsRecordedPerType() async throws {
         await DNSMetrics.shared.reset()
-        var query = makeQuery(name: "example.com")
-        let engine = DNSEngine(zoneCache: ["example.com": "1.2.3.4"])
-        _ = engine.handleQuery(buffer: &query)
+        var q1 = makeQuery(name: "example.com", type: 1)
+        var q2 = makeQuery(name: "ipv6.com", type: 28)
+        var q3 = makeQuery(name: "alias.com", type: 5)
+        let engine = DNSEngine(records: [
+            .init(name: "example.com", type: "A", value: "1.2.3.4"),
+            .init(name: "ipv6.com", type: "AAAA", value: "2001:db8::1"),
+            .init(name: "alias.com", type: "CNAME", value: "target.com")
+        ])
+        _ = engine.handleQuery(buffer: &q1)
+        _ = engine.handleQuery(buffer: &q2)
+        _ = engine.handleQuery(buffer: &q3)
         await Task.yield()
         let text = await DNSMetrics.shared.exposition()
-        XCTAssertTrue(text.contains("dns_queries_total 1"))
-        XCTAssertTrue(text.contains("dns_hits_total 1"))
+        XCTAssertTrue(text.contains("dns_queries_type_A_total 1"))
+        XCTAssertTrue(text.contains("dns_hits_type_AAAA_total 1"))
+        XCTAssertTrue(text.contains("dns_hits_type_CNAME_total 1"))
     }
 }
 


### PR DESCRIPTION
## Summary
- refactor DNSEngine to store typed records and encode AAAA/CNAME answers
- persist heterogeneous DNS records and retrieval helpers in ZoneManager
- track per-type DNS metrics and extend tests for AAAA and CNAME

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_b_6899da734494833382579703eb4638c8