### PR TITLE
Reset MIDI agent matrix and enforce SPS toolchain setup

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,6 +4,7 @@ import PackageDescription
 var products: [Product] = [
     .library(name: "FountainCore", targets: ["FountainCore"]),
     .library(name: "FountainCodex", targets: ["FountainCodex"]),
+    .library(name: "MIDI2", targets: ["MIDI2"]),
     .executable(name: "clientgen-service", targets: ["clientgen-service"]),
     .executable(name: "gateway-server", targets: ["gateway-server"]),
     .executable(name: "publishing-frontend", targets: ["publishing-frontend"])
@@ -50,13 +51,15 @@ var targets: [Target] = [
         dependencies: ["PublishingFrontend"],
         path: "Sources/publishing-frontend"
     ),
+    .target(name: "MIDI2", path: "Sources/MIDI2"),
     .testTarget(name: "FountainCoreTests", dependencies: ["FountainCore"], path: "Tests/FountainCoreTests"),
     .testTarget(name: "ClientGeneratorTests", dependencies: ["FountainCodex"], path: "Tests/ClientGeneratorTests"),
     .testTarget(name: "PublishingFrontendTests", dependencies: ["PublishingFrontend"], path: "Tests/PublishingFrontendTests"),
     .testTarget(name: "DNSTests", dependencies: ["PublishingFrontend", "FountainCodex", .product(name: "Crypto", package: "swift-crypto"), .product(name: "NIOEmbedded", package: "swift-nio"), .product(name: "NIO", package: "swift-nio")], path: "Tests/DNSTests"),
     .testTarget(name: "IntegrationRuntimeTests", dependencies: ["gateway-server", "FountainCodex"], path: "Tests/IntegrationRuntimeTests"),
     .testTarget(name: "DNSPerfTests", dependencies: ["FountainCodex", .product(name: "NIOCore", package: "swift-nio")], path: "Tests/DNSPerfTests"),
-    .testTarget(name: "NormativeLinkerTests", dependencies: ["FountainCodex"], path: "Tests/NormativeLinkerTests")
+    .testTarget(name: "NormativeLinkerTests", dependencies: ["FountainCodex"], path: "Tests/NormativeLinkerTests"),
+    .testTarget(name: "MIDI2Tests", dependencies: ["MIDI2"], path: "Tests/MIDI2Tests")
 ]
 
 #if os(Linux)

--- a/Sources/FountainCodex/DNSMetrics.swift
+++ b/Sources/FountainCodex/DNSMetrics.swift
@@ -45,6 +45,19 @@ public actor DNSMetrics {
         return lines.joined(separator: "\n")
     }
 
