### PR TITLE
feat(ops): add semantic browser service

### DIFF
--- a/FountainAiLauncher/README.md
+++ b/FountainAiLauncher/README.md
@@ -31,6 +31,7 @@ This launcher replaces Docker, `systemd`, and `launchd` with a single, lightweig
 | Function Caller        | `function-caller`      | 8004  | Maps operationIds to HTTP |
 | Persistence Service    | `persistence-service`  | 8005  | Typesense-backed corpus storage |
 | **LLM Gateway**        | `llm-gateway`          | 8006  | Connects to external LLMs (OpenAI, Claude) |
+| Semantic Browser       | `semantic-browser`     | 8007  | Headless browsing and semantic dissection |
 | **Gateway**            | `fountain-gateway`     | 8010  | HTTPS, authentication, route proxying |
 | Publishing Frontend    | `publishing-frontend`  | 8085  | Serves static publishing assets |
 | Typesense Proxy        | `typesense-proxy`      | 8100  | Swift-native wrapper around Typesense |
@@ -68,6 +69,7 @@ The launcher expects the following executables to exist on disk. Install each se
 | Function Caller      | `/usr/local/bin/function-caller`          |
 | Persistence Service  | `/usr/local/bin/persistence-service`      |
 | LLM Gateway          | `/usr/local/bin/llm-gateway`              |
+| Semantic Browser     | `/usr/local/bin/semantic-browser`         |
 | Gateway              | `/usr/local/bin/fountain-gateway`         |
 | Publishing Frontend  | `/usr/local/bin/publishing-frontend`      |
 | Typesense Proxy      | `/usr/local/bin/typesense-proxy`          |

