### PR TITLE
feat(sb): semantic browser & dissector (swift-only, cli-first)

### DIFF
--- a/sb/Sources/SBCLI/Commands/AnalyzeCommand.swift
+++ b/sb/Sources/SBCLI/Commands/AnalyzeCommand.swift
@@ -1,5 +1,43 @@
+import Foundation
+import SBCore
+
 public struct AnalyzeCommand {
     public init() {}
-    public func run() async throws {}
+
+    public func run(args: [String]) async throws {
+        var snapshotPath: URL?
+        var outDir: URL?
+        var mode: DissectionMode = .standard
+        var i = 0
+        while i < args.count {
+            let arg = args[i]
+            switch arg {
+            case "--snapshot":
+                if i + 1 < args.count { snapshotPath = URL(fileURLWithPath: args[i + 1]); i += 1 }
+            case "--out":
+                if i + 1 < args.count { outDir = URL(fileURLWithPath: args[i + 1], isDirectory: true); i += 1 }
+            case "--mode":
+                if i + 1 < args.count, let m = DissectionMode(rawValue: args[i + 1]) { mode = m; i += 1 }
+            default:
+                break
+            }
+            i += 1
+        }
+        guard let snapshotPath else { throw CLIError.invalidArguments }
+
+        let data = try Data(contentsOf: snapshotPath)
+        let snapshot = try JSONDecoder().decode(Snapshot.self, from: data)
+        let analysis = try await Dissector().analyze(from: snapshot, mode: mode, store: nil)
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        if let dir = outDir {
+            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+            try encoder.encode(analysis).write(to: dir.appendingPathComponent("analysis.json"))
+        }
+        let out = try encoder.encode(analysis)
+        FileHandle.standardOutput.write(out)
+    }
 }
+
 // © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/sb/Sources/SBCLI/Commands/BrowseCommand.swift
+++ b/sb/Sources/SBCLI/Commands/BrowseCommand.swift
@@ -1,5 +1,49 @@
+import Foundation
+import SBCore
+
 public struct BrowseCommand {
     public init() {}
-    public func run() async throws {}
+
+    public func run(args: [String]) async throws {
+        var url: URL?
+        var outDir: URL?
+        var mode: DissectionMode = .quick
+        var i = 0
+        while i < args.count {
+            let arg = args[i]
+            switch arg {
+            case "--url":
+                if i + 1 < args.count { url = URL(string: args[i + 1]); i += 1 }
+            case "--out":
+                if i + 1 < args.count { outDir = URL(fileURLWithPath: args[i + 1], isDirectory: true); i += 1 }
+            case "--mode":
+                if i + 1 < args.count, let m = DissectionMode(rawValue: args[i + 1]) { mode = m; i += 1 }
+            default:
+                break
+            }
+            i += 1
+        }
+        guard let targetURL = url else { throw CLIError.invalidArguments }
+
+        let navigator = URLNavigator()
+        let dissector = Dissector()
+        let indexer = TypesenseIndexer()
+        let sb = SB(navigator: navigator, dissector: dissector, indexer: indexer, store: nil)
+        let wait = WaitPolicy(strategy: .domContentLoaded, maxWaitMs: 15000)
+        let (snap, analysis, _) = try await sb.browseAndDissect(url: targetURL, wait: wait, mode: mode, index: nil)
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        if let dir = outDir {
+            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+            try encoder.encode(snap).write(to: dir.appendingPathComponent("snapshot.json"))
+            if let analysis = analysis {
+                try encoder.encode(analysis).write(to: dir.appendingPathComponent("analysis.json"))
+            }
+        }
+        let out = try encoder.encode(snap)
+        FileHandle.standardOutput.write(out)
+    }
 }
+
 // © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/sb/Sources/SBCLI/Commands/CLIError.swift
+++ b/sb/Sources/SBCLI/Commands/CLIError.swift
@@ -1,5 +1,5 @@
-import Foundation
-import SBCore
+enum CLIError: Error {
+    case invalidArguments
+}
 
