### PR TITLE
Add MIDI spec ingestion pipeline

### DIFF
--- a/agent.md
+++ b/agent.md
@@ -46,7 +46,7 @@ This agent maintains an up-to-date view of outstanding development tasks across 
 | Spec↔code drift | specs & servers | Track/close gaps per service | ✅ | — | process |
 | SPS validation hooks | `sps/Sources/Validation/*`, `sps/Sources/SPSCLI/main.swift` | Add coverage + reserved-bit checks | ✅ | — | sps |
 | SPS samples & usage docs | `sps/Samples`, `docs/sps-usage-guide.md` | Provide annotated sample PDFs and usage guide with page-range queries & validation hooks | ✅ | — | docs, sps |
-| MIDI 2 library | `midi/*`, `sps/*`, `Sources/MIDI2/*` | Parse MIDI 2 spec via SPS and expose Swift Package module | 🚧 | — | midi, sps, spm |
+| MIDI 2 library | `midi/*`, `sps/*`, `Sources/MIDI2/*` | Parse MIDI 2 spec via SPS and expose Swift Package module | 🚧 | Need model generation & package scaffolding | midi, sps, spm |
 
 ---
 

--- a/logs/agent-20250811185456.log
+++ b/logs/agent-20250811185456.log
@@ -1,0 +1,8 @@
+task: midi spec ingestion pipeline
+result: added midi/specs and models directories, ingestion script, updated manifests
+actions:
+  - created midi/ingest.sh
+  - scaffolded midi/specs and midi/models with README
+  - updated agent manifests
+status: completed
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/midi/agent.md
+++ b/midi/agent.md
@@ -16,4 +16,15 @@
 - Follow repository-wide SwiftLint rules.
 - Prefer value types and explicit access control in Swift code.
 
+## 🗂 Task Matrix
+
+| # | Feature / Component        | Files / Area                              | Action                                                                                           | Status |
+|---|---------------------------|-------------------------------------------|--------------------------------------------------------------------------------------------------|--------|
+| 1 | Spec ingestion pipeline   | `midi/specs/`, `sps/*`                     | Ingest MIDI 2.0 specification documents via SPS parsing pipeline                                 | ✅     |
+| 2 | Data model generation     | `midi/models/`                             | Emit normalized machine-readable models from ingested specs                                      | TODO   |
+| 3 | Swift package scaffolding | `Sources/MIDI2/*`, `Package.swift`         | Generate Swift sources for a `MIDI2` module and expose via Swift Package Manager                 | TODO   |
+| 4 | Test suite                | `Tests/MIDI2Tests/*`                       | Provide tests covering generated MIDI 2 functionality                                            | TODO   |
+| 5 | Reproducibility tooling   | `midi/*`                                   | Ensure artifacts are reproducible and regeneratable when specs change                            | TODO   |
+| 6 | Verification              | `swift test`                               | Run full `swift test` after changes                                                              | TODO   |
+
 > © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/midi/ingest.sh
+++ b/midi/ingest.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Ingest MIDI 2.0 specification PDFs via the SPS pipeline.
+set -euo pipefail
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SPS_DIR="$REPO_ROOT/sps"
+SPS_BIN="$SPS_DIR/.build/release/sps"
+if [[ ! -x "$SPS_BIN" ]]; then
+  swift build -c release --package-path "$SPS_DIR"
+fi
+SPECS_DIR="$REPO_ROOT/midi/specs"
+MODELS_DIR="$REPO_ROOT/midi/models"
+mkdir -p "$MODELS_DIR"
+INDEX_JSON="$MODELS_DIR/index.json"
+MATRIX_JSON="$MODELS_DIR/matrix.json"
+shopt -s nullglob
+PDFS=("$SPECS_DIR"/*.pdf)
+if (( ${#PDFS[@]} == 0 )); then
+  echo "No specification PDFs found in $SPECS_DIR" >&2
+  exit 0
+fi
+"$SPS_BIN" scan "${PDFS[@]}" --out "$INDEX_JSON" --include-text --sha256
+"$SPS_BIN" export-matrix "$INDEX_JSON" --out "$MATRIX_JSON" --validate
+echo "Wrote index to $INDEX_JSON"
+echo "Wrote matrix to $MATRIX_JSON"
+# © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/midi/models/README.md
+++ b/midi/models/README.md
@@ -1,0 +1,5 @@
+# MIDI 2.0 Models
+
+This directory contains machine-readable artifacts generated from the MIDI 2.0 specification via `midi/ingest.sh`. Do not edit these files manually; regenerate them when the upstream specs change.
+
+> © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/midi/specs/README.md
+++ b/midi/specs/README.md
@@ -1,0 +1,5 @@
+# MIDI 2.0 Specification PDFs
+
+Place the official MIDI 2.0 specification documents here. These PDFs are consumed by the `midi/ingest.sh` script via the `sps` CLI to produce machine-readable indices and matrices in `midi/models/`.
+
+> © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- scaffold `midi/specs` and `midi/models` directories
- add `midi/ingest.sh` to process MIDI 2.0 PDF specs with the SPS CLI
- update agent manifests with task matrix and progress notes

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_b_689a3aa659208333ab539af93e280587