### PR TITLE
feat: add security sentinel plugin

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -39,10 +39,16 @@ var targets: [Target] = [
         dependencies: [
             "FountainCodex",
             "PublishingFrontend",
+            "LLMGatewayClient",
             .product(name: "Crypto", package: "swift-crypto"),
             .product(name: "X509", package: "swift-certificates")
         ],
         path: "Sources/GatewayApp"
+    ),
+    .target(
+        name: "LLMGatewayClient",
+        path: "Sources/FountainOps/Generated/Client/llm-gateway",
+        sources: ["APIClient.swift", "APIRequest.swift"]
     ),
     .target(
         name: "PublishingFrontend",
@@ -87,7 +93,8 @@ var targets: [Target] = [
     .testTarget(name: "MIDI2ModelsTests", dependencies: ["MIDI2Models"], path: "Tests/MIDI2ModelsTests"),
     .testTarget(name: "MIDI2CoreTests", dependencies: ["MIDI2Core", "ResourceLoader", "flexctl"], path: "Tests/MIDI2CoreTests"),
     .testTarget(name: "MIDI2TransportsTests", dependencies: ["MIDI2Transports"], path: "Tests/MIDI2TransportsTests"),
-    .testTarget(name: "FlexctlTests", dependencies: ["flexctl", "ResourceLoader"], path: "Tests/FlexctlTests")
+    .testTarget(name: "FlexctlTests", dependencies: ["flexctl", "ResourceLoader"], path: "Tests/FlexctlTests"),
+    .testTarget(name: "GatewayAppTests", dependencies: ["gateway-server", "LLMGatewayClient"], path: "Tests/GatewayAppTests")
 ]
 
 #if os(Linux)

--- a/SECURITY/llm-gateway-safeguards.md
+++ b/SECURITY/llm-gateway-safeguards.md
@@ -61,4 +61,8 @@ try await client.addRole(sentinel)
 
 Embedding this consultable persona ensures that high-risk behavior is intercepted and audited before affecting production systems.
 
+### Plugin Enforcement
+
+`SecuritySentinelPlugin` hooks into the gateway request pipeline. When a request uses a destructive HTTP verb or path, the plugin summarizes it and consults `/sentinel/consult`. Decisions of `allow`, `deny`, or `escalate` are enforced immediately, and every outcome is appended to `logs/security.log` for audit.
+
 © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Client/llm-gateway/APIClient.swift
+++ b/Sources/FountainOps/Generated/Client/llm-gateway/APIClient.swift
@@ -30,4 +30,4 @@ public struct APIClient {
     }
 }
 
-© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Client/llm-gateway/APIRequest.swift
+++ b/Sources/FountainOps/Generated/Client/llm-gateway/APIRequest.swift
@@ -6,4 +6,4 @@ public protocol APIRequest {
     var path: String { get }
 }
 
-© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/GatewayApp/SecuritySentinelPlugin.swift
+++ b/Sources/GatewayApp/SecuritySentinelPlugin.swift
@@ -1,0 +1,87 @@
+import Foundation
+import FountainCodex
+import LLMGatewayClient
+
+extension APIClient: @unchecked Sendable {}
+
+public enum SentinelDecision: String, Decodable {
+    case allow
+    case deny
+    case escalate
+}
+
+/// Plugin that consults SecuritySentinel for potentially destructive actions.
+public struct SecuritySentinelPlugin: GatewayPlugin {
+    private let client: APIClient
+    private let logURL: URL
+    private let patterns: [String]
+
+    /// Creates a new plugin instance.
+    /// - Parameters:
+    ///   - client: API client used to consult the sentinel service.
+    ///   - logURL: Destination log file.
+    ///   - patterns: Path substrings considered destructive.
+    public init(client: APIClient = APIClient(baseURL: URL(string: "http://localhost:8080")!),
+                logURL: URL = URL(fileURLWithPath: "logs/security.log"),
+                patterns: [String] = ["delete", "destroy", "truncate"]) {
+        self.client = client
+        self.logURL = logURL
+        self.patterns = patterns
+    }
+
+    private struct ConsultRequest: APIRequest {
+        typealias Response = ConsultResponse
+        let summary: String
+        var method: String { "POST" }
+        var path: String {
+            let encoded = summary.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
+            return "/sentinel/consult?summary=\(encoded)"
+        }
+    }
+
+    private struct ConsultResponse: Decodable {
+        let decision: SentinelDecision
+    }
+
+    public func prepare(_ request: HTTPRequest) async throws -> HTTPRequest {
+        guard isDestructive(request) else { return request }
+        let summary = "\(request.method) \(request.path)"
+        let decision = try await client.send(ConsultRequest(summary: summary)).decision
+        log(summary: summary, decision: decision)
+        switch decision {
+        case .allow:
+            return request
+        case .deny:
+            throw DeniedError()
+        case .escalate:
+            throw EscalateError()
+        }
+    }
+
+    private func isDestructive(_ request: HTTPRequest) -> Bool {
+        if request.method.uppercased() == "DELETE" { return true }
+        return patterns.contains { request.path.lowercased().contains($0) }
+    }
+
+    private func log(summary: String, decision: SentinelDecision) {
+        let line = "\(summary) -> \(decision.rawValue)\n"
+        do {
+            let dir = logURL.deletingLastPathComponent()
+            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+            if !FileManager.default.fileExists(atPath: logURL.path) {
+                FileManager.default.createFile(atPath: logURL.path, contents: nil)
+            }
+            let handle = try FileHandle(forWritingTo: logURL)
+            defer { try? handle.close() }
+            try handle.seekToEnd()
+            try handle.write(contentsOf: Data(line.utf8))
+        } catch {
+            // ignore logging errors
+        }
+    }
+}
+
+public struct DeniedError: Error {}
+public struct EscalateError: Error {}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/GatewayApp/main.swift
+++ b/Sources/GatewayApp/main.swift
@@ -11,7 +11,7 @@ if publishingConfig == nil {
     FileHandle.standardError.write(Data("[gateway] Warning: failed to load Configuration/publishing.yml; using defaults for static content.\n".utf8))
 }
 
