### PR TITLE
feat(sb): semantic browser & dissector (swift-only, cli-first)

### DIFF
--- a/sb/Sources/SBCore/Models/Analysis.swift
+++ b/sb/Sources/SBCore/Models/Analysis.swift
@@ -1,4 +1,99 @@
+import Foundation
+
 public struct Analysis: Codable, Sendable {
-    public init() {}
+    public struct Envelope: Codable, Sendable {
+        public struct Source: Codable, Sendable {
+            public var uri: URL?
+            public var fetchedAt: Date?
+            public init(uri: URL? = nil, fetchedAt: Date? = nil) {
+                self.uri = uri
+                self.fetchedAt = fetchedAt
+            }
+        }
+        public var id: String
+        public var source: Source?
+        public var contentType: String
+        public var language: String
+        public var bytes: Int?
+        public var diagnostics: [String]?
+
+        public init(id: String, source: Source? = nil, contentType: String, language: String, bytes: Int? = nil, diagnostics: [String]? = nil) {
+            self.id = id
+            self.source = source
+            self.contentType = contentType
+            self.language = language
+            self.bytes = bytes
+            self.diagnostics = diagnostics
+        }
+    }
+
+    public struct Semantics: Codable, Sendable {
+        public struct OutlineItem: Codable, Sendable {
+            public var block: String
+            public var level: Int?
+            public init(block: String, level: Int? = nil) {
+                self.block = block
+                self.level = level
+            }
+        }
+        public struct Relation: Codable, Sendable {
+            public enum RelationType: String, Codable, Sendable {
+                case SUPPORTS, CONTRADICTS, CITES, REFERS_TO
+            }
+            public var type: RelationType
+            public var from: String
+            public var to: String
+            public init(type: RelationType, from: String, to: String) {
+                self.type = type
+                self.from = from
+                self.to = to
+            }
+        }
+        public var outline: [OutlineItem]?
+        public var entities: [Entity]?
+        public var claims: [Claim]?
+        public var relations: [Relation]?
+
+        public init(outline: [OutlineItem]? = nil, entities: [Entity]? = nil, claims: [Claim]? = nil, relations: [Relation]? = nil) {
+            self.outline = outline
+            self.entities = entities
+            self.claims = claims
+            self.relations = relations
+        }
+    }
+
+    public struct Summaries: Codable, Sendable {
+        public var abstract: String?
+        public var keyPoints: [String]?
+        public var tl_dr: String?
+        public init(abstract: String? = nil, keyPoints: [String]? = nil, tl_dr: String? = nil) {
+            self.abstract = abstract
+            self.keyPoints = keyPoints
+            self.tl_dr = tl_dr
+        }
+    }
+
+    public struct Provenance: Codable, Sendable {
+        public var pipeline: String?
+        public var model: String?
+        public init(pipeline: String? = nil, model: String? = nil) {
+            self.pipeline = pipeline
+            self.model = model
+        }
+    }
+
+    public var envelope: Envelope
+    public var blocks: [Block]
+    public var semantics: Semantics?
+    public var summaries: Summaries?
+    public var provenance: Provenance?
+
+    public init(envelope: Envelope, blocks: [Block], semantics: Semantics? = nil, summaries: Summaries? = nil, provenance: Provenance? = nil) {
+        self.envelope = envelope
+        self.blocks = blocks
+        self.semantics = semantics
+        self.summaries = summaries
+        self.provenance = provenance
+    }
 }
 // © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/sb/Sources/SBCore/Models/Blocks.swift
