### PR TITLE
feat(sb): semantic browser & dissector (swift-only, cli-first)

### DIFF
--- a/agent.md
+++ b/agent.md
@@ -48,7 +48,7 @@ This agent maintains an up-to-date view of outstanding development tasks across 
 | SPS validation hooks | `sps/Sources/Validation/*`, `sps/Sources/SPSCLI/main.swift` | Add coverage + reserved-bit checks | ✅ | — | sps |
 | SPS samples & usage docs | `sps/Samples`, `docs/sps-usage-guide.md` | Provide annotated sample PDFs and usage guide with page-range queries & validation hooks | ✅ | — | docs, sps |
 | MIDI 2 library | `midi/*`, `sps/*`, `Sources/MIDI2/*` | Parse MIDI 2 spec via SPS and expose Swift Package module | ✅ | — | midi, sps, spm |
-| Semantic browser & dissector | `sb/*` | Scaffold SPM package and core models | 🚧 | — | sb, cli, cdp, typesense, semantics |
+| Semantic browser & dissector | `sb/*` | Scaffold SPM package, core models, tests | 🚧 | — | sb, cli, cdp, typesense, semantics |
 
 
 ---

--- a/sb/Package.swift
+++ b/sb/Package.swift
@@ -15,7 +15,14 @@ let package = Package(
             name: "SBCLI",
             dependencies: ["SBCore"]
         ),
-        .target(name: "SBCore")
+        .target(name: "SBCore"),
+        .testTarget(
+            name: "SBCoreTests",
+            dependencies: ["SBCore"],
+            resources: [
+                .copy("Golden")
+            ]
+        )
     ]
 )
 // © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/sb/Tests/SBCoreTests/Golden/sample.feed.xml
+++ b/sb/Tests/SBCoreTests/Golden/sample.feed.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0"?>
+<feed><title>Sample</title><entry><title>Entry</title></entry></feed>
+<!-- © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved. -->

--- a/sb/Tests/SBCoreTests/Golden/sample.html
+++ b/sb/Tests/SBCoreTests/Golden/sample.html
@@ -1,0 +1,3 @@
+<!doctype html>
+<html><body><h1>Sample</h1><p>Hello</p><pre><code>print("hi")</code></pre><table><tr><th>A</th></tr><tr><td>1</td></tr></table></body></html>
+<!-- © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved. -->

--- a/sb/Tests/SBCoreTests/Golden/sample.json
+++ b/sb/Tests/SBCoreTests/Golden/sample.json
@@ -1,0 +1,5 @@
+{
+  "array": [1, 2],
+  "object": {"key": "value"}
+}
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/sb/Tests/SBCoreTests/Golden/sample.md
+++ b/sb/Tests/SBCoreTests/Golden/sample.md
@@ -1,0 +1,5 @@
+# Sample
+
+Paragraph text.
+
+<!-- © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved. -->

