### PR TITLE
feat(sb): semantic browser & dissector (swift-only, cli-first)

### DIFF
--- a/agent.md
+++ b/agent.md
@@ -1,6 +1,6 @@
 # 🧠 Repository Agent Manifest
 
-**Last Updated:** August 12, 2025
+**Last Updated:** August 15, 2025
 **Scope:** Full-repository self-improvement and orchestration  
 **Purpose:** Serve as a machine-actionable contract and coordination center for Codex-driven implementation, testing, and maintenance across all project modules.
 
@@ -48,6 +48,7 @@ This agent maintains an up-to-date view of outstanding development tasks across 
 | SPS validation hooks | `sps/Sources/Validation/*`, `sps/Sources/SPSCLI/main.swift` | Add coverage + reserved-bit checks | ✅ | — | sps |
 | SPS samples & usage docs | `sps/Samples`, `docs/sps-usage-guide.md` | Provide annotated sample PDFs and usage guide with page-range queries & validation hooks | ✅ | — | docs, sps |
 | MIDI 2 library | `midi/*`, `sps/*`, `Sources/MIDI2/*` | Parse MIDI 2 spec via SPS and expose Swift Package module | ✅ | — | midi, sps, spm |
+| Semantic browser & dissector | `sb/*` | Scaffold SPM package and core models | 🚧 | — | sb, cli, cdp, typesense, semantics |
 
 
 ---

