### PR TITLE
Add diagnostics script for FountainAI launcher

### DIFF
--- a/FountainAiLauncher/README.md
+++ b/FountainAiLauncher/README.md
@@ -58,6 +58,17 @@ FountainAiLauncher/
 
 ---
 
+## 🗂 Manual Service Registry
+
+FountainAI does not include automatic service discovery. The launcher and the
+`start-diagnostics.swift` script read from the manually curated
+`Sources/FountainAiLauncher/services.json` file to know which FountainOps
+servers to start. When a new service is added—or a path changes—you must update
+this file yourself. Tools like `clientgen` can generate API clients, but they do
+not register services in the launcher.
+
+---
+
 ## 🔧 Required Service Binaries
 
 The launcher expects the following executables to exist on disk. Install each service to the path shown or adjust `main.swift` if your binaries live elsewhere.
@@ -74,6 +85,16 @@ The launcher expects the following executables to exist on disk. Install each se
 | Gateway              | `/usr/local/bin/fountain-gateway`         |
 | Tools Factory        | `/usr/local/bin/tools-factory`            |
 | Typesense            | `/usr/local/bin/typesense`                |
+
+---
+
+## 🩺 Diagnostics
+
+Run the Swift diagnostics script before launching to verify all service binaries and required API keys are available:
+
+```bash
+swift Scripts/start-diagnostics.swift
+```
 
 ---
 

--- a/Scripts/start-diagnostics.swift
+++ b/Scripts/start-diagnostics.swift
@@ -1,0 +1,66 @@
+#!/usr/bin/env swift
+import Foundation
+
+/// Simple preflight script for FountainAI.
+/// It reads the **manually maintained** `services.json` file used by the
+/// launcher, verifies that each listed binary exists and is executable, and
+/// checks for required environment variables.
+///
+/// FountainAI currently has no automatic service registry—when adding new
+/// FountainOps servers you must update `services.json` by hand so this
+/// diagnostics check and the launcher know about them.
+struct Service: Decodable {
+    let name: String
+    let binaryPath: String
+}
+
+let scriptPath = URL(fileURLWithPath: CommandLine.arguments[0]).resolvingSymlinksInPath()
+let scriptDirectory = scriptPath.deletingLastPathComponent()
+let servicesURL = scriptDirectory.appendingPathComponent("../FountainAiLauncher/Sources/FountainAiLauncher/services.json").standardized
+
+var allChecksPassed = true
+
+func fail(_ message: String) {
+    print("❌ \(message)")
+    allChecksPassed = false
+}
+
+let fm = FileManager.default
+
+if fm.fileExists(atPath: servicesURL.path) {
+    do {
+        let data = try Data(contentsOf: servicesURL)
+        let services = try JSONDecoder().decode([Service].self, from: data)
+        for service in services {
+            if fm.isExecutableFile(atPath: service.binaryPath) {
+                print("✅ \(service.name) binary found at \(service.binaryPath)")
+            } else {
+                fail("\(service.name) binary missing or not executable at \(service.binaryPath)")
+            }
+        }
+    } catch {
+        fail("Failed to parse services.json: \(error)")
+    }
+} else {
+    fail("Services configuration not found at \(servicesURL.path)")
+}
+
+let requiredEnv = ["OPENAI_API_KEY", "TYPESENSE_URL", "TYPESENSE_API_KEY"]
+let env = ProcessInfo.processInfo.environment
+for key in requiredEnv {
+    if let value = env[key], !value.isEmpty {
+        print("✅ \(key) is set")
+    } else {
+        fail("\(key) is missing")
+    }
+}
+
+if allChecksPassed {
+    print("🎉 Environment looks ready for FountainAI.")
+} else {
+    print("⚠️ Missing requirements detected.")
+}
+
+exit(allChecksPassed ? 0 : 1)
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- add Swift diagnostics script to check service binaries and required API keys before running the launcher
- document new diagnostics step in FountainAiLauncher README
- clarify that FountainAI uses a manually maintained `services.json` instead of an automatic service registry

## Testing
- `swift Scripts/start-diagnostics.swift`
- `swift test --skip-build`


------
https://chatgpt.com/codex/tasks/task_b_68a08128a41c833390bf7f80892b7ccf