### PR TITLE
feat: manifest-driven FountainAI launcher

### DIFF
--- a/FountainAiLauncher/Package.swift
+++ b/FountainAiLauncher/Package.swift
@@ -12,7 +12,10 @@ let package = Package(
     targets: [
         .executableTarget(
             name: "FountainAiLauncher",
-            path: "Sources/FountainAiLauncher"
+            path: "Sources/FountainAiLauncher",
+            resources: [
+                .copy("services.json")
+            ]
         ),
         .testTarget(
             name: "FountainAiLauncherTests",

--- a/FountainAiLauncher/README.md
+++ b/FountainAiLauncher/README.md
@@ -14,6 +14,7 @@ This launcher replaces Docker, `systemd`, and `launchd` with a single, lightweig
 
 - ✅ Cross-platform orchestration (macOS & Linux)
 - 🌀 Launches all services as subprocesses
+- 📄 Loads service metadata from `services.json`
 - 🔁 Optional auto-restart on failure
 - 🌐 Optional `/status` and `/health` HTTP endpoint (coming soon)
 - 📜 Logs directly to stdout or per-service log files
@@ -25,16 +26,16 @@ This launcher replaces Docker, `systemd`, and `launchd` with a single, lightweig
 
 | Service Name           | Executable Name        | Port  | Role Description |
 |------------------------|------------------------|-------|------------------|
-| Baseline Awareness     | `awareness-service`    | 8001  | Diff, drift, narrative patterns |
-| Bootstrap Service      | `bootstrap-service`    | 8002  | Corpus and rules initializer |
-| Planner Service        | `planner-service`      | 8003  | Delegates tasks and goals |
+| Baseline Awareness     | `baseline-awareness`   | 8001  | Diff, drift, narrative patterns |
+| Bootstrap              | `bootstrap`            | 8002  | Corpus and rules initializer |
+| Planner                | `planner`              | 8003  | Delegates tasks and goals |
 | Function Caller        | `function-caller`      | 8004  | Maps operationIds to HTTP |
-| Persistence Service    | `persistence-service`  | 8005  | Typesense-backed corpus storage |
+| Persist                | `persist`              | 8005  | Typesense-backed corpus storage |
 | **LLM Gateway**        | `llm-gateway`          | 8006  | Connects to external LLMs (OpenAI, Claude) |
 | Semantic Browser       | `semantic-browser`     | 8007  | Headless browsing and semantic dissection |
 | **Gateway**            | `fountain-gateway`     | 8010  | HTTPS, authentication, route proxying |
-| Publishing Frontend    | `publishing-frontend`  | 8085  | Serves static publishing assets |
-| Typesense Proxy        | `typesense-proxy`      | 8100  | Swift-native wrapper around Typesense |
+| Tools Factory          | `tools-factory`        | 8011  | Registers callable OpenAPI tools |
+| Typesense              | `typesense`            | 8100  | Swift-native wrapper around Typesense |
 
 ---
 
@@ -63,16 +64,16 @@ The launcher expects the following executables to exist on disk. Install each se
 
 | Service Name         | Expected Path                             |
 |----------------------|-------------------------------------------|
-| Awareness Service    | `/usr/local/bin/awareness-service`        |
-| Bootstrap Service    | `/usr/local/bin/bootstrap-service`        |
-| Planner Service      | `/usr/local/bin/planner-service`          |
+| Baseline Awareness   | `/usr/local/bin/baseline-awareness`       |
+| Bootstrap            | `/usr/local/bin/bootstrap`                |
+| Planner              | `/usr/local/bin/planner`                  |
 | Function Caller      | `/usr/local/bin/function-caller`          |
-| Persistence Service  | `/usr/local/bin/persistence-service`      |
+| Persist              | `/usr/local/bin/persist`                  |
 | LLM Gateway          | `/usr/local/bin/llm-gateway`              |
 | Semantic Browser     | `/usr/local/bin/semantic-browser`         |
 | Gateway              | `/usr/local/bin/fountain-gateway`         |
-| Publishing Frontend  | `/usr/local/bin/publishing-frontend`      |
-| Typesense Proxy      | `/usr/local/bin/typesense-proxy`          |
+| Tools Factory        | `/usr/local/bin/tools-factory`            |
+| Typesense            | `/usr/local/bin/typesense`                |
 
 ---
 

--- a/FountainAiLauncher/Sources/FountainAiLauncher/HealthMonitor.swift
+++ b/FountainAiLauncher/Sources/FountainAiLauncher/HealthMonitor.swift
@@ -1,0 +1,46 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+/// Periodically probes service health endpoints and restarts failing services.
+public final class HealthMonitor {
+    private let supervisor: Supervisor
+    private var timer: DispatchSourceTimer?
+    private let interval: TimeInterval
+
+    /// Creates a new health monitor.
+    /// - Parameters:
+    ///   - supervisor: Supervisor used for restarting services.
+    ///   - interval: Time between health checks in seconds.
+    public init(supervisor: Supervisor, interval: TimeInterval = 5) {
+        self.supervisor = supervisor
+        self.interval = interval
+    }
+
+    /// Begins monitoring the provided services.
+    /// - Parameter services: Services to probe.
+    public func startMonitoring(services: [Service]) {
+        let queue = DispatchQueue(label: "health-monitor")
+        let timer = DispatchSource.makeTimerSource(queue: queue)
+        timer.schedule(deadline: .now() + interval, repeating: interval)
+        timer.setEventHandler { [weak supervisor] in
+            guard let supervisor = supervisor else { return }
+            for service in services {
+                guard service.shouldRestart, let port = service.port, let path = service.healthPath else { continue }
+                let url = URL(string: "http://127.0.0.1:\(port)\(path)")!
+                let task = URLSession.shared.dataTask(with: url) { _, response, error in
+                    if error != nil || (response as? HTTPURLResponse)?.statusCode != 200 {
+                        print("Health check failed for \(service.name)")
+                        supervisor.restart(service: service)
+                    }
+                }
+                task.resume()
+            }
+        }
+        timer.resume()
+        self.timer = timer
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/FountainAiLauncher/Sources/FountainAiLauncher/Service.swift
+++ b/FountainAiLauncher/Sources/FountainAiLauncher/Service.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Describes an executable service managed by ``Supervisor``.
-public struct Service {
+public struct Service: Codable, Sendable {
     /// Human readable identifier used by ``Supervisor``.
     public let name: String
     /// Absolute path to the executable binary on disk.
@@ -12,6 +12,9 @@ public struct Service {
     public let port: Int?
     /// Optional HTTP path of the health check endpoint.
     public let healthPath: String?
+    /// Whether the supervisor should attempt to restart the service if a
+    /// health check fails.
+    public let shouldRestart: Bool
 
     /// Creates a new service descriptor.
     /// - Parameters:
@@ -20,12 +23,35 @@ public struct Service {
     ///   - arguments: Arguments passed on launch.
     ///   - port: Optional port for health checks.
     ///   - healthPath: Health check endpoint path.
-    public init(name: String, binaryPath: String, arguments: [String] = [], port: Int? = nil, healthPath: String? = nil) {
+    ///   - shouldRestart: Restart automatically on failed health checks.
+    public init(
+        name: String,
+        binaryPath: String,
+        arguments: [String] = [],
+        port: Int? = nil,
+        healthPath: String? = nil,
+        shouldRestart: Bool = false
+    ) {
         self.name = name
         self.binaryPath = binaryPath
         self.arguments = arguments
         self.port = port
         self.healthPath = healthPath
+        self.shouldRestart = shouldRestart
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case name, binaryPath, arguments, port, healthPath, shouldRestart
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        name = try container.decode(String.self, forKey: .name)
+        binaryPath = try container.decode(String.self, forKey: .binaryPath)
+        arguments = try container.decodeIfPresent([String].self, forKey: .arguments) ?? []
+        port = try container.decodeIfPresent(Int.self, forKey: .port)
+        healthPath = try container.decodeIfPresent(String.self, forKey: .healthPath)
+        shouldRestart = try container.decodeIfPresent(Bool.self, forKey: .shouldRestart) ?? false
     }
 }
 

--- a/FountainAiLauncher/Sources/FountainAiLauncher/services.json
+++ b/FountainAiLauncher/Sources/FountainAiLauncher/services.json
@@ -1,0 +1,12 @@
+[
+  {"name":"Baseline Awareness","binaryPath":"/usr/local/bin/baseline-awareness","port":8001,"healthPath":"/metrics","shouldRestart":true},
+  {"name":"Bootstrap","binaryPath":"/usr/local/bin/bootstrap","port":8002,"healthPath":"/metrics","shouldRestart":true},
+  {"name":"Planner","binaryPath":"/usr/local/bin/planner","port":8003,"healthPath":"/metrics","shouldRestart":true},
+  {"name":"Function Caller","binaryPath":"/usr/local/bin/function-caller","port":8004,"healthPath":"/metrics","shouldRestart":true},
+  {"name":"Persist","binaryPath":"/usr/local/bin/persist","port":8005,"healthPath":"/metrics","shouldRestart":true},
+  {"name":"LLM Gateway","binaryPath":"/usr/local/bin/llm-gateway","port":8006,"healthPath":"/metrics","shouldRestart":true},
+  {"name":"Semantic Browser","binaryPath":"/usr/local/bin/semantic-browser","port":8007,"healthPath":"/metrics","shouldRestart":true},
+  {"name":"Gateway","binaryPath":"/usr/local/bin/fountain-gateway","port":8010,"healthPath":"/metrics","shouldRestart":true},
+  {"name":"Tools Factory","binaryPath":"/usr/local/bin/tools-factory","port":8011,"healthPath":"/metrics","shouldRestart":true},
+  {"name":"Typesense","binaryPath":"/usr/local/bin/typesense","port":8100,"healthPath":"/metrics","shouldRestart":true}
+]

--- a/FountainAiLauncher/Tests/FountainAiLauncherTests/FountainAiLauncherTests.swift
+++ b/FountainAiLauncher/Tests/FountainAiLauncherTests/FountainAiLauncherTests.swift
@@ -28,6 +28,7 @@ final class FountainAiLauncherTests: XCTestCase {
         XCTAssertEqual(service.arguments, ["hi"])
         XCTAssertEqual(service.port, 42)
         XCTAssertEqual(service.healthPath, "/health")
+        XCTAssertFalse(service.shouldRestart)
     }
 
     /// Ensures default initializer uses empty arguments and no health settings.
@@ -36,6 +37,17 @@ final class FountainAiLauncherTests: XCTestCase {
         XCTAssertTrue(service.arguments.isEmpty)
         XCTAssertNil(service.port)
         XCTAssertNil(service.healthPath)
+        XCTAssertFalse(service.shouldRestart)
+    }
+
+    /// Decoding JSON manifest into services works.
+    func testServiceDecoding() throws {
+        let json = """
+        [{"name":"X","binaryPath":"/bin/echo","shouldRestart":true}]
+        """.data(using: .utf8)!
+        let decoded = try JSONDecoder().decode([Service].self, from: json)
+        XCTAssertEqual(decoded.count, 1)
+        XCTAssertTrue(decoded[0].shouldRestart)
     }
 }
 


### PR DESCRIPTION
## Summary
- load FountainAI services from a bundled `services.json` manifest
- supervise subprocesses with per-service logs and restart ability
- add health monitor to probe `/metrics` endpoints
- document new service list and manifest behavior

## Testing
- `cd FountainAiLauncher && swift test`


------
https://chatgpt.com/codex/tasks/task_b_68a07afff2d483339aa6e6352c6612c3