### PR TITLE
Add diagnostics script and service registry generator for FountainAI launcher

### DIFF
--- a/FountainAiLauncher/README.md
+++ b/FountainAiLauncher/README.md
@@ -58,6 +58,30 @@ FountainAiLauncher/
 
 ---
 
+## 🗂 Manual Service Registry
+
+FountainAI does not include automatic service discovery. The launcher and the
+`start-diagnostics.swift` script read from the manually curated
+`Sources/FountainAiLauncher/services.json` file to know which FountainOps
+servers to start. When a new service is added—or a path changes—you must update
+this file yourself. Tools like `clientgen` can generate API clients, but they do
+not register services in the launcher.
+
+## 🔍 Auto-generate `services.json`
+
+To avoid editing the registry by hand, you can rebuild `services.json` by
+scanning a directory that contains all FountainOps binaries:
+
+```bash
+FOUNTAINAI_SERVICES_DIR=/usr/local/bin swift Scripts/generate-service-registry.swift
+```
+
+The script checks the specified directory for the expected executables and
+writes their locations into `Sources/FountainAiLauncher/services.json`. Run it
+whenever you install or move service binaries.
+
+---
+
 ## 🔧 Required Service Binaries
 
 The launcher expects the following executables to exist on disk. Install each service to the path shown or adjust `main.swift` if your binaries live elsewhere.
@@ -74,6 +98,16 @@ The launcher expects the following executables to exist on disk. Install each se
 | Gateway              | `/usr/local/bin/fountain-gateway`         |
 | Tools Factory        | `/usr/local/bin/tools-factory`            |
 | Typesense            | `/usr/local/bin/typesense`                |
+
+---
+
+## 🩺 Diagnostics
+
+Run the Swift diagnostics script before launching to verify all service binaries and required API keys are available:
+
+```bash
+swift Scripts/start-diagnostics.swift
+```
 
 ---
 

--- a/Scripts/generate-service-registry.swift
+++ b/Scripts/generate-service-registry.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+struct Template {
+    let name: String
+    let binary: String
+    let port: Int
+    let healthPath: String
+    let shouldRestart: Bool
+}
+
+struct Service: Codable {
+    let name: String
+    let binaryPath: String
+    let port: Int
+    let healthPath: String
+    let shouldRestart: Bool
+}
+
+let templates: [Template] = [
+    Template(name: "Baseline Awareness", binary: "baseline-awareness", port: 8001, healthPath: "/metrics", shouldRestart: true),
+    Template(name: "Bootstrap", binary: "bootstrap", port: 8002, healthPath: "/metrics", shouldRestart: true),
+    Template(name: "Planner", binary: "planner", port: 8003, healthPath: "/metrics", shouldRestart: true),
+    Template(name: "Function Caller", binary: "function-caller", port: 8004, healthPath: "/metrics", shouldRestart: true),
+    Template(name: "Persist", binary: "persist", port: 8005, healthPath: "/metrics", shouldRestart: true),
+    Template(name: "LLM Gateway", binary: "llm-gateway", port: 8006, healthPath: "/metrics", shouldRestart: true),
+    Template(name: "Semantic Browser", binary: "semantic-browser", port: 8007, healthPath: "/metrics", shouldRestart: true),
+    Template(name: "Gateway", binary: "fountain-gateway", port: 8010, healthPath: "/metrics", shouldRestart: true),
+    Template(name: "Tools Factory", binary: "tools-factory", port: 8011, healthPath: "/metrics", shouldRestart: true),
+    Template(name: "Typesense", binary: "typesense", port: 8100, healthPath: "/metrics", shouldRestart: true)
+]
+
+let servicesDir = ProcessInfo.processInfo.environment["FOUNTAINAI_SERVICES_DIR"] ?? "/usr/local/bin"
+var services: [Service] = []
+
+for t in templates {
+    let path = (servicesDir as NSString).appendingPathComponent(t.binary)
+    if !FileManager.default.isExecutableFile(atPath: path) {
+        fputs("Warning: \(path) not found or not executable\n", stderr)
+    }
+    services.append(Service(name: t.name, binaryPath: path, port: t.port, healthPath: t.healthPath, shouldRestart: t.shouldRestart))
+}
+
+do {
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.prettyPrinted]
+    let data = try encoder.encode(services)
+    let outputURL = URL(fileURLWithPath: "FountainAiLauncher/Sources/FountainAiLauncher/services.json")
+    try data.write(to: outputURL)
+    print("Wrote services.json with \(services.count) entries to \(outputURL.path)")
+} catch {
+    fputs("Failed to write services.json: \(error)\n", stderr)
+    exit(1)
+}

--- a/Scripts/start-diagnostics.swift
+++ b/Scripts/start-diagnostics.swift
@@ -1,0 +1,66 @@
+#!/usr/bin/env swift
+import Foundation
+
+/// Simple preflight script for FountainAI.
+/// It reads the **manually maintained** `services.json` file used by the
+/// launcher, verifies that each listed binary exists and is executable, and
+/// checks for required environment variables.
+///
+/// FountainAI currently has no automatic service registry—when adding new
+/// FountainOps servers you must update `services.json` by hand so this
+/// diagnostics check and the launcher know about them.
+struct Service: Decodable {
+    let name: String
+    let binaryPath: String
+}
+
+let scriptPath = URL(fileURLWithPath: CommandLine.arguments[0]).resolvingSymlinksInPath()
+let scriptDirectory = scriptPath.deletingLastPathComponent()
+let servicesURL = scriptDirectory.appendingPathComponent("../FountainAiLauncher/Sources/FountainAiLauncher/services.json").standardized
+
+var allChecksPassed = true
+
+func fail(_ message: String) {
+    print("❌ \(message)")
+    allChecksPassed = false
+}
+
+let fm = FileManager.default
+
+if fm.fileExists(atPath: servicesURL.path) {
+    do {
+        let data = try Data(contentsOf: servicesURL)
+        let services = try JSONDecoder().decode([Service].self, from: data)
+        for service in services {
+            if fm.isExecutableFile(atPath: service.binaryPath) {
+                print("✅ \(service.name) binary found at \(service.binaryPath)")
+            } else {
+                fail("\(service.name) binary missing or not executable at \(service.binaryPath)")
+            }
+        }
+    } catch {
+        fail("Failed to parse services.json: \(error)")
+    }
+} else {
+    fail("Services configuration not found at \(servicesURL.path)")
+}
+
+let requiredEnv = ["OPENAI_API_KEY", "TYPESENSE_URL", "TYPESENSE_API_KEY"]
+let env = ProcessInfo.processInfo.environment
+for key in requiredEnv {
+    if let value = env[key], !value.isEmpty {
+        print("✅ \(key) is set")
+    } else {
+        fail("\(key) is missing")
+    }
+}
+
+if allChecksPassed {
+    print("🎉 Environment looks ready for FountainAI.")
+} else {
+    print("⚠️ Missing requirements detected.")
+}
+
+exit(allChecksPassed ? 0 : 1)
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- add Swift diagnostics script to check service binaries and required API keys before running the launcher
- document manual service registry and new auto-generation script in FountainAiLauncher README
- provide script to build `services.json` by scanning a binary directory

## Testing
- `FOUNTAINAI_SERVICES_DIR=/usr/local/bin swift Scripts/generate-service-registry.swift`
- `swift Scripts/start-diagnostics.swift`
- `swift test`


------
https://chatgpt.com/codex/tasks/task_b_68a08128a41c833390bf7f80892b7ccf