+++ b/sb/Sources/SBCore/Models/Blocks.swift
@@ -1,4 +1,28 @@
-public struct Blocks: Codable, Sendable {
-    public init() {}
+import Foundation
+
+public struct Block: Codable, Sendable {
+    public enum Kind: String, Codable, Sendable {
+        case heading
+        case paragraph
+        case code
+        case caption
+        case table
+    }
+
+    public var id: String
+    public var kind: Kind
+    public var level: Int?
+    public var text: String
+    public var span: [Int]?
+    public var table: Table?
+
+    public init(id: String, kind: Kind, level: Int? = nil, text: String, span: [Int]? = nil, table: Table? = nil) {
+        self.id = id
+        self.kind = kind
+        self.level = level
+        self.text = text
+        self.span = span
+        self.table = table
+    }
 }
 // © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/sb/Sources/SBCore/Models/Claims.swift
+++ b/sb/Sources/SBCore/Models/Claims.swift
@@ -1,4 +1,42 @@
-public struct Claims: Codable, Sendable {
-    public init() {}
+import Foundation
+
+public struct Claim: Codable, Sendable {
+    public enum Stance: String, Codable, Sendable {
+        case AUTHOR_ASSERTED
+        case REPORTED
+        case UNCERTAIN
+    }
+
+    public enum Hedge: String, Codable, Sendable {
+        case LOW
+        case MEDIUM
+        case HIGH
+    }
+
+    public struct Evidence: Codable, Sendable {
+        public var block: String
+        public var span: [Int]?
+        public var tableCell: [Int]?
+
+        public init(block: String, span: [Int]? = nil, tableCell: [Int]? = nil) {
+            self.block = block
+            self.span = span
+            self.tableCell = tableCell
+        }
+    }
+
+    public var id: String
+    public var text: String
+    public var stance: Stance
+    public var hedge: Hedge
+    public var evidence: [Evidence]
+
+    public init(id: String, text: String, stance: Stance = .AUTHOR_ASSERTED, hedge: Hedge = .MEDIUM, evidence: [Evidence]) {
+        self.id = id
+        self.text = text
+        self.stance = stance
+        self.hedge = hedge
+        self.evidence = evidence
+    }
 }
 // © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/sb/Sources/SBCore/Models/DissectionMode.swift
+++ b/sb/Sources/SBCore/Models/DissectionMode.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 public enum DissectionMode: String, Codable, Sendable {
     case quick
     case standard

--- a/sb/Sources/SBCore/Models/Entities.swift
+++ b/sb/Sources/SBCore/Models/Entities.swift
@@ -1,4 +1,35 @@
-public struct Entities: Codable, Sendable {
-    public init() {}
+import Foundation
+
+public struct Entity: Codable, Sendable {
+    public enum EntityType: String, Codable, Sendable {
+        case PERSON
+        case ORG
+        case LOC
+        case PROD
+        case EVENT
+        case OTHER
+    }
+
+    public struct Mention: Codable, Sendable {
+        public var block: String
+        public var span: [Int]?
+
+        public init(block: String, span: [Int]? = nil) {
+            self.block = block
+            self.span = span
+        }
+    }
+
+    public var id: String
+    public var name: String
+    public var type: EntityType
+    public var mentions: [Mention]
+
+    public init(id: String, name: String, type: EntityType, mentions: [Mention]) {
+        self.id = id
+        self.name = name
+        self.type = type
+        self.mentions = mentions
+    }
 }
 // © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/sb/Sources/SBCore/Models/IndexDocs.swift
+++ b/sb/Sources/SBCore/Models/IndexDocs.swift
@@ -1,4 +1,80 @@
-public struct IndexDocs: Codable, Sendable {
-    public init() {}
+import Foundation
+
+public struct PageDoc: Codable, Sendable {
+    public var id: String?
+    public var url: URL?
+    public var host: String?
+    public var status: Int?
+    public var contentType: String?
+    public var lang: String?
+    public var title: String?
+    public var textSize: Int?
+    public var fetchedAt: Int?
+    public var labels: [String]?
+
+    public init(id: String? = nil, url: URL? = nil, host: String? = nil, status: Int? = nil, contentType: String? = nil, lang: String? = nil, title: String? = nil, textSize: Int? = nil, fetchedAt: Int? = nil, labels: [String]? = nil) {
+        self.id = id
+        self.url = url
+        self.host = host
+        self.status = status
+        self.contentType = contentType
+        self.lang = lang
+        self.title = title
+        self.textSize = textSize
+        self.fetchedAt = fetchedAt
+        self.labels = labels
+    }
+}
+
+public struct SegmentDoc: Codable, Sendable {
+    public var id: String?
+    public var pageId: String?
+    public var kind: String?
+    public var text: String?
+    public var pathHint: String?
+    public var offsetStart: Int?
+    public var offsetEnd: Int?
+    public var entities: [String]?
+
+    public init(id: String? = nil, pageId: String? = nil, kind: String? = nil, text: String? = nil, pathHint: String? = nil, offsetStart: Int? = nil, offsetEnd: Int? = nil, entities: [String]? = nil) {
+        self.id = id
+        self.pageId = pageId
+        self.kind = kind
+        self.text = text
+        self.pathHint = pathHint
+        self.offsetStart = offsetStart
+        self.offsetEnd = offsetEnd
+        self.entities = entities
+    }
+}
+
+public struct EntityDoc: Codable, Sendable {
+    public var id: String?
+    public var name: String?
+    public var type: String?
+    public var pageCount: Int?
+    public var mentions: Int?
+
+    public init(id: String? = nil, name: String? = nil, type: String? = nil, pageCount: Int? = nil, mentions: Int? = nil) {
+        self.id = id
+        self.name = name
+        self.type = type
+        self.pageCount = pageCount
+        self.mentions = mentions
+    }
+}
+
+public struct IndexResult: Codable, Sendable {
+    public var pagesUpserted: Int?
+    public var segmentsUpserted: Int?
+    public var entitiesUpserted: Int?
+    public var tablesUpserted: Int?
+
+    public init(pagesUpserted: Int? = nil, segmentsUpserted: Int? = nil, entitiesUpserted: Int? = nil, tablesUpserted: Int? = nil) {
+        self.pagesUpserted = pagesUpserted
+        self.segmentsUpserted = segmentsUpserted
+        self.entitiesUpserted = entitiesUpserted
+        self.tablesUpserted = tablesUpserted
+    }
 }
 // © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/sb/Sources/SBCore/Models/IndexOptions.swift
+++ b/sb/Sources/SBCore/Models/IndexOptions.swift
@@ -1,7 +1,37 @@
+import Foundation
+
 public struct IndexOptions: Codable, Sendable {
-    public var enabled: Bool
-    public init(enabled: Bool = false) {
+    public struct Typesense: Codable, Sendable {
+        public var url: URL?
+        public var apiKey: String?
+        public var timeoutMs: Int?
+
+        public init(url: URL? = nil, apiKey: String? = nil, timeoutMs: Int? = nil) {
+            self.url = url
+            self.apiKey = apiKey
+            self.timeoutMs = timeoutMs
+        }
+    }
+
+    public var enabled: Bool?
+    public var pagesCollection: String?
+    public var segmentsCollection: String?
+    public var entitiesCollection: String?
+    public var tablesCollection: String?
+    public var typesense: Typesense?
+
+    public init(enabled: Bool? = nil,
+                pagesCollection: String? = nil,
+                segmentsCollection: String? = nil,
+                entitiesCollection: String? = nil,
+                tablesCollection: String? = nil,
+                typesense: Typesense? = nil) {
         self.enabled = enabled
+        self.pagesCollection = pagesCollection
+        self.segmentsCollection = segmentsCollection
+        self.entitiesCollection = entitiesCollection
+        self.tablesCollection = tablesCollection
+        self.typesense = typesense
     }
 }
 // © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/sb/Sources/SBCore/Models/IndexResult.swift
+++ b/sb/Sources/SBCore/Models/IndexResult.swift
@@ -1,4 +1,0 @@
-public struct IndexResult: Codable, Sendable {
-    public init() {}
-}
-// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/sb/Sources/SBCore/Models/Snapshot.swift
+++ b/sb/Sources/SBCore/Models/Snapshot.swift
@@ -1,4 +1,81 @@
+import Foundation
+
 public struct Snapshot: Codable, Sendable {
-    public init() {}
+    public struct Page: Codable, Sendable {
+        public var uri: URL
+        public var finalUrl: URL?
+        public var fetchedAt: Date
+        public var status: Int
+        public var contentType: String
+        public struct Navigation: Codable, Sendable {
+            public var ttfbMs: Int?
+            public var loadMs: Int?
+            public init(ttfbMs: Int? = nil, loadMs: Int? = nil) {
+                self.ttfbMs = ttfbMs
+                self.loadMs = loadMs
+            }
+        }
+        public var navigation: Navigation?
+
+        public init(uri: URL, finalUrl: URL? = nil, fetchedAt: Date, status: Int, contentType: String, navigation: Navigation? = nil) {
+            self.uri = uri
+            self.finalUrl = finalUrl
+            self.fetchedAt = fetchedAt
+            self.status = status
+            self.contentType = contentType
+            self.navigation = navigation
+        }
+    }
+
+    public struct Rendered: Codable, Sendable {
+        public var html: String
+        public var text: String
+        public var meta: [String: String]?
+
+        public init(html: String, text: String, meta: [String: String]? = nil) {
+            self.html = html
+            self.text = text
+            self.meta = meta
+        }
+    }
+
+    public struct Network: Codable, Sendable {
+        public struct Request: Codable, Sendable {
+            public enum ResourceType: String, Codable, Sendable {
+                case Document, Stylesheet, Image, Media, Font, Script, XHR, Fetch, Other
+            }
+            public var url: URL
+            public var type: ResourceType?
+            public var status: Int?
+            public var body: String?
+
+            public init(url: URL, type: ResourceType? = nil, status: Int? = nil, body: String? = nil) {
+                self.url = url
+                self.type = type
+                self.status = status
+                self.body = body
+            }
+        }
+
+        public var requests: [Request]?
+
+        public init(requests: [Request]? = nil) {
+            self.requests = requests
+        }
+    }
+
+    public var snapshotId: String
+    public var page: Page
+    public var rendered: Rendered
+    public var network: Network?
+    public var diagnostics: [String]?
+
+    public init(snapshotId: String, page: Page, rendered: Rendered, network: Network? = nil, diagnostics: [String]? = nil) {
+        self.snapshotId = snapshotId
+        self.page = page
+        self.rendered = rendered
+        self.network = network
+        self.diagnostics = diagnostics
+    }
 }
 // © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/sb/Sources/SBCore/Models/Table.swift
+++ b/sb/Sources/SBCore/Models/Table.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+public struct Table: Codable, Sendable {
+    public var caption: String?
+    public var columns: [String]?
+    public var rows: [[String]]
+
+    public init(caption: String? = nil, columns: [String]? = nil, rows: [[String]] = []) {
+        self.caption = caption
+        self.columns = columns
+        self.rows = rows
+    }
+}
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/sb/Sources/SBCore/Models/WaitPolicy.swift
+++ b/sb/Sources/SBCore/Models/WaitPolicy.swift
@@ -1,4 +1,22 @@
-public enum WaitPolicy: String, Codable, Sendable {
-    case none
+import Foundation
+
+public struct WaitPolicy: Codable, Sendable {
+    public enum Strategy: String, Codable, Sendable {
+        case domContentLoaded
+        case networkIdle
+        case selector
+    }
+
+    public var strategy: Strategy
+    public var networkIdleMs: Int?
+    public var selector: String?
+    public var maxWaitMs: Int?
+
+    public init(strategy: Strategy, networkIdleMs: Int? = nil, selector: String? = nil, maxWaitMs: Int? = nil) {
+        self.strategy = strategy
+        self.networkIdleMs = networkIdleMs
+        self.selector = selector
+        self.maxWaitMs = maxWaitMs
+    }
 }
 // © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/sb/Sources/SBCore/Ports/ArtifactStore.swift
+++ b/sb/Sources/SBCore/Ports/ArtifactStore.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 public protocol ArtifactStore: Sendable {
     func writeSnapshot(_ snap: Snapshot) async throws
     func writeAnalysis(_ analysis: Analysis) async throws

--- a/sb/Sources/SBCore/Ports/Dissecting.swift
+++ b/sb/Sources/SBCore/Ports/Dissecting.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 public protocol Dissecting: Sendable {
     func analyze(from snapshot: Snapshot, mode: DissectionMode, store: ArtifactStore?) async throws -> Analysis
 }

--- a/sb/Sources/SBCore/Ports/Indexing.swift
+++ b/sb/Sources/SBCore/Ports/Indexing.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 public protocol Indexing: Sendable {
     func upsert(analysis: Analysis, options: IndexOptions) async throws -> IndexResult
 }


### PR DESCRIPTION
## Summary
- scaffold OpenAPI-aligned models for semantic browser core
- define hexagonal ports for navigation, dissection, indexing, and storage
- purge placeholder index result

## Testing
- `swift test --package-path sb` *(fails: no tests found)*

------
https://chatgpt.com/codex/tasks/task_b_689f5a9d1be483339058ec938cf15cc6