-let server = GatewayServer(plugins: [LoggingPlugin(), PublishingFrontendPlugin(rootPath: publishingConfig?.rootPath ?? "./Public")])
+let server = GatewayServer(plugins: [SecuritySentinelPlugin(), LoggingPlugin(), PublishingFrontendPlugin(rootPath: publishingConfig?.rootPath ?? "./Public")])
 Task { @MainActor in
     try await server.start(port: 8080)
 }

--- a/Tests/GatewayAppTests/SecuritySentinelPluginTests.swift
+++ b/Tests/GatewayAppTests/SecuritySentinelPluginTests.swift
@@ -1,0 +1,62 @@
+import XCTest
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+@testable import gateway_server
+import LLMGatewayClient
+import FountainCodex
+
+final class SecuritySentinelPluginTests: XCTestCase {
+    private struct StubSession: HTTPSession {
+        let decision: String
+        func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+            let body = "{\"decision\":\"\(decision)\"}".data(using: .utf8)!
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (body, response)
+        }
+    }
+
+    private func makePlugin(decision: String, logURL: URL) -> SecuritySentinelPlugin {
+        let session = StubSession(decision: decision)
+        let client = APIClient(baseURL: URL(string: "http://example.com")!, session: session)
+        return SecuritySentinelPlugin(client: client, logURL: logURL)
+    }
+
+    func testAllow() async throws {
+        let logURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let plugin = makePlugin(decision: "allow", logURL: logURL)
+        let request = HTTPRequest(method: "DELETE", path: "/danger")
+        _ = try await plugin.prepare(request)
+        let log = try String(contentsOf: logURL, encoding: .utf8)
+        XCTAssertTrue(log.contains("allow"))
+    }
+
+    func testDeny() async throws {
+        let logURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let plugin = makePlugin(decision: "deny", logURL: logURL)
+        let request = HTTPRequest(method: "DELETE", path: "/danger")
+        do {
+            _ = try await plugin.prepare(request)
+            XCTFail("expected deny")
+        } catch is DeniedError {
+            let log = try String(contentsOf: logURL, encoding: .utf8)
+            XCTAssertTrue(log.contains("deny"))
+        }
+    }
+
+    func testEscalate() async throws {
+        let logURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let plugin = makePlugin(decision: "escalate", logURL: logURL)
+        let request = HTTPRequest(method: "DELETE", path: "/danger")
+        do {
+            _ = try await plugin.prepare(request)
+            XCTFail("expected escalate")
+        } catch is EscalateError {
+            let log = try String(contentsOf: logURL, encoding: .utf8)
+            XCTAssertTrue(log.contains("escalate"))
+        }
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- add SecuritySentinelPlugin to vet destructive requests via `/sentinel/consult`
- register SecuritySentinelPlugin ahead of other gateway plugins
- document and test allow/deny/escalate enforcement with logging

## Testing
- `swift test --filter SecuritySentinelPluginTests`


------
https://chatgpt.com/codex/tasks/task_b_68a1fab545a08333929424c64bdffcfa