--- a/FountainAiLauncher/Sources/FountainAiLauncher/main.swift
+++ b/FountainAiLauncher/Sources/FountainAiLauncher/main.swift
@@ -8,6 +8,7 @@ let services: [Service] = [
     Service(name: "Function Caller", binaryPath: "/usr/local/bin/function-caller", port: 8004, healthPath: "/metrics"),
     Service(name: "Persistence Service", binaryPath: "/usr/local/bin/persistence-service", port: 8005, healthPath: "/metrics"),
     Service(name: "LLM Gateway", binaryPath: "/usr/local/bin/llm-gateway", port: 8006, healthPath: "/metrics"),
+    Service(name: "Semantic Browser", binaryPath: "/usr/local/bin/semantic-browser", port: 8007, healthPath: "/metrics"),
     Service(name: "Gateway", binaryPath: "/usr/local/bin/fountain-gateway", port: 8010, healthPath: "/metrics"),
     Service(name: "Publishing Frontend", binaryPath: "/usr/local/bin/publishing-frontend", port: 8085, healthPath: "/metrics"),
     Service(name: "Typesense Proxy", binaryPath: "/usr/local/bin/typesense-proxy", port: 8100, healthPath: "/metrics")

--- a/Sources/FountainOps/FountainAi/openAPI/README.md
+++ b/Sources/FountainOps/FountainAi/openAPI/README.md
@@ -13,6 +13,7 @@ This directory contains the OpenAPI specifications for each FountainAI microserv
 | Persistence | http://persist.fountain.coach/api/v1 | Typesense-backed store for baselines, drifts, reflections and registered tools. | [v1/persist.yml](v1/persist.yml) |
 | Planner | http://planner.fountain.coach/api/v1 | Orchestrates planning workflows across the LLM Gateway and Function Caller. | [v1/planner.yml](v1/planner.yml) |
 | Tools Factory | http://tools-factory.fountain.coach/api/v1 | Registers new tool definitions in the shared Typesense collection consumed by the Function Caller. | [v1/tools-factory.yml](v1/tools-factory.yml) |
+| Semantic Browser | https://api.fountain.coach/semantic-browser | Headless page renderer, semantic dissector and optional Typesense indexer. | [v1/semantic-browser.yml](v1/semantic-browser.yml) |
 | Typesense Server | http://typesense.fountain.coach | Underlying search engine powering the persistence layer. | [typesense.yml](typesense.yml) |
 
 ### Cross-service Interactions

--- a/Sources/FountainOps/FountainAi/openAPI/v1/semantic-browser.yml
+++ b/Sources/FountainOps/FountainAi/openAPI/v1/semantic-browser.yml
@@ -1,0 +1,743 @@
+openapi: 3.1.0
+info:
+  title: Semantic Browser & Dissector API
+  version: 0.2.0
+  summary: >
+    A Swift-only, JS-capable semantic browser that (1) renders a page, (2) snapshots network+DOM,
+    (3) semantically dissects rendered content into blocks/entities/claims/tables with span-level citations,
+    and (4) optionally indexes derived objects (pages/segments/entities/tables) into Typesense.
+  contact:
+    name: FountainAI
+    url: https://fountain.coach
+servers:
+  - url: https://semantic-browser.local
+    description: Local development
+  - url: https://api.fountain.coach/semantic-browser
+    description: Production
+
+tags:
+  - name: Browse
+    description: Navigate with a real browser (CDP/WebKit), wait for readiness, and capture a Snapshot.
+  - name: Analyze
+    description: Turn a Snapshot into a normalized Analysis (blocks, entities, claims, tables, summaries).
+  - name: Index
+    description: Upsert derived objects into Typesense. Typesense is a query index, not a source of truth.
+  - name: Query
+    description: Query previously indexed pages, segments, entities, and tables.
+  - name: Export
+    description: Export artifacts (rendered HTML/text/markdown/tables.csv) for auditing and handoff.
+  - name: Admin
+    description: Health, version, and runtime information.
+
+security:
+  - ApiKeyAuth: []
+
+paths:
+  /v1/browse:
+    post:
+      operationId: browseAndDissect
+      tags: [Browse]
+      summary: Navigate to a URL, snapshot the rendered page, optionally analyze and index in a single call.
+      description: >
+        Executes JavaScript (via a headless browser), waits for page readiness, captures DOM and network
+        responses, optionally runs semantic dissection and Typesense indexing. Returns the Snapshot and,
+        if requested, the Analysis and Index summary.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/BrowseRequest"
+            examples:
+              basic:
+                value:
+                  url: "https://github.com/explore"
+                  wait: { strategy: "networkIdle", networkIdleMs: 500, maxWaitMs: 10000 }
+                  mode: "standard"
+                  index: { enabled: true }
+      responses:
+        "200":
+          description: Snapshot (and optionally Analysis + Index result)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BrowseResponse"
+        "400": { $ref: "#/components/responses/BadRequest" }
+        "429": { $ref: "#/components/responses/TooManyRequests" }
+        "500": { $ref: "#/components/responses/ServerError" }
+
+  /v1/snapshot:
+    post:
+      operationId: snapshotOnly
+      tags: [Browse]
+      summary: Navigate and return only the Snapshot (no semantic analysis).
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "#/components/schemas/SnapshotRequest" }
+      responses:
+        "200":
+          description: Snapshot captured
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/SnapshotResponse" }
+        "400": { $ref: "#/components/responses/BadRequest" }
+        "429": { $ref: "#/components/responses/TooManyRequests" }
+        "500": { $ref: "#/components/responses/ServerError" }
+
+  /v1/analyze:
+    post:
+      operationId: analyzeSnapshot
+      tags: [Analyze]
+      summary: Run semantic dissection on a Snapshot (inline or by reference).
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "#/components/schemas/AnalyzeRequest" }
+            examples:
+              byId:
+                value:
+                  snapshotRef: { snapshotId: "snap_01HXYZ..." }
+                  mode: "deep"
+      responses:
+        "200":
+          description: Analysis produced
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Analysis" }
+        "400": { $ref: "#/components/responses/BadRequest" }
+        "500": { $ref: "#/components/responses/ServerError" }
+
+  /v1/index:
+    post:
+      operationId: indexAnalysis
+      tags: [Index]
+      summary: Upsert Analysis-derived objects (page/segments/entities/tables) into Typesense.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "#/components/schemas/IndexRequest" }
+      responses:
+        "200":
+          description: Index summary
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/IndexResult" }
+        "400": { $ref: "#/components/responses/BadRequest" }
+        "502": { $ref: "#/components/responses/UpstreamError" }
+
+  /v1/pages:
+    get:
+      operationId: queryPages
+      tags: [Query]
+      summary: Search previously indexed pages in Typesense.
+      parameters:
+        - name: q
+          in: query
+          description: Full-text query string.
+          schema: { type: string }
+        - name: host
+          in: query
+          description: Filter by page host (e.g., github.com).
+          schema: { type: string }
+        - name: lang
+          in: query
+          description: ISO language code filter.
+          schema: { type: string, pattern: "^[a-z]{2}(-[A-Z]{2})?$" }
+        - name: after
+          in: query
+          description: Filter pages fetched after this instant (RFC 3339).
+          schema: { type: string, format: date-time }
+        - name: before
+          in: query
+          description: Filter pages fetched before this instant (RFC 3339).
+          schema: { type: string, format: date-time }
+        - name: limit
+          in: query
+          schema: { type: integer, minimum: 1, maximum: 200, default: 20 }
+        - name: offset
+          in: query
+          schema: { type: integer, minimum: 0, default: 0 }
+      responses:
+        "200":
+          description: Page hits
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  total: { type: integer }
+                  items:
+                    type: array
+                    items: { $ref: "#/components/schemas/PageDoc" }
+
+  /v1/pages/{id}:
+    get:
+      operationId: getPage
+      tags: [Query]
+      summary: Fetch a single indexed page document by ID.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: Page document ID (Typesense or canonical ID).
+          schema: { type: string }
+      responses:
+        "200":
+          description: Page document
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/PageDoc" }
+        "404":
+          description: Not found
+
+  /v1/segments:
+    get:
+      operationId: querySegments
+      tags: [Query]
+      summary: Search segments (headings/paragraphs/code/captions/tables).
+      parameters:
+        - name: q
+          in: query
+          description: Full-text query string.
+          schema: { type: string }
+        - name: kind
+          in: query
+          schema:
+            type: string
+            enum: [heading, paragraph, code, caption, table]
+        - name: entity
+          in: query
+          schema: { type: string, description: "Filter segments mentioning a canonical entity" }
+        - name: limit
+          in: query
+          schema: { type: integer, minimum: 1, maximum: 200, default: 20 }
+        - name: offset
+          in: query
+          schema: { type: integer, minimum: 0, default: 0 }
+      responses:
+        "200":
+          description: Segment hits
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  total: { type: integer }
+                  items:
+                    type: array
+                    items: { $ref: "#/components/schemas/SegmentDoc" }
+
+  /v1/entities:
+    get:
+      operationId: queryEntities
+      tags: [Query]
+      summary: Search canonicalized entities.
+      parameters:
+        - name: q
+          in: query
+          description: Full-text query string.
+          schema: { type: string }
+        - name: type
+          in: query
+          schema: { type: string, enum: [PERSON, ORG, LOC, PROD, EVENT, OTHER] }
+        - name: limit
+          in: query
+          schema: { type: integer, minimum: 1, maximum: 200, default: 20 }
+        - name: offset
+          in: query
+          schema: { type: integer, minimum: 0, default: 0 }
+      responses:
+        "200":
+          description: Entity hits
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  total: { type: integer }
+                  items:
+                    type: array
+                    items: { $ref: "#/components/schemas/EntityDoc" }
+
+  /v1/export:
+    get:
+      operationId: exportArtifacts
+      tags: [Export]
+      summary: Export artifacts for a page/analysis.
+      parameters:
+        - name: pageId
+          in: query
+          required: true
+          schema: { type: string }
+        - name: format
+          in: query
+          required: true
+          schema:
+            type: string
+            enum: [snapshot.html, snapshot.text, analysis.json, summary.md, tables.csv]
+      responses:
+        "200":
+          description: Artifact stream
+          content:
+            text/html: { schema: { type: string } }
+            text/plain: { schema: { type: string } }
+            application/json: { schema: { type: object } }
+            text/markdown: { schema: { type: string } }
+            text/csv: { schema: { type: string } }
+        "404": { description: Not found }
+
+  /v1/health:
+    get:
+      operationId: health
+      tags: [Admin]
+      summary: Liveness and readiness probe.
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status: { type: string, enum: [ok] }
+                  version: { type: string }
+                  browserPool:
+                    type: object
+                    properties:
+                      capacity: { type: integer }
+                      inUse: { type: integer }
+
+components:
+  securitySchemes:
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: X-API-Key
+
+  parameters:
+    q:
+      name: q
+      in: query
+      description: Full-text query string.
+      schema: { type: string }
+    host:
+      name: host
+      in: query
+      description: Filter by page host (e.g., github.com).
+      schema: { type: string }
+    lang:
+      name: lang
+      in: query
+      description: ISO language code filter.
+      schema: { type: string, pattern: "^[a-z]{2}(-[A-Z]{2})?$" }
+    after:
+      name: after
+      in: query
+      description: Filter pages fetched after this instant (RFC 3339).
+      schema: { type: string, format: date-time }
+    before:
+      name: before
+      in: query
+      description: Filter pages fetched before this instant (RFC 3339).
+      schema: { type: string, format: date-time }
+    limit:
+      name: limit
+      in: query
+      schema: { type: integer, minimum: 1, maximum: 200, default: 20 }
+    offset:
+      name: offset
+      in: query
+      schema: { type: integer, minimum: 0, default: 0 }
+
+  responses:
+    BadRequest:
+      description: Bad request
+      content:
+        application/json: { schema: { $ref: "#/components/schemas/Error" } }
+    TooManyRequests:
+      description: Client or host concurrency/rate limit exceeded
+      headers:
+        Retry-After:
+          description: Seconds until a new attempt is allowed.
+          schema: { type: integer }
+      content:
+        application/json: { schema: { $ref: "#/components/schemas/Error" } }
+    UpstreamError:
+      description: Upstream service error (e.g., Typesense unavailable)
+      content:
+        application/json: { schema: { $ref: "#/components/schemas/Error" } }
+    ServerError:
+      description: Unexpected server error
+      content:
+        application/json: { schema: { $ref: "#/components/schemas/Error" } }
+
+  schemas:
+    # -------- Requests / Orchestration --------
+    BrowseRequest:
+      type: object
+      required: [url, wait, mode]
+      properties:
+        url: { type: string, format: uri }
+        wait:
+          $ref: "#/components/schemas/WaitPolicy"
+        mode:
+          $ref: "#/components/schemas/DissectionMode"
+        index:
+          $ref: "#/components/schemas/IndexOptions"
+        storeArtifacts:
+          type: boolean
+          description: Persist snapshot & analysis artifacts for later export.
+          default: true
+        labels:
+          type: array
+          items: { type: string }
+          description: Optional labels to tag the page in Typesense facets.
+
+    BrowseResponse:
+      type: object
+      required: [snapshot]
+      properties:
+        snapshot:
+          $ref: "#/components/schemas/Snapshot"
+        analysis:
+          $ref: "#/components/schemas/Analysis"
+        index:
+          $ref: "#/components/schemas/IndexResult"
+
+    SnapshotRequest:
+      type: object
+      required: [url, wait]
+      properties:
+        url: { type: string, format: uri }
+        wait: { $ref: "#/components/schemas/WaitPolicy" }
+        storeArtifacts:
+          type: boolean
+          default: true
+
+    SnapshotResponse:
+      type: object
+      required: [snapshot]
+      properties:
+        snapshot: { $ref: "#/components/schemas/Snapshot" }
+
+    AnalyzeRequest:
+      type: object
+      required: [mode]
+      properties:
+        snapshot:
+          $ref: "#/components/schemas/Snapshot"
+        snapshotRef:
+          type: object
+          properties:
+            snapshotId: { type: string }
+          description: Use a stored snapshot by ID (mutually exclusive with inline snapshot).
+        mode:
+          $ref: "#/components/schemas/DissectionMode"
+
+    IndexRequest:
+      type: object
+      required: [analysis]
+      properties:
+        analysis:
+          $ref: "#/components/schemas/Analysis"
+        options:
+          $ref: "#/components/schemas/IndexOptions"
+
+    IndexOptions:
+      type: object
+      properties:
+        enabled:
+          type: boolean
+          default: true
+        pagesCollection:
+          type: string
+          default: pages
+        segmentsCollection:
+          type: string
+          default: segments
+        entitiesCollection:
+          type: string
+          default: entities
+        tablesCollection:
+          type: string
+          default: tables
+        typesense:
+          type: object
+          description: Minimal Typesense connection details.
+          properties:
+            url: { type: string, format: uri }
+            apiKey: { type: string }
+            timeoutMs: { type: integer, default: 3000 }
+
+    DissectionMode:
+      type: string
+      enum: [quick, standard, deep]
+      description: quick=outline+summary, standard=+entities/tables, deep=+claims/relations.
+
+    WaitPolicy:
+      type: object
+      required: [strategy]
+      properties:
+        strategy:
+          type: string
+          enum: [domContentLoaded, networkIdle, selector]
+        networkIdleMs:
+          type: integer
+          minimum: 0
+          description: Quiescence window; used when strategy=networkIdle.
+        selector:
+          type: string
+          description: CSS selector to await; used when strategy=selector.
+        maxWaitMs:
+          type: integer
+          minimum: 1
+          default: 15000
+
+    # -------- Snapshot / Analysis --------
+    Snapshot:
+      type: object
+      required: [snapshotId, page, rendered]
+      properties:
+        snapshotId: { type: string }
+        page:
+          type: object
+          required: [uri, fetchedAt, status, contentType]
+          properties:
+            uri: { type: string, format: uri }
+            finalUrl: { type: string, format: uri }
+            fetchedAt: { type: string, format: date-time }
+            status: { type: integer }
+            contentType: { type: string }
+            navigation:
+              type: object
+              properties:
+                ttfbMs: { type: integer }
+                loadMs: { type: integer }
+        rendered:
+          type: object
+          required: [html, text]
+          properties:
+            html: { type: string }
+            text: { type: string }
+            meta:
+              type: object
+              additionalProperties: { type: string }
+        network:
+          type: object
+          properties:
+            requests:
+              type: array
+              items:
+                type: object
+                properties:
+                  url: { type: string, format: uri }
+                  type: { type: string, enum: [Document, Stylesheet, Image, Media, Font, Script, XHR, Fetch, Other] }
+                  status: { type: integer }
+                  body: { type: string, description: "Captured body (sniffed; may be truncated for large content)" }
+        diagnostics:
+          type: array
+          items: { type: string }
+
+    Analysis:
+      type: object
+      required: [envelope, blocks, summaries, provenance]
+      properties:
+        envelope:
+          type: object
+          required: [id, source, contentType, language]
+          properties:
+            id: { type: string, description: "sha256 of raw bytes or url+etag" }
+            source:
+              type: object
+              properties:
+                uri: { type: string, format: uri }
+                fetchedAt: { type: string, format: date-time }
+            contentType: { type: string }
+            language: { type: string }
+            bytes: { type: integer }
+            diagnostics:
+              type: array
+              items: { type: string }
+        blocks:
+          type: array
+          items:
+            $ref: "#/components/schemas/Block"
+        semantics:
+          type: object
+          properties:
+            outline:
+              type: array
+              items:
+                type: object
+                properties:
+                  block: { type: string }
+                  level: { type: integer, minimum: 1, maximum: 6 }
+            entities:
+              type: array
+              items: { $ref: "#/components/schemas/Entity" }
+            claims:
+              type: array
+              items: { $ref: "#/components/schemas/Claim" }
+            relations:
+              type: array
+              items:
+                type: object
+                properties:
+                  type: { type: string, enum: [SUPPORTS, CONTRADICTS, CITES, REFERS_TO] }
+                  from: { type: string }
+                  to: { type: string }
+        summaries:
+          type: object
+          properties:
+            abstract: { type: string }
+            keyPoints:
+              type: array
+              items: { type: string }
+            tl;dr: { type: string }
+        provenance:
+          type: object
+          properties:
+            pipeline: { type: string }
+            model: { type: string }
+
+    Block:
+      type: object
+      required: [id, kind, text]
+      properties:
+        id: { type: string }
+        kind:
+          type: string
+          enum: [heading, paragraph, code, caption, table]
+        level:
+          type: integer
+          description: Heading level (1..6) when kind=heading.
+        text:
+          type: string
+        span:
+          type: array
+          items: { type: integer }
+          minItems: 2
+          maxItems: 2
+          description: Character offsets [start,end) into rendered.text
+        table:
+          $ref: "#/components/schemas/Table"
+
+    Table:
+      type: object
+      required: [rows]
+      properties:
+        caption: { type: string }
+        columns:
+          type: array
+          items: { type: string }
+        rows:
+          type: array
+          items:
+            type: array
+            items: { type: string }
+
+    Entity:
+      type: object
+      required: [id, name, type, mentions]
+      properties:
+        id: { type: string }
+        name: { type: string }
+        type: { type: string, enum: [PERSON, ORG, LOC, PROD, EVENT, OTHER] }
+        mentions:
+          type: array
+          items:
+            type: object
+            properties:
+              block: { type: string }
+              span:
+                type: array
+                items: { type: integer }
+                minItems: 2
+                maxItems: 2
+
+    Claim:
+      type: object
+      required: [id, text, evidence]
+      properties:
+        id: { type: string }
+        text: { type: string }
+        stance: { type: string, enum: [AUTHOR_ASSERTED, REPORTED, UNCERTAIN], default: AUTHOR_ASSERTED }
+        hedge: { type: string, enum: [LOW, MEDIUM, HIGH], default: MEDIUM }
+        evidence:
+          type: array
+          items:
+            type: object
+            properties:
+              block: { type: string }
+              span:
+                type: array
+                items: { type: integer }
+                minItems: 2
+                maxItems: 2
+              tableCell:
+                type: array
+                items: { type: integer }
+                minItems: 2
+                maxItems: 2
+                description: Optional [rowIndex, colIndex] when citing a table cell
+
+    # -------- Index (Typesense-shaped docs) --------
+    PageDoc:
+      type: object
+      properties:
+        id: { type: string }
+        url: { type: string, format: uri }
+        host: { type: string }
+        status: { type: integer }
+        contentType: { type: string }
+        lang: { type: string }
+        title: { type: string }
+        textSize: { type: integer }
+        fetchedAt: { type: integer, description: "epoch ms" }
+        labels:
+          type: array
+          items: { type: string }
+
+    SegmentDoc:
+      type: object
+      properties:
+        id: { type: string }
+        pageId: { type: string }
+        kind: { type: string, enum: [heading, paragraph, code, caption, table] }
+        text: { type: string }
+        pathHint: { type: string }
+        offsetStart: { type: integer }
+        offsetEnd: { type: integer }
+        entities:
+          type: array
+          items: { type: string }
+
+    EntityDoc:
+      type: object
+      properties:
+        id: { type: string }
+        name: { type: string }
+        type: { type: string }
+        pageCount: { type: integer }
+        mentions: { type: integer }
+
+    IndexResult:
+      type: object
+      properties:
+        pagesUpserted: { type: integer }
+        segmentsUpserted: { type: integer }
+        entitiesUpserted: { type: integer }
+        tablesUpserted: { type: integer }
+
+    # -------- Errors --------
+    Error:
+      type: object
+      properties:
+        code: { type: string }
+        message: { type: string }
+        details: { type: object }
+# © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Client/semantic-browser/APIClient.swift
+++ b/Sources/FountainOps/Generated/Client/semantic-browser/APIClient.swift
@@ -1,0 +1,48 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+public protocol HTTPSession {
+    func data(for request: URLRequest) async throws -> (Data, URLResponse)
+}
+
+extension URLSession: HTTPSession {
+    public func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+        try await self.data(for: request, delegate: nil)
+    }
+}
+
+public struct APIClient {
+    let baseURL: URL
+    let session: HTTPSession
+    let defaultHeaders: [String: String]
+
+    public init(baseURL: URL, session: HTTPSession = URLSession.shared, defaultHeaders: [String: String] = [:]) {
+        self.baseURL = baseURL
+        self.session = session
+        self.defaultHeaders = defaultHeaders
+    }
+
+    public func send<R: APIRequest>(_ request: R) async throws -> R.Response {
+        var urlRequest = URLRequest(url: baseURL.appendingPathComponent(request.path))
+        urlRequest.httpMethod = request.method
+        for (header, value) in defaultHeaders {
+            urlRequest.setValue(value, forHTTPHeaderField: header)
+        }
+        if let body = request.body {
+            urlRequest.httpBody = try JSONEncoder().encode(body)
+            urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        }
+        let (data, _) = try await session.data(for: urlRequest)
+        return try JSONDecoder().decode(R.Response.self, from: data)
+    }
+}
+
+public extension APIClient {
+    init(baseURL: URL, bearerToken: String, session: HTTPSession = URLSession.shared) {
+        self.init(baseURL: baseURL, session: session, defaultHeaders: ["Authorization": "Bearer \(bearerToken)"])
+    }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Client/semantic-browser/APIRequest.swift
+++ b/Sources/FountainOps/Generated/Client/semantic-browser/APIRequest.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+/// Empty body type used for requests without a payload.
+public struct NoBody: Codable {}
+
+public protocol APIRequest {
+    associatedtype Body: Encodable = NoBody
+    associatedtype Response: Decodable
+    var method: String { get }
+    var path: String { get }
+    var body: Body? { get }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Client/semantic-browser/Models.swift
+++ b/Sources/FountainOps/Generated/Client/semantic-browser/Models.swift
@@ -1,0 +1,176 @@
+// Models for Semantic Browser & Dissector API
+
+public struct Analysis: Codable {
+    public let blocks: [Block]
+    public let envelope: [String: String]
+    public let provenance: [String: String]
+    public let semantics: [String: String]
+    public let summaries: [String: String]
+}
+
+public struct AnalyzeRequest: Codable {
+    public let mode: DissectionMode
+    public let snapshot: Snapshot
+    public let snapshotRef: [String: String]
+}
+
+public struct Block: Codable {
+    public let id: String
+    public let kind: String
+    public let level: Int
+    public let span: [Int]
+    public let table: Table
+    public let text: String
+}
+
+public struct BrowseRequest: Codable {
+    public let index: IndexOptions
+    public let labels: [String]
+    public let mode: DissectionMode
+    public let storeArtifacts: Bool
+    public let url: String
+    public let wait: WaitPolicy
+}
+
+public struct BrowseResponse: Codable {
+    public let analysis: Analysis
+    public let index: IndexResult
+    public let snapshot: Snapshot
+}
+
+public struct Claim: Codable {
+    public let evidence: [[String: String]]
+    public let hedge: String
+    public let id: String
+    public let stance: String
+    public let text: String
+}
+
+public enum DissectionMode: String, Codable {
+    case quick
+    case standard
+    case deep
+}
+
+public struct Entity: Codable {
+    public let id: String
+    public let mentions: [[String: String]]
+    public let name: String
+    public let type: String
+}
+
+public struct EntityDoc: Codable {
+    public let id: String
+    public let mentions: Int
+    public let name: String
+    public let pageCount: Int
+    public let type: String
+}
+
+public struct Error: Codable {
+    public let code: String
+    public let details: [String: String]
+    public let message: String
+}
+
+public struct IndexOptions: Codable {
+    public let enabled: Bool
+    public let entitiesCollection: String
+    public let pagesCollection: String
+    public let segmentsCollection: String
+    public let tablesCollection: String
+    public let typesense: [String: String]
+}
+
+public struct IndexRequest: Codable {
+    public let analysis: Analysis
+    public let options: IndexOptions
+}
+
+public struct IndexResult: Codable {
+    public let entitiesUpserted: Int
+    public let pagesUpserted: Int
+    public let segmentsUpserted: Int
+    public let tablesUpserted: Int
+}
+
+public struct PageDoc: Codable {
+    public let contentType: String
+    public let fetchedAt: Int
+    public let host: String
+    public let id: String
+    public let labels: [String]
+    public let lang: String
+    public let status: Int
+    public let textSize: Int
+    public let title: String
+    public let url: String
+}
+
+public struct SegmentDoc: Codable {
+    public let entities: [String]
+    public let id: String
+    public let kind: String
+    public let offsetEnd: Int
+    public let offsetStart: Int
+    public let pageId: String
+    public let pathHint: String
+    public let text: String
+}
+
+public struct Snapshot: Codable {
+    public let diagnostics: [String]
+    public let network: [String: String]
+    public let page: [String: String]
+    public let rendered: [String: String]
+    public let snapshotId: String
+}
+
+public struct SnapshotRequest: Codable {
+    public let storeArtifacts: Bool
+    public let url: String
+    public let wait: WaitPolicy
+}
+
+public struct SnapshotResponse: Codable {
+    public let snapshot: Snapshot
+}
+
+public struct Table: Codable {
+    public let caption: String
+    public let columns: [String]
+    public let rows: [[String]]
+}
+
+public struct WaitPolicy: Codable {
+    public let maxWaitMs: Int
+    public let networkIdleMs: Int
+    public let selector: String
+    public let strategy: String
+}
+
+public struct queryPagesResponse: Codable {
+    public let items: [PageDoc]
+    public let total: Int
+}
+
+public struct healthResponse: Codable {
+    public let browserPool: [String: String]
+    public let status: String
+    public let version: String
+}
+
+public struct queryEntitiesResponse: Codable {
+    public let items: [EntityDoc]
+    public let total: Int
+}
+
+public typealias exportArtifactsResponse = [String: String]
+
+public struct querySegmentsResponse: Codable {
+    public let items: [SegmentDoc]
+    public let total: Int
+}
+
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Client/semantic-browser/Requests/analyzeSnapshot.swift
+++ b/Sources/FountainOps/Generated/Client/semantic-browser/Requests/analyzeSnapshot.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+public struct analyzeSnapshot: APIRequest {
+    public typealias Body = AnalyzeRequest
+    public typealias Response = Analysis
+    public var method: String { "POST" }
+    public var path: String { "/v1/analyze" }
+    public var body: Body?
+
+    public init(body: Body? = nil) {
+        self.body = body
+    }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Client/semantic-browser/Requests/browseAndDissect.swift
+++ b/Sources/FountainOps/Generated/Client/semantic-browser/Requests/browseAndDissect.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+public struct browseAndDissect: APIRequest {
+    public typealias Body = BrowseRequest
+    public typealias Response = BrowseResponse
+    public var method: String { "POST" }
+    public var path: String { "/v1/browse" }
+    public var body: Body?
+
+    public init(body: Body? = nil) {
+        self.body = body
+    }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Client/semantic-browser/Requests/exportArtifacts.swift
+++ b/Sources/FountainOps/Generated/Client/semantic-browser/Requests/exportArtifacts.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+public struct exportArtifactsParameters: Codable {
+    public let pageid: String
+    public let format: String
+}
+
+public struct exportArtifacts: APIRequest {
+    public typealias Body = NoBody
+    public typealias Response = exportArtifactsResponse
+    public var method: String { "GET" }
+    public var parameters: exportArtifactsParameters
+    public var path: String {
+        var path = "/v1/export"
+        var query: [String] = []
+        query.append("pageId=\(parameters.pageid)")
+        query.append("format=\(parameters.format)")
+        if !query.isEmpty { path += "?" + query.joined(separator: "&") }
+        return path
+    }
+    public var body: Body?
+
+    public init(parameters: exportArtifactsParameters, body: Body? = nil) {
+        self.parameters = parameters
+        self.body = body
+    }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Client/semantic-browser/Requests/getPage.swift
+++ b/Sources/FountainOps/Generated/Client/semantic-browser/Requests/getPage.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+public struct getPageParameters: Codable {
+    public let id: String
+}
+
+public struct getPage: APIRequest {
+    public typealias Body = NoBody
+    public typealias Response = PageDoc
+    public var method: String { "GET" }
+    public var parameters: getPageParameters
+    public var path: String {
+        var path = "/v1/pages/{id}"
+        var query: [String] = []
+        path = path.replacingOccurrences(of: "{id}", with: String(parameters.id))
+        if !query.isEmpty { path += "?" + query.joined(separator: "&") }
+        return path
+    }
+    public var body: Body?
+
+    public init(parameters: getPageParameters, body: Body? = nil) {
+        self.parameters = parameters
+        self.body = body
+    }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Client/semantic-browser/Requests/health.swift
+++ b/Sources/FountainOps/Generated/Client/semantic-browser/Requests/health.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+public struct health: APIRequest {
+    public typealias Body = NoBody
+    public typealias Response = healthResponse
+    public var method: String { "GET" }
+    public var path: String { "/v1/health" }
+    public var body: Body?
+
+    public init(body: Body? = nil) {
+        self.body = body
+    }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Client/semantic-browser/Requests/indexAnalysis.swift
+++ b/Sources/FountainOps/Generated/Client/semantic-browser/Requests/indexAnalysis.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+public struct indexAnalysis: APIRequest {
+    public typealias Body = IndexRequest
+    public typealias Response = IndexResult
+    public var method: String { "POST" }
+    public var path: String { "/v1/index" }
+    public var body: Body?
+
+    public init(body: Body? = nil) {
+        self.body = body
+    }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Client/semantic-browser/Requests/queryEntities.swift
+++ b/Sources/FountainOps/Generated/Client/semantic-browser/Requests/queryEntities.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+public struct queryEntitiesParameters: Codable {
+    public var q: String?
+    public var type: String?
+    public var limit: Int?
+    public var offset: Int?
+}
+
+public struct queryEntities: APIRequest {
+    public typealias Body = NoBody
+    public typealias Response = queryEntitiesResponse
+    public var method: String { "GET" }
+    public var parameters: queryEntitiesParameters
+    public var path: String {
+        var path = "/v1/entities"
+        var query: [String] = []
+        if let value = parameters.q { query.append("q=\(value)") }
+        if let value = parameters.type { query.append("type=\(value)") }
+        if let value = parameters.limit { query.append("limit=\(value)") }
+        if let value = parameters.offset { query.append("offset=\(value)") }
+        if !query.isEmpty { path += "?" + query.joined(separator: "&") }
+        return path
+    }
+    public var body: Body?
+
+    public init(parameters: queryEntitiesParameters, body: Body? = nil) {
+        self.parameters = parameters
+        self.body = body
+    }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Client/semantic-browser/Requests/queryPages.swift
+++ b/Sources/FountainOps/Generated/Client/semantic-browser/Requests/queryPages.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+public struct queryPagesParameters: Codable {
+    public var q: String?
+    public var host: String?
+    public var lang: String?
+    public var after: String?
+    public var before: String?
+    public var limit: Int?
+    public var offset: Int?
+}
+
+public struct queryPages: APIRequest {
+    public typealias Body = NoBody
+    public typealias Response = queryPagesResponse
+    public var method: String { "GET" }
+    public var parameters: queryPagesParameters
+    public var path: String {
+        var path = "/v1/pages"
+        var query: [String] = []
+        if let value = parameters.q { query.append("q=\(value)") }
+        if let value = parameters.host { query.append("host=\(value)") }
+        if let value = parameters.lang { query.append("lang=\(value)") }
+        if let value = parameters.after { query.append("after=\(value)") }
+        if let value = parameters.before { query.append("before=\(value)") }
+        if let value = parameters.limit { query.append("limit=\(value)") }
+        if let value = parameters.offset { query.append("offset=\(value)") }
+        if !query.isEmpty { path += "?" + query.joined(separator: "&") }
+        return path
+    }
+    public var body: Body?
+
+    public init(parameters: queryPagesParameters, body: Body? = nil) {
+        self.parameters = parameters
+        self.body = body
+    }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Client/semantic-browser/Requests/querySegments.swift
+++ b/Sources/FountainOps/Generated/Client/semantic-browser/Requests/querySegments.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+public struct querySegmentsParameters: Codable {
+    public var q: String?
+    public var kind: String?
+    public var entity: String?
+    public var limit: Int?
+    public var offset: Int?
+}
+
+public struct querySegments: APIRequest {
+    public typealias Body = NoBody
+    public typealias Response = querySegmentsResponse
+    public var method: String { "GET" }
+    public var parameters: querySegmentsParameters
+    public var path: String {
+        var path = "/v1/segments"
+        var query: [String] = []
+        if let value = parameters.q { query.append("q=\(value)") }
+        if let value = parameters.kind { query.append("kind=\(value)") }
+        if let value = parameters.entity { query.append("entity=\(value)") }
+        if let value = parameters.limit { query.append("limit=\(value)") }
+        if let value = parameters.offset { query.append("offset=\(value)") }
+        if !query.isEmpty { path += "?" + query.joined(separator: "&") }
+        return path
+    }
+    public var body: Body?
+
+    public init(parameters: querySegmentsParameters, body: Body? = nil) {
+        self.parameters = parameters
+        self.body = body
+    }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Client/semantic-browser/Requests/snapshotOnly.swift
+++ b/Sources/FountainOps/Generated/Client/semantic-browser/Requests/snapshotOnly.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+public struct snapshotOnly: APIRequest {
+    public typealias Body = SnapshotRequest
+    public typealias Response = SnapshotResponse
+    public var method: String { "POST" }
+    public var path: String { "/v1/snapshot" }
+    public var body: Body?
+
+    public init(body: Body? = nil) {
+        self.body = body
+    }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Server/semantic-browser/HTTPKernel.swift
+++ b/Sources/FountainOps/Generated/Server/semantic-browser/HTTPKernel.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+public struct HTTPKernel {
+    let router: Router
+
+    public init(handlers: Handlers = Handlers()) {
+        self.router = Router(handlers: handlers)
+    }
+
+    public func handle(_ request: HTTPRequest) async throws -> HTTPResponse {
+        try await router.route(request)
+    }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Server/semantic-browser/HTTPRequest.swift
+++ b/Sources/FountainOps/Generated/Server/semantic-browser/HTTPRequest.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+public struct NoBody: Codable {}
+
+public struct HTTPRequest {
+    public let method: String
+    public let path: String
+    public var headers: [String: String]
+    public var body: Data
+
+    public init(method: String, path: String, headers: [String: String] = [:], body: Data = Data()) {
+        self.method = method
+        self.path = path
+        self.headers = headers
+        self.body = body
+    }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Server/semantic-browser/HTTPResponse.swift
+++ b/Sources/FountainOps/Generated/Server/semantic-browser/HTTPResponse.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+public struct HTTPResponse {
+    public var status: Int
+    public var headers: [String: String]
+    public var body: Data
+
+    public init(status: Int = 200, headers: [String: String] = [:], body: Data = Data()) {
+        self.status = status
+        self.headers = headers
+        self.body = body
+    }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Server/semantic-browser/HTTPServer.swift
+++ b/Sources/FountainOps/Generated/Server/semantic-browser/HTTPServer.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+public class HTTPServer: URLProtocol {
+    static var kernel: HTTPKernel?
+
+    public static func register(kernel: HTTPKernel) {
+        self.kernel = kernel
+        URLProtocol.registerClass(HTTPServer.self)
+    }
+
+    public override class func canInit(with request: URLRequest) -> Bool {
+        request.url?.host == "localhost"
+    }
+
+    public override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override public func startLoading() {
+        guard let kernel = HTTPServer.kernel, let url = request.url else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+            return
+        }
+        let req = HTTPRequest(method: request.httpMethod ?? "GET", path: url.path, headers: request.allHTTPHeaderFields ?? [:], body: request.httpBody ?? Data())
+        let strongSelf = self
+        Task { @Sendable in
+            do {
+                let resp = try await kernel.handle(req)
+                let httpResponse = HTTPURLResponse(url: url, statusCode: resp.status, httpVersion: "HTTP/1.1", headerFields: resp.headers)!
+                client?.urlProtocol(strongSelf, didReceive: httpResponse, cacheStoragePolicy: .notAllowed)
+                client?.urlProtocol(strongSelf, didLoad: resp.body)
+                client?.urlProtocolDidFinishLoading(strongSelf)
+            } catch {
+                client?.urlProtocol(strongSelf, didFailWithError: error)
+            }
+        }
+    }
+
+    override public func stopLoading() {}
+}
+
+extension HTTPServer: @unchecked Sendable {}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Server/semantic-browser/Handlers.swift
+++ b/Sources/FountainOps/Generated/Server/semantic-browser/Handlers.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+public struct Handlers {
+    public init() {}
+    public func querypages(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
+        return HTTPResponse(status: 501, headers: ["Content-Type": "text/plain"], body: Data("not implemented".utf8))
+    }
+    public func browseanddissect(_ request: HTTPRequest, body: BrowseRequest?) async throws -> HTTPResponse {
+        return HTTPResponse(status: 501, headers: ["Content-Type": "text/plain"], body: Data("not implemented".utf8))
+    }
+    public func snapshotonly(_ request: HTTPRequest, body: SnapshotRequest?) async throws -> HTTPResponse {
+        return HTTPResponse(status: 501, headers: ["Content-Type": "text/plain"], body: Data("not implemented".utf8))
+    }
+    public func health(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
+        return HTTPResponse(status: 501, headers: ["Content-Type": "text/plain"], body: Data("not implemented".utf8))
+    }
+    public func queryentities(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
+        return HTTPResponse(status: 501, headers: ["Content-Type": "text/plain"], body: Data("not implemented".utf8))
+    }
+    public func indexanalysis(_ request: HTTPRequest, body: IndexRequest?) async throws -> HTTPResponse {
+        return HTTPResponse(status: 501, headers: ["Content-Type": "text/plain"], body: Data("not implemented".utf8))
+    }
+    public func exportartifacts(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
+        return HTTPResponse(status: 501, headers: ["Content-Type": "text/plain"], body: Data("not implemented".utf8))
+    }
+    public func querysegments(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
+        return HTTPResponse(status: 501, headers: ["Content-Type": "text/plain"], body: Data("not implemented".utf8))
+    }
+    public func getpage(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
+        return HTTPResponse(status: 501, headers: ["Content-Type": "text/plain"], body: Data("not implemented".utf8))
+    }
+    public func analyzesnapshot(_ request: HTTPRequest, body: AnalyzeRequest?) async throws -> HTTPResponse {
+        return HTTPResponse(status: 501, headers: ["Content-Type": "text/plain"], body: Data("not implemented".utf8))
+    }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Server/semantic-browser/Models.swift
+++ b/Sources/FountainOps/Generated/Server/semantic-browser/Models.swift
@@ -1,0 +1,176 @@
+// Models for Semantic Browser & Dissector API
+
+public struct Analysis: Codable {
+    public let blocks: [Block]
+    public let envelope: [String: String]
+    public let provenance: [String: String]
+    public let semantics: [String: String]
+    public let summaries: [String: String]
+}
+
+public struct AnalyzeRequest: Codable {
+    public let mode: DissectionMode
+    public let snapshot: Snapshot
+    public let snapshotRef: [String: String]
+}
+
+public struct Block: Codable {
+    public let id: String
+    public let kind: String
+    public let level: Int
+    public let span: [Int]
+    public let table: Table
+    public let text: String
+}
+
+public struct BrowseRequest: Codable {
+    public let index: IndexOptions
+    public let labels: [String]
+    public let mode: DissectionMode
+    public let storeArtifacts: Bool
+    public let url: String
+    public let wait: WaitPolicy
+}
+
+public struct BrowseResponse: Codable {
+    public let analysis: Analysis
+    public let index: IndexResult
+    public let snapshot: Snapshot
+}
+
+public struct Claim: Codable {
+    public let evidence: [[String: String]]
+    public let hedge: String
+    public let id: String
+    public let stance: String
+    public let text: String
+}
+
+public enum DissectionMode: String, Codable {
+    case quick
+    case standard
+    case deep
+}
+
+public struct Entity: Codable {
+    public let id: String
+    public let mentions: [[String: String]]
+    public let name: String
+    public let type: String
+}
+
+public struct EntityDoc: Codable {
+    public let id: String
+    public let mentions: Int
+    public let name: String
+    public let pageCount: Int
+    public let type: String
+}
+
+public struct Error: Codable {
+    public let code: String
+    public let details: [String: String]
+    public let message: String
+}
+
+public struct IndexOptions: Codable {
+    public let enabled: Bool
+    public let entitiesCollection: String
+    public let pagesCollection: String
+    public let segmentsCollection: String
+    public let tablesCollection: String
+    public let typesense: [String: String]
+}
+
+public struct IndexRequest: Codable {
+    public let analysis: Analysis
+    public let options: IndexOptions
+}
+
+public struct IndexResult: Codable {
+    public let entitiesUpserted: Int
+    public let pagesUpserted: Int
+    public let segmentsUpserted: Int
+    public let tablesUpserted: Int
+}
+
+public struct PageDoc: Codable {
+    public let contentType: String
+    public let fetchedAt: Int
+    public let host: String
+    public let id: String
+    public let labels: [String]
+    public let lang: String
+    public let status: Int
+    public let textSize: Int
+    public let title: String
+    public let url: String
+}
+
+public struct SegmentDoc: Codable {
+    public let entities: [String]
+    public let id: String
+    public let kind: String
+    public let offsetEnd: Int
+    public let offsetStart: Int
+    public let pageId: String
+    public let pathHint: String
+    public let text: String
+}
+
+public struct Snapshot: Codable {
+    public let diagnostics: [String]
+    public let network: [String: String]
+    public let page: [String: String]
+    public let rendered: [String: String]
+    public let snapshotId: String
+}
+
+public struct SnapshotRequest: Codable {
+    public let storeArtifacts: Bool
+    public let url: String
+    public let wait: WaitPolicy
+}
+
+public struct SnapshotResponse: Codable {
+    public let snapshot: Snapshot
+}
+
+public struct Table: Codable {
+    public let caption: String
+    public let columns: [String]
+    public let rows: [[String]]
+}
+
+public struct WaitPolicy: Codable {
+    public let maxWaitMs: Int
+    public let networkIdleMs: Int
+    public let selector: String
+    public let strategy: String
+}
+
+public struct queryPagesResponse: Codable {
+    public let items: [PageDoc]
+    public let total: Int
+}
+
+public struct healthResponse: Codable {
+    public let browserPool: [String: String]
+    public let status: String
+    public let version: String
+}
+
+public struct queryEntitiesResponse: Codable {
+    public let items: [EntityDoc]
+    public let total: Int
+}
+
+public typealias exportArtifactsResponse = [String: String]
+
+public struct querySegmentsResponse: Codable {
+    public let items: [SegmentDoc]
+    public let total: Int
+}
+
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Server/semantic-browser/Router.swift
+++ b/Sources/FountainOps/Generated/Server/semantic-browser/Router.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+public struct Router {
+    public var handlers: Handlers
+
+    public init(handlers: Handlers = Handlers()) {
+        self.handlers = handlers
+    }
+
+    public func route(_ request: HTTPRequest) async throws -> HTTPResponse {
+        switch (request.method, request.path) {
+        case ("GET", "/v1/pages"):
+            let body = try? JSONDecoder().decode(NoBody.self, from: request.body)
+            return try await handlers.querypages(request, body: body)
+        case ("POST", "/v1/browse"):
+            let body = try? JSONDecoder().decode(BrowseRequest.self, from: request.body)
+            return try await handlers.browseanddissect(request, body: body)
+        case ("POST", "/v1/snapshot"):
+            let body = try? JSONDecoder().decode(SnapshotRequest.self, from: request.body)
+            return try await handlers.snapshotonly(request, body: body)
+        case ("GET", "/v1/health"):
+            let body = try? JSONDecoder().decode(NoBody.self, from: request.body)
+            return try await handlers.health(request, body: body)
+        case ("GET", "/v1/entities"):
+            let body = try? JSONDecoder().decode(NoBody.self, from: request.body)
+            return try await handlers.queryentities(request, body: body)
+        case ("POST", "/v1/index"):
+            let body = try? JSONDecoder().decode(IndexRequest.self, from: request.body)
+            return try await handlers.indexanalysis(request, body: body)
+        case ("GET", "/v1/export"):
+            let body = try? JSONDecoder().decode(NoBody.self, from: request.body)
+            return try await handlers.exportartifacts(request, body: body)
+        case ("GET", "/v1/segments"):
+            let body = try? JSONDecoder().decode(NoBody.self, from: request.body)
+            return try await handlers.querysegments(request, body: body)
+        case ("GET", "/v1/pages/{id}"):
+            let body = try? JSONDecoder().decode(NoBody.self, from: request.body)
+            return try await handlers.getpage(request, body: body)
+        case ("POST", "/v1/analyze"):
+            let body = try? JSONDecoder().decode(AnalyzeRequest.self, from: request.body)
+            return try await handlers.analyzesnapshot(request, body: body)
+        default:
+            return HTTPResponse(status: 404)
+        }
+    }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- add Semantic Browser OpenAPI spec and generated client/server stubs
- register Semantic Browser in launcher and service catalog

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_b_689f835564108333bb2875d38351f9c6