--- a/sb/Package.swift
+++ b/sb/Package.swift
@@ -1,0 +1,21 @@
+// swift-tools-version: 6.1
+import PackageDescription
+
+let package = Package(
+    name: "SemanticBrowser",
+    platforms: [
+        .macOS(.v13)
+    ],
+    products: [
+        .executable(name: "sb", targets: ["SBCLI"]),
+        .library(name: "SBCore", targets: ["SBCore"])
+    ],
+    targets: [
+        .executableTarget(
+            name: "SBCLI",
+            dependencies: ["SBCore"]
+        ),
+        .target(name: "SBCore")
+    ]
+)
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/sb/Sources/SBCLI/Commands/AnalyzeCommand.swift
+++ b/sb/Sources/SBCLI/Commands/AnalyzeCommand.swift
@@ -1,0 +1,5 @@
+public struct AnalyzeCommand {
+    public init() {}
+    public func run() async throws {}
+}
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/sb/Sources/SBCLI/Commands/BrowseCommand.swift
+++ b/sb/Sources/SBCLI/Commands/BrowseCommand.swift
@@ -1,0 +1,5 @@
+public struct BrowseCommand {
+    public init() {}
+    public func run() async throws {}
+}
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/sb/Sources/SBCLI/Commands/IndexCommand.swift
+++ b/sb/Sources/SBCLI/Commands/IndexCommand.swift
@@ -1,0 +1,5 @@
+public struct IndexCommand {
+    public init() {}
+    public func run() async throws {}
+}
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/sb/Sources/SBCLI/main.swift
+++ b/sb/Sources/SBCLI/main.swift
@@ -1,0 +1,5 @@
+import Foundation
+import SBCore
+
+print("SBCLI placeholder")
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/sb/Sources/SBCore/Models/Analysis.swift
+++ b/sb/Sources/SBCore/Models/Analysis.swift
@@ -1,0 +1,4 @@
+public struct Analysis: Codable, Sendable {
+    public init() {}
+}
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/sb/Sources/SBCore/Models/Blocks.swift
+++ b/sb/Sources/SBCore/Models/Blocks.swift
@@ -1,0 +1,4 @@
+public struct Blocks: Codable, Sendable {
+    public init() {}
+}
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/sb/Sources/SBCore/Models/Claims.swift
+++ b/sb/Sources/SBCore/Models/Claims.swift
@@ -1,0 +1,4 @@
+public struct Claims: Codable, Sendable {
+    public init() {}
+}
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/sb/Sources/SBCore/Models/DissectionMode.swift
+++ b/sb/Sources/SBCore/Models/DissectionMode.swift
@@ -1,0 +1,6 @@
+public enum DissectionMode: String, Codable, Sendable {
+    case quick
+    case standard
+    case deep
+}
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/sb/Sources/SBCore/Models/Entities.swift
+++ b/sb/Sources/SBCore/Models/Entities.swift
@@ -1,0 +1,4 @@
+public struct Entities: Codable, Sendable {
+    public init() {}
+}
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/sb/Sources/SBCore/Models/IndexDocs.swift
+++ b/sb/Sources/SBCore/Models/IndexDocs.swift
@@ -1,0 +1,4 @@
+public struct IndexDocs: Codable, Sendable {
+    public init() {}
+}
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/sb/Sources/SBCore/Models/IndexOptions.swift
+++ b/sb/Sources/SBCore/Models/IndexOptions.swift
@@ -1,0 +1,7 @@
+public struct IndexOptions: Codable, Sendable {
+    public var enabled: Bool
+    public init(enabled: Bool = false) {
+        self.enabled = enabled
+    }
+}
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/sb/Sources/SBCore/Models/IndexResult.swift
+++ b/sb/Sources/SBCore/Models/IndexResult.swift
@@ -1,0 +1,4 @@
+public struct IndexResult: Codable, Sendable {
+    public init() {}
+}
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/sb/Sources/SBCore/Models/Snapshot.swift
+++ b/sb/Sources/SBCore/Models/Snapshot.swift
@@ -1,0 +1,4 @@
+public struct Snapshot: Codable, Sendable {
+    public init() {}
+}
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/sb/Sources/SBCore/Models/WaitPolicy.swift
+++ b/sb/Sources/SBCore/Models/WaitPolicy.swift
@@ -1,0 +1,4 @@
+public enum WaitPolicy: String, Codable, Sendable {
+    case none
+}
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/sb/Sources/SBCore/Pipeline/Orchestrator.swift
+++ b/sb/Sources/SBCore/Pipeline/Orchestrator.swift
@@ -1,0 +1,4 @@
+public struct Orchestrator {
+    public init() {}
+}
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/sb/Sources/SBCore/Ports/ArtifactStore.swift
+++ b/sb/Sources/SBCore/Ports/ArtifactStore.swift
@@ -1,0 +1,6 @@
+public protocol ArtifactStore: Sendable {
+    func writeSnapshot(_ snap: Snapshot) async throws
+    func writeAnalysis(_ analysis: Analysis) async throws
+    func readSnapshot(id: String) async throws -> Snapshot?
+}
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/sb/Sources/SBCore/Ports/Dissecting.swift
+++ b/sb/Sources/SBCore/Ports/Dissecting.swift
@@ -1,0 +1,4 @@
+public protocol Dissecting: Sendable {
+    func analyze(from snapshot: Snapshot, mode: DissectionMode, store: ArtifactStore?) async throws -> Analysis
+}
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/sb/Sources/SBCore/Ports/Indexing.swift
+++ b/sb/Sources/SBCore/Ports/Indexing.swift
@@ -1,0 +1,4 @@
+public protocol Indexing: Sendable {
+    func upsert(analysis: Analysis, options: IndexOptions) async throws -> IndexResult
+}
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/sb/Sources/SBCore/Ports/Navigating.swift
+++ b/sb/Sources/SBCore/Ports/Navigating.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+public protocol Navigating: Sendable {
+    func snapshot(url: URL, wait: WaitPolicy, store: ArtifactStore?) async throws -> Snapshot
+}
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/sb/Sources/SBCore/SB.swift
+++ b/sb/Sources/SBCore/SB.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+public actor SB {
+    let navigator: any Navigating
+    let dissector: any Dissecting
+    let indexer: any Indexing
+    let store: ArtifactStore?
+
+    public init(navigator: any Navigating, dissector: any Dissecting,
+                indexer: any Indexing, store: ArtifactStore?) {
+        self.navigator = navigator
+        self.dissector = dissector
+        self.indexer = indexer
+        self.store = store
+    }
+
+    public func browseAndDissect(url: URL, wait: WaitPolicy, mode: DissectionMode,
+                                 index: IndexOptions?) async throws -> (Snapshot, Analysis?, IndexResult?) {
+        let snap = try await navigator.snapshot(url: url, wait: wait, store: store)
+        let analysis = try await dissector.analyze(from: snap, mode: mode, store: store)
+        let res = (index?.enabled ?? false) ? try await indexer.upsert(analysis: analysis, options: index!) : nil
+        return (snap, analysis, res)
+    }
+}
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/sb/agent.md
+++ b/sb/agent.md
@@ -27,7 +27,7 @@ sb/
 │   │       ├── AnalyzeCommand.swift
 │   │       └── IndexCommand.swift
 │   ├── SBCore/                         # Domain core, actors, models
