### PR TITLE
Scaffold MIDI 2 spec parsing via SPS

### DIFF
--- a/agent.md
+++ b/agent.md
@@ -46,6 +46,7 @@ This agent maintains an up-to-date view of outstanding development tasks across 
 | Spec↔code drift | specs & servers | Track/close gaps per service | ✅ | — | process |
 | SPS validation hooks | `sps/Sources/Validation/*`, `sps/Sources/SPSCLI/main.swift` | Add coverage + reserved-bit checks | ✅ | — | sps |
 | SPS samples & usage docs | `sps/Samples`, `docs/sps-usage-guide.md` | Provide annotated sample PDFs and usage guide with page-range queries & validation hooks | ✅ | — | docs, sps |
+| MIDI 2 library | `midi/*`, `sps/*`, `Sources/MIDI2/*` | Parse MIDI 2 spec via SPS and expose Swift Package module | 🚧 | — | midi, sps, spm |
 
 ---
 

--- a/midi/agent.md
+++ b/midi/agent.md
@@ -1,0 +1,19 @@
+# MIDI 2 Development Agent
+
+**Last Updated:** August 11, 2025  
+**Scope:** `midi/` and generated Swift MIDI 2 modules  
+**Purpose:** Guide conversion of the official MIDI 2.0 specification into machine-readable data models using the SPS API and surface them as Swift Package Manager libraries.
+
+## 🎯 Tasks
+- Use the SPS parsing pipeline under `/sps` to ingest MIDI 2.0 specification documents placed in `midi/specs/`.
+- Emit normalized machine-readable models to `midi/models/`.
+- Generate Swift sources for a `MIDI2` package under `Sources/MIDI2` driven by the data models.
+- Expose the package via `Package.swift` and provide corresponding tests under `Tests/MIDI2Tests`.
+- Keep artifacts reproducible: regenerate instead of hand-editing when specs change.
+- Verify all changes with `swift test`.
+
+## 📝 Style
+- Follow repository-wide SwiftLint rules.
+- Prefer value types and explicit access control in Swift code.
+
+> © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- add dedicated agent instructions for converting MIDI 2.0 spec via SPS into Swift Package artifacts
- track MIDI 2 library work in repository-wide task matrix
- remove obsolete manually curated MIDI 1.0 JSON spec

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_b_689a3326e8508333a369118d2a965b10