### PR TITLE
Add DNS server and integration tests

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -65,7 +65,7 @@ let package = Package(
         .testTarget(name: "FountainCoreTests", dependencies: ["FountainCore"], path: "Tests/FountainCoreTests"),
         .testTarget(name: "ClientGeneratorTests", dependencies: ["FountainCodex"], path: "Tests/ClientGeneratorTests"),
         .testTarget(name: "PublishingFrontendTests", dependencies: ["PublishingFrontend"], path: "Tests/PublishingFrontendTests"),
-        .testTarget(name: "DNSTests", dependencies: ["PublishingFrontend", "FountainCodex", .product(name: "Crypto", package: "swift-crypto"), .product(name: "NIOEmbedded", package: "swift-nio")], path: "Tests/DNSTests"),
+        .testTarget(name: "DNSTests", dependencies: ["PublishingFrontend", "FountainCodex", .product(name: "Crypto", package: "swift-crypto"), .product(name: "NIOEmbedded", package: "swift-nio"), .product(name: "NIO", package: "swift-nio")], path: "Tests/DNSTests"),
         .testTarget(name: "IntegrationRuntimeTests", dependencies: ["gateway-server", "FountainCodex"], path: "Tests/IntegrationRuntimeTests"),
         .testTarget(name: "DNSPerfTests", dependencies: ["FountainCodex", .product(name: "NIOCore", package: "swift-nio")], path: "Tests/DNSPerfTests")
     ]

--- a/Sources/FountainCodex/DNSHandler.swift
+++ b/Sources/FountainCodex/DNSHandler.swift
@@ -1,6 +1,6 @@
 import NIOCore
 
