### PR TITLE
Fix build warnings in Gateway server and tests

### DIFF
--- a/Sources/GatewayApp/main.swift
+++ b/Sources/GatewayApp/main.swift
@@ -21,7 +21,11 @@ if CommandLine.arguments.contains("--dns") {
         let zoneURL = URL(fileURLWithPath: "Configuration/zones.yml")
         if let manager = try? ZoneManager(fileURL: zoneURL) {
             let dns = await DNSServer(zoneManager: manager)
-            try? await dns.start(udpPort: 1053)
+            do {
+                try await dns.start(udpPort: 1053)
+            } catch {
+                FileHandle.standardError.write(Data("[gateway] Warning: DNS failed to start on port 1053: \(error)\n".utf8))
+            }
         } else {
             FileHandle.standardError.write(Data("[gateway] Warning: failed to initialize ZoneManager\n".utf8))
         }


### PR DESCRIPTION
## Summary
- handle DNS start errors instead of ignoring them
- remove unused mutable response bindings in GatewayServerTests
- avoid task capture mutation in testPersistenceAcrossRestart

## Testing
- ⚠️ `swift build -v` *(dependency build was interrupted due to environment limits)*
- ✅ `swift test --parallel`


------
https://chatgpt.com/codex/tasks/task_b_68a00bfaf8a08333a84480e52193a60a