### PR TITLE
Add SPS sample PDFs and usage guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ Operational assets like Dockerfiles and OpenAPI specifications live under [`Sour
 
 ![image_gen: Flow from OpenAPI specs to generated clients and server binaries]
 
+#### Semantic PDF Scanner (SPS)
+Command-line tool for extracting text and tables from PDFs. Supports page range queries and validation hooks for Midi2Swift.
+See [SPS Usage Guide](docs/sps-usage-guide.md) for end-to-end examples.
+
 ### Design Patterns
 The project adopts several common patterns which can be seen in the implementation files:
 

--- a/agent.md
+++ b/agent.md
@@ -1,6 +1,6 @@
 # 🧠 Repository Agent Manifest
 
-**Last Updated:** August 06, 2025
+**Last Updated:** August 11, 2025
 **Scope:** Full-repository self-improvement and orchestration  
 **Purpose:** Serve as a machine-actionable contract and coordination center for Codex-driven implementation, testing, and maintenance across all project modules.
 
@@ -45,6 +45,7 @@ This agent maintains an up-to-date view of outstanding development tasks across 
 | opId→handler audit | repo-wide | Script to diff specs vs code | ✅ | — | tooling, docs |
 | Spec↔code drift | specs & servers | Track/close gaps per service | ✅ | — | process |
 | SPS validation hooks | `sps/Sources/Validation/*`, `sps/Sources/SPSCLI/main.swift` | Add coverage + reserved-bit checks | ✅ | — | sps |
+| SPS samples & usage docs | `sps/Samples`, `docs/sps-usage-guide.md` | Provide annotated sample PDFs and usage guide with page-range queries & validation hooks | ✅ | — | docs, sps |
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,6 +32,7 @@ As modules gain documentation, brief summaries are added here.
 - **publishing-frontend CLI** – documented main entrypoint starting the static server.
 - **clientgen-service CLI** – wrapper around GeneratorCLI is now documented.
 - **gateway-server CLI** – documented gateway server entrypoint exposing the HTTP gateway.
+ - **SPS CLI** – [usage guide](sps-usage-guide.md) covers page range queries, validation hooks, and sample PDFs.
 - **GatewayServerTests** – verifies the gateway's health endpoint.
 - **GatewayServer** – documentation now covers health and metrics endpoints.
 - **Service** and **Supervisor** – properties and lifecycle methods documented.

--- a/docs/sps-usage-guide.md
+++ b/docs/sps-usage-guide.md
@@ -1,0 +1,28 @@
+# SPS Usage Guide
+
+This guide demonstrates end-to-end workflows with the Semantic PDF Scanner CLI, including page range queries and validation hooks.
+
+## 1. Scan PDFs into an index
+```bash
+swift build -c release
+.build/release/sps scan sps/Samples/extraction_sample.pdf sps/Samples/table_detection_sample.pdf --out index.json --include-text --page-range 1-2
+```
+
+## 2. Validate the generated index
+```bash
+.build/release/sps index validate index.json
+```
+
+## 3. Query the index with page ranges
+```bash
+.build/release/sps query index.json --q "annotated" --page-range 1
+```
+
+## 4. Export a matrix with validation hooks
+```bash
+.build/release/sps export-matrix index.json --out matrix.json --validate
+```
+The `--page-range` flag accepts comma-separated ranges such as `1-3,5`,
+while `--validate` emits `matrix.json.validation.json` summarizing coverage and reserved-bit checks.
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/sps/Samples/README.md
+++ b/sps/Samples/README.md
@@ -1,0 +1,8 @@
+# SPS Sample PDFs
+
+This directory provides small, annotated PDFs used for demonstrating text extraction and table detection.
+
+- `extraction_sample.pdf` – highlights an annotated text snippet for extraction pipelines.
+- `table_detection_sample.pdf` – contains a simple table for detector evaluation.
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/sps/Samples/extraction_sample.pdf
+++ b/sps/Samples/extraction_sample.pdf
@@ -1,0 +1,81 @@
+%PDF-1.4
+% ReportLab Generated PDF document http://www.reportlab.com
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /ZapfDingbats /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/Contents 8 0 R /MediaBox [ 0 0 612 792 ] /Parent 7 0 R /Resources <<
+/ExtGState <<
+/gRLs0 <<
+/ca .5
+>>
+>> /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/PageMode /UseNone /Pages 7 0 R /Type /Catalog
+>>
+endobj
+6 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20250811162741+00'00') /Creator (ReportLab PDF Library - www.reportlab.com) /Keywords () /ModDate (D:20250811162741+00'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (unspecified) /Title (untitled) /Trapped /False
+>>
+endobj
+7 0 obj
+<<
+/Count 1 /Kids [ 4 0 R ] /Type /Pages
+>>
+endobj
+8 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 259
+>>
+stream
+Gar'#4`A1k&;GE/MK_`3LsLb&Nhn$86WJEu@O63W&o>[u.XjR:`R(@V)Xd%(HO5jpC*([9?DHloUnAa,>BeFa*42A"P:"[P?cO]PAJ+Fc@7Ru43*q[tge,YFi^"p=*PPJ=')IPVcT^C\UB_SK67f"d&M>E_91`_D5)/_DoFLTZG5"44o3<HrC.hB$D=JZ7iC05D(2ku%2V?EL$4_MEc-\ON<njY[8PKKbcD0"rDp*anVn$?hP\p9)j561GY)gb%)?~>endstream
+endobj
+xref
+0 9
+0000000000 65535 f 
+0000000073 00000 n 
+0000000114 00000 n 
+0000000221 00000 n 
+0000000304 00000 n 
+0000000534 00000 n 
+0000000602 00000 n 
+0000000898 00000 n 
+0000000957 00000 n 
+trailer
+<<
+/ID 
+[<532290a194bb161974a796e4195b2529><532290a194bb161974a796e4195b2529>]
+% ReportLab generated PDF document -- digest (http://www.reportlab.com)
+
+/Info 6 0 R
+/Root 5 0 R
+/Size 9
+>>
+startxref
+1306
+%%EOF
+
+
+% © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/sps/Samples/table_detection_sample.pdf
+++ b/sps/Samples/table_detection_sample.pdf
@@ -1,0 +1,83 @@
+%PDF-1.4
+% ReportLab Generated PDF document http://www.reportlab.com
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R /F3 4 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/BaseFont /ZapfDingbats /Name /F3 /Subtype /Type1 /Type /Font
+>>
+endobj
+5 0 obj
+<<
+/Contents 9 0 R /MediaBox [ 0 0 612 792 ] /Parent 8 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+6 0 obj
+<<
+/PageMode /UseNone /Pages 8 0 R /Type /Catalog
+>>
+endobj
+7 0 obj
+<<
+/Author (\(anonymous\)) /CreationDate (D:20250811162741+00'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20250811162741+00'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (\(unspecified\)) /Title (\(anonymous\)) /Trapped /False
+>>
+endobj
+8 0 obj
+<<
+/Count 1 /Kids [ 5 0 R ] /Type /Pages
+>>
+endobj
+9 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 514
+>>
+stream
+GasIdbAMqd&A7TLHcR@i<6'1+,KHZR,#pc_%8njm:bW1^JX3gL^[Kkf+:(gfn7k(WnZob8-pGk&_\9i&LZsZsj5@tn";0QV_U>nW/64K2&"L1_AAkF_MOfIA=KR6h:8l&"]M\4+`crGmhGX_1Gf+Hi(D'.a6^?`c%JU1t-e`0b:Lh@\8d*km.Q_*<2Kp![=1geQ#AaF"0gZ'!U1]$0'8t'Tl?WNCCO'QV.Q*RR<MHTh*"YfA14C_DkVH2?Ha[$7-_b3je8IRpUP/2-0*u3JfCp4)i%m`L8YVaqoWF!ZaLU;hAq\T]SccEpXFpQN8tJ+T=&MLG<iAI9Q$pIB:hBR;`fe45V0Jn2q(PQPCLGkhoEqB'X5<:Y^tu&!N%ZkC8.B'6_SX^bBq7#ZAR(pmdMlasD/;93W^h]"U!_f[BO#c;pm'Udm$-7DT4^dq-s8fs-G^Q816YRU<3T'5j$&N60Y_\?RU%FS=bV'ai@[iu89T?&`dp+mi_)b:1N-\"!FKg+/H~>endstream
+endobj
+xref
+0 10
+0000000000 65535 f 
+0000000073 00000 n 
+0000000124 00000 n 
+0000000231 00000 n 
+0000000343 00000 n 
+0000000426 00000 n 
+0000000619 00000 n 
+0000000687 00000 n 
+0000000970 00000 n 
+0000001029 00000 n 
+trailer
+<<
+/ID 
+[<bdbe406d905e01b761176c112b8c7643><bdbe406d905e01b761176c112b8c7643>]
+% ReportLab generated PDF document -- digest (http://www.reportlab.com)
+
+/Info 7 0 R
+/Root 6 0 R
+/Size 10
+>>
+startxref
+1633
+%%EOF
+
+
+% © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- add annotated sample PDFs for extraction and table detection
- document SPS CLI workflows with page ranges and validation hooks
- update AGENT manifests and docs for new CLI options

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_b_689a190572388333b960fdd5e640a6eb