--- a/sb/Tests/SBCoreTests/Golden/sample.pdf
+++ b/sb/Tests/SBCoreTests/Golden/sample.pdf
@@ -1,0 +1,37 @@
+%PDF-1.1
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 144] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>
+endobj
+4 0 obj
+<< /Length 44 >>
+stream
+BT
+/F1 24 Tf
+100 100 Td
+(Hello) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /Name /F1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000010 00000 n 
+0000000061 00000 n 
+0000000116 00000 n 
+0000000223 00000 n 
+0000000380 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+444
+%%EOF
+% © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/sb/Tests/SBCoreTests/ModelCodingTests.swift
+++ b/sb/Tests/SBCoreTests/ModelCodingTests.swift
@@ -1,0 +1,30 @@
+import XCTest
+@testable import SBCore
+
+final class ModelCodingTests: XCTestCase {
+    func testSnapshotCodingRoundTrip() throws {
+        let snap = Snapshot(
+            snapshotId: "s1",
+            page: .init(uri: URL(string: "https://example.com")!, fetchedAt: Date(timeIntervalSince1970: 0), status: 200, contentType: "text/html"),
+            rendered: .init(html: "<p>hi</p>", text: "hi"),
+            network: .init(requests: []),
+            diagnostics: ["ok"]
+        )
+        let data = try JSONEncoder().encode(snap)
+        let decoded = try JSONDecoder().decode(Snapshot.self, from: data)
+        XCTAssertEqual(decoded.snapshotId, "s1")
+        XCTAssertEqual(decoded.page.status, 200)
+    }
+
+    func testAnalysisCodingRoundTrip() throws {
+        let analysis = Analysis(
+            envelope: .init(id: "a1", contentType: "text/html", language: "en"),
+            blocks: [Block(id: "b1", kind: .paragraph, text: "hi", span: [0,2])]
+        )
+        let data = try JSONEncoder().encode(analysis)
+        let decoded = try JSONDecoder().decode(Analysis.self, from: data)
+        XCTAssertEqual(decoded.envelope.id, "a1")
+        XCTAssertEqual(decoded.blocks.first?.id, "b1")
+    }
+}
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/sb/Tests/SBCoreTests/SBOrchestratorTests.swift
+++ b/sb/Tests/SBCoreTests/SBOrchestratorTests.swift
@@ -1,0 +1,66 @@
+import XCTest
+@testable import SBCore
+
+final class SBOrchestratorTests: XCTestCase {
+    actor MockNavigator: Navigating {
+        func snapshot(url: URL, wait: WaitPolicy, store: ArtifactStore?) async throws -> Snapshot {
+            Snapshot(
+                snapshotId: "s1",
+                page: .init(uri: url, fetchedAt: Date(timeIntervalSince1970: 0), status: 200, contentType: "text/html"),
+                rendered: .init(html: "<p>hi</p>", text: "hi")
+            )
+        }
+    }
+
+    actor MockDissector: Dissecting {
+        func analyze(from snapshot: Snapshot, mode: DissectionMode, store: ArtifactStore?) async throws -> Analysis {
+            Analysis(
+                envelope: .init(id: "a1", contentType: "text/html", language: "en"),
+                blocks: []
+            )
+        }
+    }
+
+    actor MockIndexer: Indexing {
+        private(set) var callCount = 0
+        func upsert(analysis: Analysis, options: IndexOptions) async throws -> IndexResult {
+            callCount += 1
+            return IndexResult(pagesUpserted: 1)
+        }
+    }
+
+    struct MockStore: ArtifactStore {
+        func writeSnapshot(_ snap: Snapshot) async throws {}
+        func writeAnalysis(_ analysis: Analysis) async throws {}
+        func readSnapshot(id: String) async throws -> Snapshot? { nil }
+    }
+
+    func testBrowseAndDissectWithoutIndex() async throws {
+        let sb = SB(navigator: MockNavigator(), dissector: MockDissector(), indexer: MockIndexer(), store: nil)
+        let (snap, analysis, result) = try await sb.browseAndDissect(
+            url: URL(string: "https://example.com")!,
+            wait: WaitPolicy(strategy: .domContentLoaded),
+            mode: .quick,
+            index: nil
+        )
+        XCTAssertEqual(snap.snapshotId, "s1")
+        XCTAssertNotNil(analysis)
+        XCTAssertNil(result)
+    }
+
+    func testBrowseAndDissectWithIndex() async throws {
+        let indexer = MockIndexer()
+        let sb = SB(navigator: MockNavigator(), dissector: MockDissector(), indexer: indexer, store: nil)
+        let opts = IndexOptions(enabled: true)
+        let (_, _, result) = try await sb.browseAndDissect(
+            url: URL(string: "https://example.com")!,
+            wait: WaitPolicy(strategy: .domContentLoaded),
+            mode: .quick,
+            index: opts
+        )
+        XCTAssertEqual(result?.pagesUpserted, 1)
+        let calls = await indexer.callCount
+        XCTAssertEqual(calls, 1)
+    }
+}
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- set up SBCore test target with golden fixtures
- add orchestrator workflow tests and model encoding checks
- update repository task matrix for test coverage

## Testing
- `cd sb && swift test`


------
https://chatgpt.com/codex/tasks/task_b_689f5c911b708333a8f7ac08a6fce562