### PR TITLE
fix(ci): use supported swiftlint and swift 6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,22 +7,22 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-      - uses: norio-nomura/action-swiftlint@v4
+      - uses: norio-nomura/action-swiftlint@3.2.1
         with:
           args: --config .swiftlint.yml
   test:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-14]
+        os: [ubuntu-22.04, macos-14]
     steps:
       - uses: actions/checkout@v4
       - uses: swift-actions/setup-swift@v1
         with:
-          swift-version: '6.1'
+          swift-version: '6.0.1'
       - name: Install coverage tools
         if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y lcov


### PR DESCRIPTION
## Summary
- switch CI to ubuntu-22.04 and Swift 6.0.1
- pin SwiftLint action to 3.2.1

## Testing
- `./sps/install-deps.sh`
- `swift test` *(fails: build still in progress, interrupted)*

------
https://chatgpt.com/codex/tasks/task_b_689b4b9a74d083339d4fa9ec14dc278d