-print("SBCLI placeholder")
 // © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/sb/Sources/SBCLI/Commands/IndexCommand.swift
+++ b/sb/Sources/SBCLI/Commands/IndexCommand.swift
@@ -1,5 +1,40 @@
+import Foundation
+import SBCore
+
 public struct IndexCommand {
     public init() {}
-    public func run() async throws {}
+
+    public func run(args: [String]) async throws {
+        var analysisPath: URL?
+        var tsURL: URL?
+        var apiKey: String?
+        var i = 0
+        while i < args.count {
+            let arg = args[i]
+            switch arg {
+            case "--analysis":
+                if i + 1 < args.count { analysisPath = URL(fileURLWithPath: args[i + 1]); i += 1 }
+            case "--typesense-url":
+                if i + 1 < args.count { tsURL = URL(string: args[i + 1]); i += 1 }
+            case "--typesense-key":
+                if i + 1 < args.count { apiKey = args[i + 1]; i += 1 }
+            default:
+                break
+            }
+            i += 1
+        }
+        guard let analysisPath, let tsURL, let apiKey else { throw CLIError.invalidArguments }
+
+        let data = try Data(contentsOf: analysisPath)
+        let analysis = try JSONDecoder().decode(Analysis.self, from: data)
+        var options = IndexOptions(enabled: true)
+        options.typesense = .init(url: tsURL, apiKey: apiKey, timeoutMs: nil)
+        let result = try await TypesenseIndexer().upsert(analysis: analysis, options: options)
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let out = try encoder.encode(result)
+        FileHandle.standardOutput.write(out)
+    }
 }
+
 // © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/sb/Sources/SBCLI/SBCLI.swift
+++ b/sb/Sources/SBCLI/SBCLI.swift
@@ -1,0 +1,26 @@
+import Foundation
+import SBCore
+
+@main
+struct SBCLI {
+    static func main() async throws {
+        var args = CommandLine.arguments.dropFirst()
+        guard let command = args.first else {
+            print("usage: sb <browse|analyze|index> ...")
+            return
+        }
+        args = args.dropFirst()
+        switch command {
+        case "browse":
+            try await BrowseCommand().run(args: Array(args))
+        case "analyze":
+            try await AnalyzeCommand().run(args: Array(args))
+        case "index":
+            try await IndexCommand().run(args: Array(args))
+        default:
+            print("unknown command \(command)")
+        }
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/sb/Sources/SBCore/Browser/URLNavigator.swift
+++ b/sb/Sources/SBCore/Browser/URLNavigator.swift
@@ -1,0 +1,26 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+public struct URLNavigator: Navigating {
+    private let session: URLSession
+    private let builder: SnapshotBuilder
+
+    public init(session: URLSession = .shared, builder: SnapshotBuilder = .init()) {
+        self.session = session
+        self.builder = builder
+    }
+
+    public func snapshot(url: URL, wait: WaitPolicy, store: ArtifactStore?) async throws -> Snapshot {
+        let (data, response) = try await session.data(from: url)
+        let html = String(decoding: data, as: UTF8.self)
+        let contentType = (response as? HTTPURLResponse)?.value(forHTTPHeaderField: "Content-Type") ?? "text/html"
+        let text = html.replacingOccurrences(of: "<[^>]+>", with: "", options: .regularExpression)
+        let snap = builder.build(url: url, status: (response as? HTTPURLResponse)?.statusCode ?? 0, contentType: contentType, html: html, text: text)
+        try await store?.writeSnapshot(snap)
+        return snap
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- add async entry point for `sb` and wire subcommands
- provide `URLNavigator` and basic `browse`, `analyze`, and `index` commands

## Testing
- `swift test` (sb)
- `swift test` *(fails: repository-wide build exceeds practical limits)*

------
https://chatgpt.com/codex/tasks/task_b_689f7009fbfc8333a0dea15c5d2b3e53