### PR TITLE
feat: add loopback MIDI transport

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -54,6 +54,7 @@ var targets: [Target] = [
     ),
     .target(name: "MIDI2Models", path: "Sources/MIDI2Models"),
     .target(name: "MIDI2Core", dependencies: [.product(name: "MIDI2", package: "midi2")], path: "Sources/MIDI2Core"),
+    .target(name: "MIDI2Transports", path: "Sources/MIDI2Transports"),
     .testTarget(name: "FountainCoreTests", dependencies: ["FountainCore"], path: "Tests/FountainCoreTests"),
     .testTarget(name: "ClientGeneratorTests", dependencies: ["FountainCodex"], path: "Tests/ClientGeneratorTests"),
     .testTarget(name: "PublishingFrontendTests", dependencies: ["PublishingFrontend"], path: "Tests/PublishingFrontendTests"),
@@ -62,7 +63,8 @@ var targets: [Target] = [
     .testTarget(name: "DNSPerfTests", dependencies: ["FountainCodex", .product(name: "NIOCore", package: "swift-nio")], path: "Tests/DNSPerfTests"),
     .testTarget(name: "NormativeLinkerTests", dependencies: ["FountainCodex"], path: "Tests/NormativeLinkerTests"),
     .testTarget(name: "MIDI2ModelsTests", dependencies: ["MIDI2Models"], path: "Tests/MIDI2ModelsTests"),
-    .testTarget(name: "MIDI2CoreTests", dependencies: ["MIDI2Core"], path: "Tests/MIDI2CoreTests")
+    .testTarget(name: "MIDI2CoreTests", dependencies: ["MIDI2Core"], path: "Tests/MIDI2CoreTests"),
+    .testTarget(name: "MIDI2TransportsTests", dependencies: ["MIDI2Transports"], path: "Tests/MIDI2TransportsTests")
 ]
 
 #if os(Linux)

--- a/Sources/MIDI2Transports/LoopbackTransport.swift
+++ b/Sources/MIDI2Transports/LoopbackTransport.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+public final class LoopbackTransport: MIDITransport {
+    public var onReceiveUMP: (([UInt32]) -> Void)?
+
+    public init() {}
+
+    public func open() throws {}
+
+    public func close() throws {}
+
+    public func send(umpWords: [UInt32]) throws {
+        onReceiveUMP?(umpWords)
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/MIDI2Transports/MIDITransport.swift
+++ b/Sources/MIDI2Transports/MIDITransport.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+public protocol MIDITransport {
+    func open() throws
+    func close() throws
+    func send(umpWords: [UInt32]) throws
+    var onReceiveUMP: (([UInt32]) -> Void)? { get set }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Tests/MIDI2TransportsTests/LoopbackTransportTests.swift
+++ b/Tests/MIDI2TransportsTests/LoopbackTransportTests.swift
@@ -1,0 +1,22 @@
+import XCTest
+@testable import MIDI2Transports
+
+final class MIDI2TransportsTests: XCTestCase {
+    func testLoopbackTransportEchoesUMP() throws {
+        let transport = LoopbackTransport()
+        let exp = expectation(description: "received")
+        var received: [UInt32] = []
+        transport.onReceiveUMP = { words in
+            received = words
+            exp.fulfill()
+        }
+        try transport.open()
+        let packet: [UInt32] = [0x12345678, 0x9ABCDEF0]
+        try transport.send(umpWords: packet)
+        wait(for: [exp], timeout: 1.0)
+        XCTAssertEqual(received, packet)
+        try transport.close()
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/agent.md
+++ b/agent.md
@@ -47,7 +47,7 @@ This agent maintains an up-to-date view of outstanding development tasks across 
 | Spec↔code drift | specs & servers | Track/close gaps per service | ✅ | — | process |
 | SPS validation hooks | `sps/Sources/Validation/*`, `sps/Sources/SPSCLI/main.swift` | Add coverage + reserved-bit checks | ✅ | — | sps |
 | SPS samples & usage docs | `sps/Samples`, `docs/sps-usage-guide.md` | Provide annotated sample PDFs and usage guide with page-range queries & validation hooks | ✅ | — | docs, sps |
-| MIDI 2 library | `midi/*`, `sps/*`, `Sources/MIDI2/*` | Parse MIDI 2 spec via SPS and expose Swift Package module | 🚧 (PR-1) | Next: transport boundary | midi, sps, spm |
+| MIDI 2 library | `midi/*`, `sps/*`, `Sources/MIDI2/*` | Parse MIDI 2 spec via SPS and expose Swift Package module | 🚧 (PR-2) | Next: FlexBridge | midi, sps, spm |
 
 
 ---

--- a/logs/agent-20250814161531.log
+++ b/logs/agent-20250814161531.log
@@ -1,0 +1,2 @@
+[PR-2] Added MIDITransport protocol and LoopbackTransport.
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/midi/FountainAI-Codex-Plan.md
+++ b/midi/FountainAI-Codex-Plan.md
@@ -71,8 +71,8 @@ Keep the mapping as code + fixtures (Appendix A in the proposal):
 - Add `MIDI2Core` facade (types, codecs).  
 - Add JSON Schema for envelopes; round‑trip tests + golden vectors per intent.
 
-**PR‑2 — Transport boundary**  
-- Add `MIDITransport` protocol + `LoopbackTransport`.  
+**PR‑2 — Transport boundary ✅**
+- Added `MIDITransport` protocol + `LoopbackTransport`.
 - Route any existing MIDI code exclusively through the protocol.
 
 **PR‑3 — FlexBridge**  
@@ -143,3 +143,5 @@ flexctl tail --corr dE8x-7qF
 # Replay a golden UMP vector through loopback
 flexctl replay --ump ./examples/planner.execute.ump
 ```
+
+> © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- introduce `MIDITransport` protocol and loopback implementation
- add tests for loopback UMP echo
- note PR-2 completion in MIDI plan and agent manifest

## Testing
- `swift test --filter MIDI2Transports`


------
https://chatgpt.com/codex/tasks/task_b_689e0ad97b6c833383c38130abecd3ad