### PR TITLE
Add FountainAIToolsmith package with CLI

### DIFF
--- a/FountainAIToolsmith/.gitignore
+++ b/FountainAIToolsmith/.gitignore
@@ -1,0 +1,9 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc
+# © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/FountainAIToolsmith/Package.swift
+++ b/FountainAIToolsmith/Package.swift
@@ -1,0 +1,24 @@
+// swift-tools-version: 6.1
+import PackageDescription
+
+let package = Package(
+    name: "FountainAIToolsmith",
+    platforms: [
+        .macOS(.v14)
+    ],
+    products: [
+        .library(name: "Toolsmith", targets: ["Toolsmith"]),
+        .library(name: "SandboxRunner", targets: ["SandboxRunner"]),
+        .library(name: "ToolsmithAPI", targets: ["ToolsmithAPI"]),
+        .executable(name: "toolsmith-cli", targets: ["toolsmith-cli"])
+    ],
+    dependencies: [],
+    targets: [
+        .target(name: "Toolsmith", dependencies: []),
+        .target(name: "SandboxRunner", dependencies: []),
+        .target(name: "ToolsmithAPI", dependencies: []),
+        .executableTarget(name: "toolsmith-cli", dependencies: ["Toolsmith"])
+    ]
+)
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/FountainAIToolsmith/Sources/SandboxRunner/SandboxRunner.swift
+++ b/FountainAIToolsmith/Sources/SandboxRunner/SandboxRunner.swift
@@ -1,0 +1,5 @@
+public struct SandboxRunner {
+    public init() {}
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/FountainAIToolsmith/Sources/Toolsmith/Toolsmith.swift
+++ b/FountainAIToolsmith/Sources/Toolsmith/Toolsmith.swift
@@ -1,0 +1,5 @@
+public struct Toolsmith {
+    public init() {}
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/FountainAIToolsmith/Sources/ToolsmithAPI/ToolsmithAPI.swift
+++ b/FountainAIToolsmith/Sources/ToolsmithAPI/ToolsmithAPI.swift
@@ -1,0 +1,5 @@
+public struct ToolsmithAPI {
+    public init() {}
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/FountainAIToolsmith/Sources/toolsmith-cli/main.swift
+++ b/FountainAIToolsmith/Sources/toolsmith-cli/main.swift
@@ -1,0 +1,10 @@
+import Toolsmith
+
+@main
+struct ToolsmithCLI {
+    static func main() {
+        print("Toolsmith CLI")
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Package.swift
+++ b/Package.swift
@@ -125,6 +125,7 @@ let package = Package(
     ],
     products: products,
     dependencies: [
+        .package(path: "./FountainAIToolsmith"),
         .package(url: "https://github.com/jpsim/Yams.git", from: "5.0.0"),
         .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.21.0"),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.63.0"),

--- a/agent.md
+++ b/agent.md
@@ -51,6 +51,7 @@ This agent maintains an up-to-date view of outstanding development tasks across 
 | SPS samples & usage docs | `sps/Samples`, `docs/sps-usage-guide.md` | Provide annotated sample PDFs and usage guide with page-range queries & validation hooks | ✅ | — | docs, sps |
 | MIDI 2 library | `midi/*`, `sps/*`, `Sources/MIDI2/*` | Parse MIDI 2 spec via SPS and expose Swift Package module | ✅ | — | midi, sps, spm |
 | Semantic browser & dissector | `sb/*` | Wire CLI commands and integrate Typesense indexer | ✅ | — | sb, cli, cdp, typesense, semantics |
+| Toolsmith package | `FountainAIToolsmith/*` | Scaffold Toolsmith orchestration package with CLI | ✅ | — | toolsmith |
 
 
 ---

--- a/logs/agent-20250819135153.log
+++ b/logs/agent-20250819135153.log
@@ -1,0 +1,5 @@
+[2025-08-19T13:51:53Z] Added FountainAIToolsmith package with Toolsmith, SandboxRunner, ToolsmithAPI, and toolsmith-cli.
+[2025-08-19T13:51:53Z] Updated root Package.swift to depend on FountainAIToolsmith.
+[2025-08-19T13:51:53Z] Logged repository manifest for Toolsmith package.
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- scaffold `FountainAIToolsmith` Swift package with Toolsmith, SandboxRunner, ToolsmithAPI, and a `toolsmith-cli` executable
- wire root package to depend on the new Toolsmith components
- record the new package in the repository agent manifest

## Testing
- `swift build`
- `swift build --package-path FountainAIToolsmith`
- `swift run --package-path FountainAIToolsmith toolsmith-cli`


------
https://chatgpt.com/codex/tasks/task_b_68a480b428b88333ac99d91b223f6269