### PR TITLE
feat(sb): semantic browser & dissector (swift-only, cli-first)

### DIFF
--- a/agent.md
+++ b/agent.md
@@ -48,7 +48,7 @@ This agent maintains an up-to-date view of outstanding development tasks across 
 | SPS validation hooks | `sps/Sources/Validation/*`, `sps/Sources/SPSCLI/main.swift` | Add coverage + reserved-bit checks | ✅ | — | sps |
 | SPS samples & usage docs | `sps/Samples`, `docs/sps-usage-guide.md` | Provide annotated sample PDFs and usage guide with page-range queries & validation hooks | ✅ | — | docs, sps |
 | MIDI 2 library | `midi/*`, `sps/*`, `Sources/MIDI2/*` | Parse MIDI 2 spec via SPS and expose Swift Package module | ✅ | — | midi, sps, spm |
-| Semantic browser & dissector | `sb/*` | Implement SnapshotBuilder for DOM/text/meta capture | 🚧 | — | sb, cli, cdp, typesense, semantics |
+| Semantic browser & dissector | `sb/*` | Implement Dissector with basic segmentation and entity extraction | 🚧 | — | sb, cli, cdp, typesense, semantics |
 
 
 ---

--- a/sb/Sources/SBCore/Dissector/Dissector.swift
+++ b/sb/Sources/SBCore/Dissector/Dissector.swift
@@ -1,0 +1,77 @@
+import Foundation
+
+public struct Dissector: Dissecting {
+    public init() {}
+
+    public func analyze(from snapshot: Snapshot, mode: DissectionMode, store: ArtifactStore?) async throws -> Analysis {
+        let text = snapshot.rendered.text
+        let paragraphs = text.split(whereSeparator: { $0 == "\n" })
+        var blocks: [Block] = []
+        var offset = 0
+        for (idx, para) in paragraphs.enumerated() {
+            let str = String(para)
+            let start = offset
+            let end = start + str.count
+            let block = Block(id: "b\(idx)", kind: .paragraph, text: str, span: [start, end])
+            blocks.append(block)
+            offset = end + 1 // account for newline
+        }
+
+        let envelope = Analysis.Envelope(
+            id: snapshot.snapshotId,
+            source: .init(uri: snapshot.page.uri, fetchedAt: snapshot.page.fetchedAt),
+            contentType: snapshot.page.contentType,
+            language: "und",
+            bytes: snapshot.rendered.html.utf8.count
+        )
+
+        var semantics: Analysis.Semantics? = nil
+        if mode != .quick {
+            let entityPattern = try NSRegularExpression(pattern: "[A-Z][a-zA-Z]+")
+            var entitiesDict: [String: Entity] = [:]
+            for block in blocks {
+                let nsText = block.text as NSString
+                let matches = entityPattern.matches(in: block.text, range: NSRange(location: 0, length: nsText.length))
+                for match in matches {
+                    let name = nsText.substring(with: match.range)
+                    let globalStart = (block.span?[0] ?? 0) + match.range.location
+                    let globalEnd = globalStart + match.range.length
+                    let mention = Entity.Mention(block: block.id, span: [globalStart, globalEnd])
+                    if var existing = entitiesDict[name] {
+                        existing.mentions.append(mention)
+                        entitiesDict[name] = existing
+                    } else {
+                        entitiesDict[name] = Entity(id: "e\(entitiesDict.count)", name: name, type: .OTHER, mentions: [mention])
+                    }
+                }
+            }
+            let entities = Array(entitiesDict.values)
+
+            var claims: [Claim]? = nil
+            if mode == .deep {
+                claims = blocks.enumerated().map { idx, block in
+                    Claim(
+                        id: "c\(idx)",
+                        text: block.text,
+                        stance: .AUTHOR_ASSERTED,
+                        hedge: .MEDIUM,
+                        evidence: [Claim.Evidence(block: block.id, span: block.span)]
+                    )
+                }
+            }
+
+            semantics = Analysis.Semantics(entities: entities, claims: claims)
+        }
+
+        var summaries: Analysis.Summaries? = nil
+        if let first = blocks.first {
+            summaries = Analysis.Summaries(abstract: first.text)
+        }
+
+        let analysis = Analysis(envelope: envelope, blocks: blocks, semantics: semantics, summaries: summaries)
+        try await store?.writeAnalysis(analysis)
+        return analysis
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/sb/Tests/SBCoreTests/DissectorTests.swift
+++ b/sb/Tests/SBCoreTests/DissectorTests.swift
@@ -1,0 +1,36 @@
+import XCTest
+import SBCore
+
+final class DissectorTests: XCTestCase {
+    func testAnalyzeQuickProducesBlocksOnly() async throws {
+        let snapshot = SnapshotBuilder().build(
+            url: URL(string: "https://example.com")!,
+            status: 200,
+            contentType: "text/html",
+            html: "<p>Hello World</p>",
+            text: "Hello World"
+        )
+        let dissector = Dissector()
+        let analysis = try await dissector.analyze(from: snapshot, mode: .quick, store: nil)
+        XCTAssertEqual(analysis.blocks.count, 1)
+        XCTAssertNil(analysis.semantics?.entities)
+    }
+
+    func testAnalyzeDeepProducesEntitiesAndClaims() async throws {
+        let text = "Hello Alice\nBob loves Swift"
+        let snapshot = SnapshotBuilder().build(
+            url: URL(string: "https://example.com")!,
+            status: 200,
+            contentType: "text/plain",
+            html: text,
+            text: text
+        )
+        let dissector = Dissector()
+        let analysis = try await dissector.analyze(from: snapshot, mode: .deep, store: nil)
+        XCTAssertEqual(analysis.blocks.count, 2)
+        XCTAssertNotNil(analysis.semantics?.entities)
+        XCTAssertNotNil(analysis.semantics?.claims)
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- add basic Dissector that segments text into blocks and extracts entities and claims
- exercise Dissector through new unit tests for quick and deep modes
- update agent task matrix to reflect Dissector progress

## Testing
- `cd sb && swift test`

------
https://chatgpt.com/codex/tasks/task_b_689f69d9b7ac833390b9b42ea9876691