### PR TITLE
Add async job queue and status command

### DIFF
--- a/docs/sps-usage-guide.md
+++ b/docs/sps-usage-guide.md
@@ -14,6 +14,19 @@ swift build -c release
 .build/release/sps scan sps/Samples/extraction_sample.pdf sps/Samples/table_detection_sample.pdf --out index.json --include-text --page-range 1-2
 ```
 
+## 1a. Run scans asynchronously
+The `scan` command now enqueues work and returns a ticket immediately:
+```bash
+.build/release/sps scan sps/Samples/extraction_sample.pdf --out async-index.json
+# -> SPS: enqueued scan job -> <ticket>
+```
+
+Check progress with rotating motivational messages:
+```bash
+.build/release/sps status <ticket>
+```
+States include `pending`, `running`, `completed`, and `failed`. When completed, the status command prints the result path.
+
 ## 2. Validate the generated index
 ```bash
 .build/release/sps index validate index.json

--- a/sps/Sources/SPSCLI/JobQueue.swift
+++ b/sps/Sources/SPSCLI/JobQueue.swift
@@ -1,0 +1,103 @@
+import Foundation
+
+final class SPSJobQueue: @unchecked Sendable {
+    static let shared = SPSJobQueue()
+    private let queue = DispatchQueue(label: "sps.job.queue", attributes: .concurrent)
+    private let storageURL: URL
+
+    enum State: String, Codable { case pending, running, completed, failed }
+
+    struct Job: Codable {
+        var id: UUID
+        var state: State
+        var progress: Double
+        var result: String?
+        var error: String?
+    }
+
+    private var jobs: [UUID: Job] = [:]
+
+    private init() {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent("sps-jobs", isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        storageURL = dir
+        if let files = try? FileManager.default.contentsOfDirectory(at: dir, includingPropertiesForKeys: nil) {
+            for file in files where file.pathExtension == "json" {
+                if let data = try? Data(contentsOf: file),
+                   let job = try? JSONDecoder().decode(Job.self, from: data) {
+                    jobs[job.id] = job
+                }
+            }
+        }
+    }
+
+    private func persist(_ job: Job) {
+        let url = storageURL.appendingPathComponent("\(job.id.uuidString).json")
+        if let data = try? JSONEncoder().encode(job) {
+            try? data.write(to: url)
+        }
+    }
+
+    private func update(id: UUID, _ mutate: @escaping @Sendable (inout Job) -> Void) {
+        queue.async(flags: .barrier) {
+            guard var job = self.jobs[id] else { return }
+            mutate(&job)
+            self.jobs[id] = job
+            self.persist(job)
+        }
+    }
+
+    func enqueueScan(pdfs: [String], out: String, includeText: Bool, sha256: Bool) -> UUID {
+        let id = UUID()
+        let job = Job(id: id, state: .pending, progress: 0, result: nil, error: nil)
+        queue.async(flags: .barrier) {
+            self.jobs[id] = job
+            self.persist(job)
+        }
+
+        DispatchQueue.global().async {
+            self.update(id: id) { $0.state = .running }
+            do {
+                var docs: [IndexDoc] = []
+                for (idx, path) in pdfs.enumerated() {
+                    let url = URL(fileURLWithPath: path)
+                    let data = (try? Data(contentsOf: url)) ?? Data()
+                    let pages = extractPages(data: data, includeText: includeText)
+                    let hash = sha256 ? sha256Hex(data: data) : nil
+                    let doc = IndexDoc(id: UUID().uuidString, fileName: url.lastPathComponent, size: data.count, sha256: hash, pages: pages)
+                    docs.append(doc)
+                    let pct = Double(idx + 1) / Double(pdfs.count)
+                    self.update(id: id) { $0.progress = pct }
+                }
+                let index = IndexRoot(documents: docs)
+                let enc = JSONEncoder()
+                enc.outputFormatting = [.prettyPrinted, .sortedKeys]
+                let json = try enc.encode(index)
+                try json.write(to: URL(fileURLWithPath: out))
+                self.update(id: id) {
+                    $0.state = .completed
+                    $0.progress = 1.0
+                    $0.result = out
+                }
+            } catch {
+                self.update(id: id) {
+                    $0.state = .failed
+                    $0.progress = 1.0
+                    $0.error = String(describing: error)
+                }
+            }
+        }
+
+        return id
+    }
+
+    func status(id: UUID) -> Job? {
+        var job: Job?
+        queue.sync {
+            job = jobs[id]
+        }
+        return job
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/sps/Tests/SPSCLITests/JobQueueTests.swift
+++ b/sps/Tests/SPSCLITests/JobQueueTests.swift
@@ -1,0 +1,21 @@
+import XCTest
+@testable import SPSCLI
+
+final class JobQueueTests: XCTestCase {
+    func testEnqueueAndComplete() throws {
+        let tmpPDF = FileManager.default.temporaryDirectory.appendingPathComponent("sample.pdf")
+        try Data().write(to: tmpPDF)
+        let outPath = FileManager.default.temporaryDirectory.appendingPathComponent("index.json").path
+        let ticket = SPSJobQueue.shared.enqueueScan(pdfs: [tmpPDF.path], out: outPath, includeText: false, sha256: false)
+        var final: SPSJobQueue.Job? = nil
+        for _ in 0..<50 {
+            final = SPSJobQueue.shared.status(id: ticket)
+            if final?.state == .completed || final?.state == .failed { break }
+            usleep(100_000)
+        }
+        XCTAssertNotNil(final)
+        XCTAssertEqual(final?.state, .completed)
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- introduce `SPSJobQueue` to run scans in the background and persist job state
- add `status` CLI command showing progress with rotating motivational messages
- document asynchronous scan workflow and add basic job queue test

## Testing
- `swift test` *(failed: Exited with unexpected signal code 4)*
- `swift test --filter JobQueueTests`

------
https://chatgpt.com/codex/tasks/task_b_689ad5e511a883339d27b7643e16ec07