+    /// Waits until the recorded query count reaches or exceeds the target.
+    /// - Parameters:
+    ///   - target: Desired query count.
+    ///   - timeout: Maximum time to wait in seconds.
+    /// - Returns: ``true`` if the target count was reached before the timeout elapsed.
+    public func wait(forQueries target: Int, timeout: TimeInterval = 1.0) async -> Bool {
+        let start = Date()
+        while queries < target && Date().timeIntervalSince(start) < timeout {
+            await Task.yield()
+        }
+        return queries >= target
+    }
+
     public func reset() {
         queries = 0
         hits = 0

--- a/Sources/MIDI2/ModelIndex.swift
+++ b/Sources/MIDI2/ModelIndex.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+public struct MIDIModelIndex: Codable {
+    public struct Document: Codable {
+        public let fileName: String
+        public let id: String
+        public let pages: [Page]
+        public let sha256: String
+        public let size: Int
+        public init(fileName: String, id: String, pages: [Page], sha256: String, size: Int) {
+            self.fileName = fileName
+            self.id = id
+            self.pages = pages
+            self.sha256 = sha256
+            self.size = size
+        }
+    }
+
+    public struct Page: Codable {
+        public let lines: [String]
+        public let number: Int
+        public let text: String
+        public init(lines: [String], number: Int, text: String) {
+            self.lines = lines
+            self.number = number
+            self.text = text
+        }
+    }
+
+    public let documents: [Document]
+    public init(documents: [Document]) {
+        self.documents = documents
+    }
+
+    public static func load(from path: String = "midi/models/index.json") throws -> MIDIModelIndex {
+        let url = URL(fileURLWithPath: FileManager.default.currentDirectoryPath).appendingPathComponent(path)
+        let data = try Data(contentsOf: url)
+        return try JSONDecoder().decode(MIDIModelIndex.self, from: data)
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Tests/DNSPerfTests/DNSPerformanceTests.swift
+++ b/Tests/DNSPerfTests/DNSPerformanceTests.swift
@@ -32,6 +32,8 @@ final class DNSPerformanceTests: XCTestCase {
                 }
             }
         }
+        let finished = await DNSMetrics.shared.wait(forQueries: 1000)
+        XCTAssertTrue(finished)
         let text = await DNSMetrics.shared.exposition()
         XCTAssertTrue(text.contains("dns_queries_total 1000"))
         await DNSMetrics.shared.reset()

--- a/Tests/MIDI2Tests/MIDI2Tests.swift
+++ b/Tests/MIDI2Tests/MIDI2Tests.swift
@@ -1,0 +1,11 @@
+import XCTest
+@testable import MIDI2
+
+final class MIDI2Tests: XCTestCase {
+    func testLoadIndex() throws {
+        let index = try MIDIModelIndex.load()
+        XCTAssertFalse(index.documents.isEmpty)
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/agent.md
+++ b/agent.md
@@ -46,7 +46,7 @@ This agent maintains an up-to-date view of outstanding development tasks across 
 | Spec↔code drift | specs & servers | Track/close gaps per service | ✅ | — | process |
 | SPS validation hooks | `sps/Sources/Validation/*`, `sps/Sources/SPSCLI/main.swift` | Add coverage + reserved-bit checks | ✅ | — | sps |
 | SPS samples & usage docs | `sps/Samples`, `docs/sps-usage-guide.md` | Provide annotated sample PDFs and usage guide with page-range queries & validation hooks | ✅ | — | docs, sps |
-| MIDI 2 library | `midi/*`, `sps/*`, `Sources/MIDI2/*` | Parse MIDI 2 spec via SPS and expose Swift Package module | 🚧 | Models generated; need package scaffolding | midi, sps, spm |
+| MIDI 2 library | `midi/*`, `sps/*`, `Sources/MIDI2/*` | Parse MIDI 2 spec via SPS and expose Swift Package module | 🚧 | – | midi, sps, spm |
 
 ---
 

--- a/logs/agent-20250812063830.log
+++ b/logs/agent-20250812063830.log
@@ -1,0 +1,8 @@
+task: midi spec ingestion via SPSJobQueue
+result: Job queue returned 'Job not found' during status polling; models regenerated from existing matrix
+actions:
+  - added wait helper in DNSMetrics and updated DNSPerformanceTests
+  - attempted SPSJobQueue scan (failed)
+  - regenerated MIDI models
+status: partial
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/logs/agent-20250812065710.log
+++ b/logs/agent-20250812065710.log
@@ -1,0 +1,8 @@
+task: analyze SPSJobQueue scan failure
+result: discovered CLI terminates before async job persists, yielding 'Job not found' on status check
+actions:
+  - inspected sps/Sources/SPSCLI/JobQueue.swift
+  - confirmed enqueue writes to temp dir asynchronously, allowing process exit before persistence
+  - outlined fix to persist synchronously and add worker or --wait mode
+status: analysis
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/logs/agent-20250812072116.log
+++ b/logs/agent-20250812072116.log
@@ -1,0 +1,3 @@
+2025-08-12T07:21:16Z fixed SPSJobQueue persistence and added --wait flag
+2025-08-12T07:21:16Z re-ingested MIDI 2 specs -> midi/models/index.json
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/logs/agent-20250812121311.log
+++ b/logs/agent-20250812121311.log
@@ -1,0 +1,4 @@
+2025-08-12T12:13:11Z Reset MIDI agent matrix and re-ran spec ingestion via SPSJobQueue (PDFium missing, text extraction unavailable)
+2025-08-12T12:13:11Z Regenerated MIDI 2 data models
+2025-08-12T12:13:11Z swift test
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/logs/agent-20250812122924.log
+++ b/logs/agent-20250812122924.log
@@ -1,0 +1,6 @@
+2025-08-12T12:29:24Z make -C sps deps (failed: Unable to locate package libpdfium-dev)
+2025-08-12T12:29:24Z sps scan midi/specs/*.pdf --out midi/models/index.json --include-text --sha256 --wait
+2025-08-12T12:29:24Z sps export-matrix midi/models/index.json --out midi/models/matrix.json --validate
+2025-08-12T12:29:24Z midi/build-models.sh
+2025-08-12T12:29:24Z swift test
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/midi/agent.md
+++ b/midi/agent.md
@@ -5,6 +5,7 @@
 **Purpose:** Guide conversion of the official MIDI 2.0 specification into machine-readable data models using the SPS API and surface them as Swift Package Manager libraries.
 
 ## 🎯 Tasks
+- Ensure SPS toolchain prerequisites are installed (`make -C sps deps`) so PDFium and other requirements are available.
 - Use the SPS parsing pipeline under `/sps` to ingest MIDI 2.0 specification documents placed in `midi/specs/`.
 - Queue long-running scans through `SPSJobQueue` and poll `status` for progress.
 - Emit normalized machine-readable models to `midi/models/`.
@@ -19,14 +20,15 @@
 
 ## 🗂 Task Matrix
 
-| # | Feature / Component        | Files / Area                              | Action | Problems | Results | Status |
-|---|---------------------------|-------------------------------------------|--------|----------|---------|--------|
-| 1 | Spec ingestion pipeline   | `midi/specs/`, `sps/*`                     | Ingest MIDI 2.0 specification documents via SPS parsing pipeline using `SPSJobQueue` for asynchronous processing | – | – | TODO |
-| 2 | Data model generation     | `midi/models/`                             | Emit normalized machine-readable models from ingested specs | – | – | TODO |
-| 3 | Swift package scaffolding | `Sources/MIDI2/*`, `Package.swift`         | Generate Swift sources for a `MIDI2` module and expose via Swift Package Manager | – | – | TODO |
-| 4 | Test suite                | `Tests/MIDI2Tests/*`                       | Provide tests covering generated MIDI 2 functionality | – | – | TODO |
-| 5 | Reproducibility tooling   | `midi/*`                                   | Ensure artifacts are reproducible and regeneratable when specs change | – | – | TODO |
-| 6 | Verification              | `swift test`                               | Run full `swift test` after changes | – | – | TODO |
-
+| # | Feature | Area | Action | Problems | Results | Status |
+|---|---------|------|--------|----------|---------|--------|
+| 1 | SPS toolchain setup | `sps/` | Install deps via `make -C sps deps` | — | — | TODO |
+| 2 | Spec ingestion pipeline | `midi/specs/`, `sps/*` | Ingest specs via `sps scan --wait` | — | — | TODO |
+| 3 | Data model generation | `midi/models/` | Emit normalized models | — | — | TODO |
+| 4 | Swift package scaffolding | `Sources/MIDI2/*`, `Package.swift` | Generate `MIDI2` module | — | — | TODO |
+| 5 | Test suite | `Tests/MIDI2Tests/*` | Cover generated functionality | — | — | TODO |
+| 6 | Reproducibility tooling | `midi/*` | Keep artifacts reproducible | — | — | TODO |
+| 7 | Verification | `swift test` | Run full test suite | — | — | TODO |
+| 8 | Job queue reliability | `sps/Sources/SPSCLI/JobQueue.swift` | Ensure queue persists jobs & wait mode | — | — | TODO |
 
 > © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/midi/models/index.json
+++ b/midi/models/index.json
@@ -1,94 +1,83 @@
 {
-  "documents" : [
+  "documents": [
     {
-      "fileName" : "M2-100-U_v1-1_MIDI_2-0_Specification_Overview.pdf",
-      "id" : "233A838A-68C1-41C9-A5C9-355D797FBA84",
-      "pages" : [
+      "fileName": "M2-100-U_v1-1_MIDI_2-0_Specification_Overview.pdf",
+      "id": "D8BE35D3-F01E-462C-AFE6-C981066193F1",
+      "pages": [
         {
-          "lines" : [
-
-          ],
-          "number" : 1,
-          "text" : "(text extraction unavailable)"
+          "lines": [],
+          "number": 1,
+          "text": "(text extraction unavailable)"
         }
       ],
-      "sha256" : "sum64-0000000003b1ed35",
-      "size" : 492880
+      "sha256": "sum64-0000000003b1ed35",
+      "size": 492880
     },
     {
-      "fileName" : "M2-101-UM_v1-2_MIDI-CI_Specification.pdf",
-      "id" : "83B5C4A8-F8B0-4239-963C-83B61D9740C8",
-      "pages" : [
+      "fileName": "M2-101-UM_v1-2_MIDI-CI_Specification.pdf",
+      "id": "CE4B7DC7-2425-4A11-AC99-F4A5D4393CFF",
+      "pages": [
         {
-          "lines" : [
-
-          ],
-          "number" : 1,
-          "text" : "(text extraction unavailable)"
+          "lines": [],
+          "number": 1,
+          "text": "(text extraction unavailable)"
         }
       ],
-      "sha256" : "sum64-0000000007dbb22c",
-      "size" : 1049390
+      "sha256": "sum64-0000000007dbb22c",
+      "size": 1049390
     },
     {
-      "fileName" : "M2-102-U_v1-1_Common_Rules_for_MIDI-CI_Profiles.pdf",
-      "id" : "BB6EEFDD-05FC-45E8-8556-B3621F1976A1",
-      "pages" : [
+      "fileName": "M2-102-U_v1-1_Common_Rules_for_MIDI-CI_Profiles.pdf",
+      "id": "2495F12B-EE97-4DC6-9E17-7B16166B02F2",
+      "pages": [
         {
-          "lines" : [
-
-          ],
-          "number" : 1,
-          "text" : "(text extraction unavailable)"
+          "lines": [],
+          "number": 1,
+          "text": "(text extraction unavailable)"
         }
       ],
-      "sha256" : "sum64-00000000052dca1c",
-      "size" : 684485
+      "sha256": "sum64-00000000052dca1c",
+      "size": 684485
     },
     {
-      "fileName" : "M2-103-UM_v1-2_Common Rules_for_MIDI-CI_Property_Exchange.pdf",
-      "id" : "31C9AF17-20CB-44D9-8C0B-BCE647F6E3FD",
-      "pages" : [
+      "fileName": "M2-103-UM_v1-2_Common Rules_for_MIDI-CI_Property_Exchange.pdf",
+      "id": "9758D827-85AC-46B5-B94E-00244242B4A6",
+      "pages": [
         {
-          "lines" : [
-
-          ],
-          "number" : 1,
-          "text" : "(text extraction unavailable)"
+          "lines": [],
+          "number": 1,
+          "text": "(text extraction unavailable)"
         }
       ],
-      "sha256" : "sum64-000000000a9f8ccd",
-      "size" : 1521778
+      "sha256": "sum64-000000000a9f8ccd",
+      "size": 1521778
     },
     {
-      "fileName" : "M2-104-UM_v1-1-2_UMP_and_MIDI_2-0_Protocol_Specification.pdf",
-      "id" : "2C8582A6-B127-4691-8D5D-9016CDC1F3ED",
-      "pages" : [
+      "fileName": "M2-104-UM_v1-1-2_UMP_and_MIDI_2-0_Protocol_Specification.pdf",
+      "id": "B882FCDD-0A84-4144-884A-7DE3741F722E",
+      "pages": [
         {
-          "lines" : [
-
-          ],
-          "number" : 1,
-          "text" : "(text extraction unavailable)"
+          "lines": [],
+          "number": 1,
+          "text": "(text extraction unavailable)"
         }
       ],
-      "sha256" : "sum64-0000000023a0cbd8",
-      "size" : 4941141
+      "sha256": "sum64-0000000023a0cbd8",
+      "size": 4941141
     },
     {
-      "fileName" : "M2-116-U_v1-0_MIDI_Clip_File_Specification.pdf",
-      "id" : "6F03B582-5919-47B9-8282-A7AB560082C5",
-      "pages" : [
+      "fileName": "M2-116-U_v1-0_MIDI_Clip_File_Specification.pdf",
+      "id": "7666EBF5-78C3-48E6-A854-859E7CE60649",
+      "pages": [
         {
-          "lines" : [
-
-          ],
-          "number" : 1,
-          "text" : "(text extraction unavailable)"
+          "lines": [],
+          "number": 1,
+          "text": "(text extraction unavailable)"
         }
       ],
-      "sha256" : "sum64-0000000006ae8c37",
-      "size" : 895904
+      "sha256": "sum64-0000000006ae8c37",
+      "size": 895904
     }
-  ]
+  ],
+  "_copyright": "© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved."
 }

--- a/sps/Sources/SPSCLI/JobQueue.swift
+++ b/sps/Sources/SPSCLI/JobQueue.swift
@@ -50,7 +50,7 @@ final class SPSJobQueue: @unchecked Sendable {
     func enqueueScan(pdfs: [String], out: String, includeText: Bool, sha256: Bool) -> UUID {
         let id = UUID()
         let job = Job(id: id, state: .pending, progress: 0, result: nil, error: nil)
-        queue.async(flags: .barrier) {
+        queue.sync(flags: .barrier) {
             self.jobs[id] = job
             self.persist(job)
         }


### PR DESCRIPTION
## Summary
- add explicit SPS dependency installation step to MIDI agent and reset its task matrix
- rerun MIDI specification ingestion and refresh model index after toolchain check (PDFium still missing)

## Testing
- `make -C sps deps` *(failed: Unable to locate package libpdfium-dev)*
- `sps/.build/release/sps scan midi/specs/*.pdf --out midi/models/index.json --include-text --sha256 --wait`
- `sps/.build/release/sps export-matrix midi/models/index.json --out midi/models/matrix.json --validate`
- `./midi/build-models.sh`
- `swift test`


------
https://chatgpt.com/codex/tasks/task_b_689add0efdb88333be3232cc5cf01534