### PR TITLE
feat(sb): semantic browser & dissector (swift-only, cli-first)

### DIFF
--- a/agent.md
+++ b/agent.md
@@ -48,7 +48,7 @@ This agent maintains an up-to-date view of outstanding development tasks across 
 | SPS validation hooks | `sps/Sources/Validation/*`, `sps/Sources/SPSCLI/main.swift` | Add coverage + reserved-bit checks | ✅ | — | sps |
 | SPS samples & usage docs | `sps/Samples`, `docs/sps-usage-guide.md` | Provide annotated sample PDFs and usage guide with page-range queries & validation hooks | ✅ | — | docs, sps |
 | MIDI 2 library | `midi/*`, `sps/*`, `Sources/MIDI2/*` | Parse MIDI 2 spec via SPS and expose Swift Package module | ✅ | — | midi, sps, spm |
-| Semantic browser & dissector | `sb/*` | Scaffold SPM package, core models, tests | 🚧 | — | sb, cli, cdp, typesense, semantics |
+| Semantic browser & dissector | `sb/*` | Add BrowserPool and CDP client skeleton | 🚧 | — | sb, cli, cdp, typesense, semantics |
 
 
 ---

--- a/sb/Sources/SBCore/Browser/BrowserPool.swift
+++ b/sb/Sources/SBCore/Browser/BrowserPool.swift
@@ -1,0 +1,65 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+public actor BrowserPool {
+    public struct Options: Sendable {
+        public var executable: String
+        public init(executable: String = "chromium") {
+            self.executable = executable
+        }
+    }
+
+    private var processes: [Process] = []
+
+    public init() {}
+
+    @discardableResult
+    public func launch(_ options: Options = .init()) throws -> CDPClient {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: options.executable)
+        process.arguments = ["--headless=new", "--remote-debugging-port=0"]
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = pipe
+        try process.run()
+
+        let handle = pipe.fileHandleForReading
+        var buffer = Data()
+        var wsURL: URL?
+        while wsURL == nil {
+            let chunk = try handle.read(upToCount: 512) ?? Data()
+            if chunk.isEmpty { break }
+            buffer.append(chunk)
+            if let str = String(data: buffer, encoding: .utf8) {
+                wsURL = parseWebSocketURL(from: str)
+            }
+        }
+        guard let url = wsURL else {
+            process.terminate()
+            throw BrowserError.websocketURLNotFound
+        }
+        processes.append(process)
+        return CDPClient(endpoint: url)
+    }
+
+    private func parseWebSocketURL(from text: String) -> URL? {
+        guard let range = text.range(of: "ws://") else { return nil }
+        let substring = text[range.lowerBound...]
+        let end = substring.firstIndex { $0 == "\n" || $0 == "\r" } ?? substring.endIndex
+        return URL(string: String(substring[..<end]))
+    }
+
+    public enum BrowserError: Error {
+        case websocketURLNotFound
+    }
+
+    deinit {
+        for p in processes {
+            p.terminate()
+        }
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/sb/Sources/SBCore/Browser/CDPClient.swift
+++ b/sb/Sources/SBCore/Browser/CDPClient.swift
@@ -1,0 +1,72 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+public actor CDPClient {
+    public struct Command<P: Encodable & Sendable>: Encodable, Sendable {
+        public let id: Int
+        public let method: String
+        public let params: P?
+        public init(id: Int, method: String, params: P? = nil) {
+            self.id = id
+            self.method = method
+            self.params = params
+        }
+    }
+
+    public struct Response<R: Decodable & Sendable>: Decodable, Sendable {
+        public let id: Int
+        public let result: R?
+        public let error: RPCError?
+    }
+
+    public struct RPCError: Error, Decodable, Sendable {
+        public let code: Int
+        public let message: String
+    }
+
+    private let task: URLSessionWebSocketTask
+    private var nextId: Int = 0
+    private let encoder = JSONEncoder()
+    private let decoder = JSONDecoder()
+
+    public init(endpoint: URL, session: URLSession = .shared) {
+        self.task = session.webSocketTask(with: endpoint)
+        self.task.resume()
+    }
+
+    @discardableResult
+    public func send<P: Encodable & Sendable, R: Decodable & Sendable>(_ method: String, params: P? = nil, result: R.Type = R.self) async throws -> R {
+        nextId += 1
+        let cmd = Command(id: nextId, method: method, params: params)
+        let payload = try encoder.encode(cmd)
+        try await task.send(.data(payload))
+        while true {
+            let message = try await task.receive()
+            let data: Data
+            switch message {
+            case .data(let d):
+                data = d
+            case .string(let s):
+                data = Data(s.utf8)
+            @unknown default:
+                continue
+            }
+            let resp = try decoder.decode(Response<R>.self, from: data)
+            if resp.id == cmd.id {
+                if let result = resp.result {
+                    return result
+                } else {
+                    throw resp.error ?? RPCError(code: -1, message: "Unknown error")
+                }
+            }
+        }
+    }
+
+    public func close() {
+        task.cancel(with: .goingAway, reason: nil)
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/sb/Tests/SBCoreTests/CDPClientTests.swift
+++ b/sb/Tests/SBCoreTests/CDPClientTests.swift
@@ -1,0 +1,15 @@
+import XCTest
+@testable import SBCore
+
+final class CDPClientTests: XCTestCase {
+    func testCommandEncoding() throws {
+        let cmd = CDPClient.Command(id: 1, method: "Page.navigate", params: ["url": "https://example.com"])
+        let data = try JSONEncoder().encode(cmd)
+        let obj = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        XCTAssertEqual(obj?["method"] as? String, "Page.navigate")
+        let params = obj?["params"] as? [String: String]
+        XCTAssertEqual(params?["url"], "https://example.com")
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- add CDP client with JSON-RPC send routine
- manage headless Chromium sessions via BrowserPool actor
- verify CDP command encoding with new unit test

## Testing
- `swift test --package-path sb`


------
https://chatgpt.com/codex/tasks/task_b_689f5dffc25883339ce3bb6cca6c0095