### PR TITLE
docs: link DNS API spec

### DIFF
--- a/Sources/FountainCodex/DNS/README.md
+++ b/Sources/FountainCodex/DNS/README.md
@@ -59,6 +59,7 @@ $ swift run GatewayApp --dns
 ## Control plane API
 
 The HTTP gateway exposes endpoints that delegate to `ZoneManager`:
+The full API specification is defined in [`Sources/FountainOps/FountainAi/openAPI/v1/dns.yml`](../../FountainOps/FountainAi/openAPI/v1/dns.yml).
 
 - `GET  /zones` – list all zones
 - `POST /zones` – create a new zone


### PR DESCRIPTION
## Summary
- reference the full DNS API specification in the control plane API docs

## Testing
- `swift test` *(fails: build interrupted, see logs)*

------
https://chatgpt.com/codex/tasks/task_b_68a155fff3248333b0513be5bdc321e2