### PR TITLE
feat(sb): semantic browser & dissector (swift-only, cli-first)

### DIFF
--- a/agent.md
+++ b/agent.md
@@ -48,7 +48,7 @@ This agent maintains an up-to-date view of outstanding development tasks across 
 | SPS validation hooks | `sps/Sources/Validation/*`, `sps/Sources/SPSCLI/main.swift` | Add coverage + reserved-bit checks | ✅ | — | sps |
 | SPS samples & usage docs | `sps/Samples`, `docs/sps-usage-guide.md` | Provide annotated sample PDFs and usage guide with page-range queries & validation hooks | ✅ | — | docs, sps |
 | MIDI 2 library | `midi/*`, `sps/*`, `Sources/MIDI2/*` | Parse MIDI 2 spec via SPS and expose Swift Package module | ✅ | — | midi, sps, spm |
-| Semantic browser & dissector | `sb/*` | Add BrowserPool and CDP client skeleton | 🚧 | — | sb, cli, cdp, typesense, semantics |
+| Semantic browser & dissector | `sb/*` | Implement SnapshotBuilder for DOM/text/meta capture | 🚧 | — | sb, cli, cdp, typesense, semantics |
 
 
 ---

--- a/sb/Sources/SBCore/Browser/SnapshotBuilder.swift
+++ b/sb/Sources/SBCore/Browser/SnapshotBuilder.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+public struct SnapshotBuilder: Sendable {
+    public init() {}
+
+    public func build(
+        url: URL,
+        finalUrl: URL? = nil,
+        fetchedAt: Date = Date(),
+        status: Int,
+        contentType: String,
+        html: String,
+        text: String,
+        meta: [String: String]? = nil,
+        network: [Snapshot.Network.Request]? = nil,
+        navigation: Snapshot.Page.Navigation? = nil,
+        diagnostics: [String]? = nil
+    ) -> Snapshot {
+        let page = Snapshot.Page(
+            uri: url,
+            finalUrl: finalUrl,
+            fetchedAt: fetchedAt,
+            status: status,
+            contentType: contentType,
+            navigation: navigation
+        )
+        let rendered = Snapshot.Rendered(html: html, text: text, meta: meta)
+        let net = network.map { Snapshot.Network(requests: $0) }
+        return Snapshot(
+            snapshotId: UUID().uuidString,
+            page: page,
+            rendered: rendered,
+            network: net,
+            diagnostics: diagnostics
+        )
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/sb/Tests/SBCoreTests/SnapshotBuilderTests.swift
+++ b/sb/Tests/SBCoreTests/SnapshotBuilderTests.swift
@@ -1,0 +1,24 @@
+import XCTest
+@testable import SBCore
+
+final class SnapshotBuilderTests: XCTestCase {
+    func testBuildSnapshotWithMetaAndNetwork() throws {
+        let builder = SnapshotBuilder()
+        let url = URL(string: "https://example.com")!
+        let request = Snapshot.Network.Request(url: url, type: .Document, status: 200, body: "<html></html>")
+        let snap = builder.build(
+            url: url,
+            status: 200,
+            contentType: "text/html",
+            html: "<p>hi</p>",
+            text: "hi",
+            meta: ["title": "hi"],
+            network: [request]
+        )
+        XCTAssertEqual(snap.page.uri, url)
+        XCTAssertEqual(snap.rendered.meta?["title"], "hi")
+        XCTAssertEqual(snap.network?.requests?.first?.body, "<html></html>")
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- implement `SnapshotBuilder` to assemble snapshots from DOM, text, metadata and network info
- exercise builder via unit test
- track progress in repository agent manifest

## Testing
- `cd sb && swift test`


------
https://chatgpt.com/codex/tasks/task_b_689f67cac71c83339a4115107e38b245