-│   │   ├── SPS.swift                    # façade for end-to-end run
+│   │   ├── SB.swift                    # façade for end-to-end run
 │   │   ├── Models/                      # OpenAPI-aligned data models
 │   │   │   ├── Snapshot.swift
 │   │   │   ├── Analysis.swift
@@ -55,7 +55,7 @@ sb/
 ## 2) OpenAPI → Swift Bindings (HTTP Kernel is Optional)
 - Keep the OpenAPI spec at `sb/openapi/semantic-browser.openapi.yaml` .
 - Generate Swift server stubs using your **Swift OpenAPI kernel** (already used in other services).
-- Route implementations in `SBHTTPKernel/Kernel.swift` should delegate to `SBCore.SPS` façade.
+- Route implementations in `SBHTTPKernel/Kernel.swift` should delegate to `SBCore.SB` façade.
 
 > If you choose to run CLI-only, Codex interacts with `SBCLI` and skips the HTTP kernel.
 
@@ -224,7 +224,7 @@ Exit codes: 0 success; 2 bad args; 3 upstream (Typesense) unavailable; 4 navigat
     •    SB_HEADLESS (default true)
     •    SB_MAX_HOST_CONCURRENCY (default 2)
     •    SB_USER_AGENT (default generic)
-    •    SB_TYPESENSE_URL, SPS_TYPESENSE_API_KEY (optional)
+    •    SB_TYPESENSE_URL, SB_TYPESENSE_API_KEY (optional)
     •    SB_MAX_BODY_BYTES (e.g., 2_000_000 for XHR body capture)
     •    SB_SNAPSHOT_TEXT_TRUNCATE (safety cap for innerText)
 ```
@@ -291,7 +291,7 @@ Exit codes: 0 success; 2 bad args; 3 upstream (Typesense) unavailable; 4 navigat
     11.    Docs: add README.md and this agent.md; document CLI usage and OpenAPI URL.
 
 ### Commit/PR conventions:
-    •    PR title: feat(sps): semantic browser & dissector (swift-only, cli-first)
+    •    PR title: feat(sb): semantic browser & dissector (swift-only, cli-first)
     •    Labels: swift, cli, cdp, typesense, semantics
     •    Changelist order: scaffolding → browser → snapshot → dissector → indexer → CLI → tests.
 
@@ -317,3 +317,4 @@ End of agent brief.
 Codex: follow the runbook, keep commits focused, and ensure all models match the OpenAPI schemas exactly.
 
 
+> © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/sb/openapi/semantic-browser.openapi.yaml
+++ b/sb/openapi/semantic-browser.openapi.yaml
@@ -707,3 +707,4 @@ components:
         code: { type: string }
         message: { type: string }
         details: { type: object }
+# © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- rename façade to `SB.swift` and cleanly separate SB from existing SPS service
- update SB agent instructions with corrected environment variable and routing references

## Testing
- `cd sb && swift build`


------
https://chatgpt.com/codex/tasks/task_b_689f5576128c83339ff58cc927ce9d08