-final class DNSHandler: ChannelInboundHandler {
+final class DNSHandler: ChannelInboundHandler, @unchecked Sendable {
     typealias InboundIn = ByteBuffer
     typealias OutboundOut = ByteBuffer
 

--- a/Sources/FountainCodex/DNSServer.swift
+++ b/Sources/FountainCodex/DNSServer.swift
@@ -1,0 +1,111 @@
+import NIOCore
+import NIOPosix
+
+/// NIO-based DNS server booting UDP and optional TCP listeners.
+public final class DNSServer: @unchecked Sendable {
+    private let group: EventLoopGroup
+    private let engine: DNSEngine
+    private var udpChannel: Channel?
+    private var tcpChannel: Channel?
+
+    /// Creates a server bound to the provided ``ZoneManager``.
+    /// - Parameters:
+    ///   - zoneManager: Actor supplying DNS records.
+    ///   - signer: Optional DNSSEC signer for the engine.
+    ///   - group: Event loop group powering the server. Defaults to a single-threaded group.
+    public init(zoneManager: ZoneManager, signer: DNSSECSigner? = nil, group: EventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)) async {
+        self.group = group
+        self.engine = await DNSEngine(zoneManager: zoneManager, signer: signer)
+    }
+
+    /// Starts the UDP server and optionally a TCP server.
+    /// - Parameters:
+    ///   - udpPort: UDP port to bind to.
+    ///   - tcpPort: Optional TCP port; when provided a TCP listener is started.
+    /// - Returns: The bound UDP port.
+    @discardableResult
+    public func start(udpPort: Int, tcpPort: Int? = nil) async throws -> Int {
+        let udpBootstrap = DatagramBootstrap(group: group)
+            .channelInitializer { channel in
+                channel.pipeline.addHandler(DatagramCodec()).flatMap {
+                    channel.pipeline.addHandler(DNSHandler(engine: self.engine))
+                }
+            }
+        self.udpChannel = try await udpBootstrap.bind(host: "127.0.0.1", port: udpPort).get()
+        if let tcpPort {
+            let tcpBootstrap = ServerBootstrap(group: group)
+                .childChannelInitializer { channel in
+                    channel.pipeline.addHandler(ByteToMessageHandler(TCPFrameDecoder())).flatMap {
+                        channel.pipeline.addHandler(TCPFrameEncoder())
+                    }.flatMap {
+                        channel.pipeline.addHandler(DNSHandler(engine: self.engine))
+                    }
+                }
+            self.tcpChannel = try await tcpBootstrap.bind(host: "127.0.0.1", port: tcpPort).get()
+        }
+        return self.udpChannel?.localAddress?.port ?? udpPort
+    }
+
+    /// Shuts down the server and releases resources.
+    public func stop() async throws {
+        try await udpChannel?.close().get()
+        try await tcpChannel?.close().get()
+        try await group.shutdownGracefully()
+    }
+}
+
+/// UDP datagram codec translating `AddressedEnvelope` packets for ``DNSHandler``.
+private final class DatagramCodec: ChannelDuplexHandler, @unchecked Sendable {
+    typealias InboundIn = AddressedEnvelope<ByteBuffer>
+    typealias InboundOut = ByteBuffer
+    typealias OutboundIn = ByteBuffer
+    typealias OutboundOut = AddressedEnvelope<ByteBuffer>
+    private var remoteAddress: SocketAddress?
+
+    func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+        let envelope = self.unwrapInboundIn(data)
+        remoteAddress = envelope.remoteAddress
+        context.fireChannelRead(self.wrapInboundOut(envelope.data))
+    }
+
+    func write(context: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {
+        let buffer = self.unwrapOutboundIn(data)
+        if let addr = remoteAddress {
+            remoteAddress = nil
+            let envelope = AddressedEnvelope(remoteAddress: addr, data: buffer)
+            context.write(self.wrapOutboundOut(envelope), promise: promise)
+        } else {
+            promise?.succeed(())
+        }
+    }
+}
+
+/// Decoder for TCP DNS length-prefixed frames.
+private final class TCPFrameDecoder: ByteToMessageDecoder, @unchecked Sendable {
+    typealias InboundOut = ByteBuffer
+    func decode(context: ChannelHandlerContext, buffer: inout ByteBuffer) throws -> DecodingState {
+        guard let length: UInt16 = buffer.getInteger(at: buffer.readerIndex) else { return .needMoreData }
+        let total = Int(length) + 2
+        guard buffer.readableBytes >= total else { return .needMoreData }
+        buffer.moveReaderIndex(forwardBy: 2)
+        if let slice = buffer.readSlice(length: Int(length)) {
+            context.fireChannelRead(self.wrapInboundOut(slice))
+        }
+        return .continue
+    }
+}
+
+/// Encoder for TCP DNS length-prefixed frames.
+private final class TCPFrameEncoder: ChannelOutboundHandler, @unchecked Sendable {
+    typealias OutboundIn = ByteBuffer
+    typealias OutboundOut = ByteBuffer
+    func write(context: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {
+        var buf = context.channel.allocator.buffer(capacity: 2)
+        var bytes = self.unwrapOutboundIn(data)
+        buf.writeInteger(UInt16(bytes.readableBytes), as: UInt16.self)
+        buf.writeBuffer(&bytes)
+        context.write(self.wrapOutboundOut(buf), promise: promise)
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/GatewayApp/main.swift
+++ b/Sources/GatewayApp/main.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Dispatch
 import PublishingFrontend
+import FountainCodex
 
 /// Launches ``GatewayServer`` with the publishing plugin enabled.
 /// The server stays running until the process is terminated.
@@ -9,9 +10,22 @@ let publishingConfig = try? loadPublishingConfig()
 if publishingConfig == nil {
     FileHandle.standardError.write(Data("[gateway] Warning: failed to load Configuration/publishing.yml; using defaults for static content.\n".utf8))
 }
+
 let server = GatewayServer(plugins: [LoggingPlugin(), PublishingFrontendPlugin(rootPath: publishingConfig?.rootPath ?? "./Public")])
 Task { @MainActor in
     try await server.start(port: 8080)
+}
+
+if CommandLine.arguments.contains("--dns") {
+    Task {
+        let zoneURL = URL(fileURLWithPath: "Configuration/zones.yml")
+        if let manager = try? ZoneManager(fileURL: zoneURL) {
+            let dns = await DNSServer(zoneManager: manager)
+            try? await dns.start(udpPort: 1053)
+        } else {
+            FileHandle.standardError.write(Data("[gateway] Warning: failed to initialize ZoneManager\n".utf8))
+        }
+    }
 }
 
 dispatchMain()

--- a/Tests/DNSTests/DNSServerTests.swift
+++ b/Tests/DNSTests/DNSServerTests.swift
@@ -1,0 +1,90 @@
+import XCTest
+import Foundation
+import NIOCore
+import NIOPosix
+@testable import FountainCodex
+
+final class DNSServerTests: XCTestCase {
+    static func makeQuery(name: String) -> ByteBuffer {
+        var buf = ByteBufferAllocator().buffer(capacity: 512)
+        buf.writeInteger(UInt16(0x1234), as: UInt16.self)
+        buf.writeInteger(UInt16(0), as: UInt16.self)
+        buf.writeInteger(UInt16(1), as: UInt16.self)
+        buf.writeInteger(UInt16(0), as: UInt16.self)
+        buf.writeInteger(UInt16(0), as: UInt16.self)
+        buf.writeInteger(UInt16(0), as: UInt16.self)
+        for label in name.split(separator: ".") {
+            let bytes = Array(label.utf8)
+            buf.writeInteger(UInt8(bytes.count), as: UInt8.self)
+            buf.writeBytes(bytes)
+        }
+        buf.writeInteger(UInt8(0), as: UInt8.self)
+        buf.writeInteger(UInt16(1), as: UInt16.self)
+        buf.writeInteger(UInt16(1), as: UInt16.self)
+        return buf
+    }
+
+    static func extractIPv4(_ buf: ByteBuffer) -> String? {
+        guard buf.readableBytes >= 4 else { return nil }
+        let start = buf.readerIndex + buf.readableBytes - 4
+        guard let b1: UInt8 = buf.getInteger(at: start),
+              let b2: UInt8 = buf.getInteger(at: start + 1),
+              let b3: UInt8 = buf.getInteger(at: start + 2),
+              let b4: UInt8 = buf.getInteger(at: start + 3) else { return nil }
+        return "\(b1).\(b2).\(b3).\(b4)"
+    }
+
+    func testServerRespondsToUDPQueries() async throws {
+        let tmp = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let manager = try ZoneManager(fileURL: tmp, enableGitCommits: false)
+        let zone = try await manager.createZone(name: "example.com")
+        let rec = try await manager.createRecord(zoneId: zone.id, name: "", type: "A", value: "1.2.3.4")
+        let server = await DNSServer(zoneManager: manager)
+        let port = try await server.start(udpPort: 0)
+
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        var query = Self.makeQuery(name: "example.com")
+        let promise = group.next().makePromise(of: ByteBuffer.self)
+        var client = try await DatagramBootstrap(group: group)
+            .channelInitializer { channel in
+                channel.pipeline.addHandler(ResponseHandler(promise: promise))
+            }
+            .bind(host: "127.0.0.1", port: 0).get()
+        let envelope = try AddressedEnvelope(remoteAddress: SocketAddress(ipAddress: "127.0.0.1", port: port), data: query)
+        try await client.writeAndFlush(envelope).get()
+        var response = try await promise.futureResult.get()
+        XCTAssertEqual(Self.extractIPv4(response), "1.2.3.4")
+
+        // update record and ensure server reflects change
+        _ = try await manager.updateRecord(zoneId: zone.id, recordId: rec!.id, name: "", type: "A", value: "5.6.7.8")
+        try await Task.sleep(nanoseconds: 200_000_000)
+        try await client.close().get()
+        let promise2 = group.next().makePromise(of: ByteBuffer.self)
+        client = try await DatagramBootstrap(group: group)
+            .channelInitializer { channel in
+                channel.pipeline.addHandler(ResponseHandler(promise: promise2))
+            }
+            .bind(host: "127.0.0.1", port: 0).get()
+        query = Self.makeQuery(name: "example.com")
+        let env2 = try AddressedEnvelope(remoteAddress: SocketAddress(ipAddress: "127.0.0.1", port: port), data: query)
+        try await client.writeAndFlush(env2).get()
+        response = try await promise2.futureResult.get()
+        XCTAssertEqual(Self.extractIPv4(response), "5.6.7.8")
+
+        try await client.close().get()
+        try await server.stop()
+        try await group.shutdownGracefully()
+    }
+
+    final class ResponseHandler: ChannelInboundHandler, @unchecked Sendable {
+        typealias InboundIn = AddressedEnvelope<ByteBuffer>
+        let promise: EventLoopPromise<ByteBuffer>
+        init(promise: EventLoopPromise<ByteBuffer>) { self.promise = promise }
+        func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+            let env = unwrapInboundIn(data)
+            promise.succeed(env.data)
+        }
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- add NIO-based DNSServer booting UDP and optional TCP pipelines
- stream ZoneManager changes into DNSEngine cache
- allow `gateway-server` to launch DNS server via `--dns`
- exercise DNS responses end-to-end through new integration test

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_b_6899e00ce460833388f3c68b6c062cde