### PR TITLE
Add Toolsmith client and server generation

### DIFF
--- a/FountainAIToolsmith/Sources/ToolsmithAPI/APIClient.swift
+++ b/FountainAIToolsmith/Sources/ToolsmithAPI/APIClient.swift
@@ -1,0 +1,33 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+public protocol HTTPSession {
+    func data(for request: URLRequest) async throws -> (Data, URLResponse)
+}
+
+extension URLSession: HTTPSession {
+    public func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+        try await self.data(for: request, delegate: nil)
+    }
+}
+
+public struct APIClient {
+    let baseURL: URL
+    let session: HTTPSession
+
+    public init(baseURL: URL, session: HTTPSession = URLSession.shared) {
+        self.baseURL = baseURL
+        self.session = session
+    }
+
+    public func send<R: APIRequest>(_ request: R) async throws -> R.Response {
+        var urlRequest = URLRequest(url: baseURL.appendingPathComponent(request.path))
+        urlRequest.httpMethod = request.method
+        let (data, _) = try await session.data(for: urlRequest)
+        return try JSONDecoder().decode(R.Response.self, from: data)
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/FountainAIToolsmith/Sources/ToolsmithAPI/APIRequest.swift
+++ b/FountainAIToolsmith/Sources/ToolsmithAPI/APIRequest.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public protocol APIRequest {
+    associatedtype Response: Decodable
+    var method: String { get }
+    var path: String { get }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/FountainAIToolsmith/Sources/ToolsmithAPI/Models.swift
+++ b/FountainAIToolsmith/Sources/ToolsmithAPI/Models.swift
@@ -1,0 +1,26 @@
+// Models for FountainAI Tools Factory Service
+
+public struct ErrorResponse: Codable {
+    public let error_code: String
+    public let message: String
+}
+
+public struct FunctionInfo: Codable {
+    public let description: String
+    public let function_id: String
+    public let http_method: String
+    public let http_path: String
+    public let name: String
+    public let openapi: String
+    public let parameters_schema: String
+}
+
+public struct FunctionListResponse: Codable {
+    public let functions: String
+    public let page: Int
+    public let page_size: Int
+    public let total: Int
+}
+
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/FountainAIToolsmith/Sources/ToolsmithAPI/Requests/list_tools.swift
+++ b/FountainAIToolsmith/Sources/ToolsmithAPI/Requests/list_tools.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public struct list_tools: APIRequest {
+    public typealias Response = Data
+    public var method: String { "GET" }
+    public var path: String { "/tools" }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/FountainAIToolsmith/Sources/ToolsmithAPI/Requests/register_openapi.swift
+++ b/FountainAIToolsmith/Sources/ToolsmithAPI/Requests/register_openapi.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public struct register_openapi: APIRequest {
+    public typealias Response = Data
+    public var method: String { "POST" }
+    public var path: String { "/tools/register" }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/FountainAIToolsmith/Sources/ToolsmithAPI/ToolsmithAPI.swift
+++ b/FountainAIToolsmith/Sources/ToolsmithAPI/ToolsmithAPI.swift
@@ -1,5 +1,0 @@
-public struct ToolsmithAPI {
-    public init() {}
-}
-
-// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,8 @@ var products: [Product] = [
     .executable(name: "clientgen-service", targets: ["clientgen-service"]),
     .executable(name: "gateway-server", targets: ["gateway-server"]),
     .executable(name: "publishing-frontend", targets: ["publishing-frontend"]),
-    .executable(name: "flexctl", targets: ["flexctl"])
+    .executable(name: "flexctl", targets: ["flexctl"]),
+    .executable(name: "tools-factory-server", targets: ["tools-factory-server"])
 ]
 
 var targets: [Target] = [
@@ -94,6 +95,18 @@ var targets: [Target] = [
         dependencies: ["MIDI2Core", .product(name: "MIDI2", package: "midi2")],
         path: "Sources/flexctl",
         resources: [.process("Resources")]
+    ),
+    .target(
+        name: "ToolsFactoryService",
+        dependencies: ["ServiceShared", "Yams", "FountainCodex"],
+        path: "Sources/ToolServer/Service"
+    ),
+    .executableTarget(
+        name: "tools-factory-server",
+        dependencies: ["ToolsFactoryService"],
+        path: "Sources/ToolServer",
+        exclude: ["Dockerfile", "Service"],
+        sources: ["main.swift"]
     ),
     .testTarget(name: "ClientGeneratorTests", dependencies: ["FountainCodex"], path: "Tests/ClientGeneratorTests"),
     .testTarget(name: "PublishingFrontendTests", dependencies: ["PublishingFrontend"], path: "Tests/PublishingFrontendTests"),

--- a/Scripts/generate-toolsmith-client.swift
+++ b/Scripts/generate-toolsmith-client.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+let fm = FileManager.default
+let root = URL(fileURLWithPath: fm.currentDirectoryPath)
+let spec = root.appendingPathComponent("Sources/FountainOps/FountainAi/openAPI/v1/tools-factory.yml")
+let tmp = root.appendingPathComponent(".toolsmith-gen")
+try? fm.removeItem(at: tmp)
+try fm.createDirectory(at: tmp, withIntermediateDirectories: true)
+
+let proc = Process()
+proc.executableURL = URL(fileURLWithPath: "/usr/bin/swift")
+proc.arguments = ["run", "clientgen-service", "--input", spec.path, "--output", tmp.path]
+proc.standardOutput = FileHandle.standardOutput
+proc.standardError = FileHandle.standardError
+try proc.run()
+proc.waitUntilExit()
+
+guard proc.terminationStatus == 0 else {
+    throw NSError(domain: "Generator", code: Int(proc.terminationStatus), userInfo: nil)
+}
+
+let clientSrc = tmp.appendingPathComponent("Client/tools-factory")
+let clientDst = root.appendingPathComponent("FountainAIToolsmith/Sources/ToolsmithAPI")
+if fm.fileExists(atPath: clientDst.path) { try fm.removeItem(at: clientDst) }
+try fm.createDirectory(at: clientDst.deletingLastPathComponent(), withIntermediateDirectories: true)
+try fm.moveItem(at: clientSrc, to: clientDst)
+
+let serverSrc = tmp.appendingPathComponent("Server/tools-factory")
+let serverDst = root.appendingPathComponent("Sources/ToolServer")
+if fm.fileExists(atPath: serverDst.path) { try fm.removeItem(at: serverDst) }
+try fm.moveItem(at: serverSrc, to: serverDst)
+
+try fm.removeItem(at: tmp)
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/ToolServer/Dockerfile
+++ b/Sources/ToolServer/Dockerfile
@@ -1,0 +1,11 @@
+# tools-factory server container
+FROM swift:6.1-jammy AS build
+WORKDIR /src
+COPY . .
+RUN swift build -c release --product tools-factory-server
+
+FROM ubuntu:22.04
+COPY --from=build /src/.build/release/tools-factory-server /server
+CMD ["/server"]
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/ToolServer/Service/HTTPKernel.swift
+++ b/Sources/ToolServer/Service/HTTPKernel.swift
@@ -1,0 +1,22 @@
+import Foundation
+import ServiceShared
+
+public struct HTTPKernel {
+    let router: Router
+
+    public init(handlers: Handlers = Handlers()) {
+        self.router = Router(handlers: handlers)
+    }
+
+    public func handle(_ request: HTTPRequest) async throws -> HTTPResponse {
+        if let token = ProcessInfo.processInfo.environment["TOOLS_FACTORY_AUTH_TOKEN"] {
+            let expected = "Bearer \(token)"
+            if request.headers["Authorization"] != expected { return HTTPResponse(status: 401) }
+        }
+        let resp = try await router.route(request)
+        await PrometheusAdapter.shared.record(service: "tools-factory", path: request.path)
+        return resp
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/ToolServer/Service/HTTPRequest.swift
+++ b/Sources/ToolServer/Service/HTTPRequest.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+public struct HTTPRequest {
+    public let method: String
+    public let path: String
+    public var headers: [String: String]
+    public var body: Data
+
+    public init(method: String, path: String, headers: [String: String] = [:], body: Data = Data()) {
+        self.method = method
+        self.path = path
+        self.headers = headers
+        self.body = body
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/ToolServer/Service/HTTPResponse.swift
+++ b/Sources/ToolServer/Service/HTTPResponse.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+public struct HTTPResponse {
+    public var status: Int
+    public var headers: [String: String]
+    public var body: Data
+
+    public init(status: Int = 200, headers: [String: String] = [:], body: Data = Data()) {
+        self.status = status
+        self.headers = headers
+        self.body = body
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/ToolServer/Service/Handlers.swift
+++ b/Sources/ToolServer/Service/Handlers.swift
@@ -1,0 +1,129 @@
+import Foundation
+import ServiceShared
+import Parser
+import Yams
+
+/// Implements the Tools Factory persistence logic backed by ``TypesenseClient``.
+public struct Handlers {
+    let typesense: TypesenseClient
+
+    public init(typesense: TypesenseClient = .shared) {
+        self.typesense = typesense
+        Task {
+            if await typesense.listFunctions().isEmpty {
+                let f1 = Function(description: "test1", functionId: "test1", httpMethod: "GET", httpPath: "http://example.com/test1", name: "test1")
+                let f2 = Function(description: "test2", functionId: "test2", httpMethod: "GET", httpPath: "http://example.com/test2", name: "test2")
+                await typesense.addFunction(f1)
+                await typesense.addFunction(f2)
+            }
+        }
+    }
+
+    /// Registers one or more functions defined by an OpenAPI document.
+    /// The request body may contain JSON or YAML. Each operationId is mapped to
+    /// a ``Function`` persisted via ``TypesenseClient``.
+    public func registerOpenapi(_ request: HTTPRequest) async throws -> HTTPResponse {
+        let data = request.body
+
+        if let list = try? JSONDecoder().decode([Function].self, from: data) {
+            for fn in list { await typesense.addFunction(fn) }
+            let enc = JSONEncoder()
+            enc.keyEncodingStrategy = .convertToSnakeCase
+            let envelope = FunctionListResponse(functions: list, page: 1, page_size: list.count, total: list.count)
+            let respData = try enc.encode(envelope)
+            return HTTPResponse(body: respData)
+        }
+
+        let spec: OpenAPISpec
+        do {
+            if let decoded = try? JSONDecoder().decode(OpenAPISpec.self, from: data) {
+                spec = decoded
+            } else if let string = String(data: data, encoding: .utf8),
+                      let yaml = try? Yams.load(yaml: string),
+                      let json = try? JSONSerialization.data(withJSONObject: yaml),
+                      let decoded = try? JSONDecoder().decode(OpenAPISpec.self, from: json) {
+                spec = decoded
+            } else {
+                throw SpecValidator.ValidationError("invalid document")
+            }
+            try SpecValidator.validate(spec)
+        } catch let error as SpecValidator.ValidationError {
+            let payload = try JSONEncoder().encode(ErrorResponse(error_code: "validation_error", message: error.message))
+            return HTTPResponse(status: 422, body: payload)
+        } catch {
+            let payload = try JSONEncoder().encode(ErrorResponse(error_code: "parse_error", message: "Unable to parse document"))
+            return HTTPResponse(status: 422, body: payload)
+        }
+
+        var functions: [Function] = []
+        if let paths = spec.paths {
+            for (path, item) in paths {
+                if let op = item.get {
+                    let schemaData = op.requestBody?.content["application/json"]?.schema
+                    let schemaString = schemaData.flatMap { try? String(data: JSONEncoder().encode($0), encoding: .utf8) }
+                    functions.append(Function(description: op.operationId,
+                                                functionId: op.operationId,
+                                                httpMethod: "GET",
+                                                httpPath: path,
+                                                name: op.operationId,
+                                                parametersSchema: schemaString))
+                }
+                if let op = item.post {
+                    let schemaData = op.requestBody?.content["application/json"]?.schema
+                    let schemaString = schemaData.flatMap { try? String(data: JSONEncoder().encode($0), encoding: .utf8) }
+                    functions.append(Function(description: op.operationId,
+                                                functionId: op.operationId,
+                                                httpMethod: "POST",
+                                                httpPath: path,
+                                                name: op.operationId,
+                                                parametersSchema: schemaString))
+                }
+                if let op = item.put {
+                    let schemaData = op.requestBody?.content["application/json"]?.schema
+                    let schemaString = schemaData.flatMap { try? String(data: JSONEncoder().encode($0), encoding: .utf8) }
+                    functions.append(Function(description: op.operationId,
+                                                functionId: op.operationId,
+                                                httpMethod: "PUT",
+                                                httpPath: path,
+                                                name: op.operationId,
+                                                parametersSchema: schemaString))
+                }
+                if let op = item.delete {
+                    let schemaData = op.requestBody?.content["application/json"]?.schema
+                    let schemaString = schemaData.flatMap { try? String(data: JSONEncoder().encode($0), encoding: .utf8) }
+                    functions.append(Function(description: op.operationId,
+                                                functionId: op.operationId,
+                                                httpMethod: "DELETE",
+                                                httpPath: path,
+                                                name: op.operationId,
+                                                parametersSchema: schemaString))
+                }
+            }
+        }
+
+        for fn in functions { await typesense.addFunction(fn) }
+        let enc = JSONEncoder()
+        enc.keyEncodingStrategy = .convertToSnakeCase
+        let envelope = FunctionListResponse(functions: functions, page: 1, page_size: functions.count, total: functions.count)
+        let respData = try enc.encode(envelope)
+        return HTTPResponse(body: respData)
+    }
+
+    /// Returns all stored function definitions.
+    public func listTools(_ request: HTTPRequest) async throws -> HTTPResponse {
+        let items = await typesense.listFunctions()
+        let comps = URLComponents(string: request.path)
+        let page = comps?.queryItems?.first(where: { $0.name == "page" }).flatMap { Int($0.value ?? "") } ?? 1
+        let pageSize = comps?.queryItems?.first(where: { $0.name == "page_size" }).flatMap { Int($0.value ?? "") } ?? 20
+        let start = max(0, (page - 1) * pageSize)
+        let end = min(start + pageSize, items.count)
+        let pageItems = start < items.count ? Array(items[start..<end]) : []
+        let envelope = FunctionListResponse(functions: pageItems, page: page, page_size: pageSize, total: items.count)
+        let encoder = JSONEncoder()
+        encoder.keyEncodingStrategy = .convertToSnakeCase
+        let data = try encoder.encode(envelope)
+        return HTTPResponse(body: data)
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/ToolServer/Service/Models.swift
+++ b/Sources/ToolServer/Service/Models.swift
@@ -1,0 +1,28 @@
+// Models for FountainAI Tools Factory Service
+
+import ServiceShared
+
+public struct ErrorResponse: Codable {
+    public let error_code: String
+    public let message: String
+}
+
+public struct FunctionInfo: Codable {
+    public let description: String
+    public let function_id: String
+    public let http_method: String
+    public let http_path: String
+    public let name: String
+    public let openapi: String?
+    public let parameters_schema: String?
+}
+
+public struct FunctionListResponse: Codable {
+    public let functions: [Function]
+    public let page: Int
+    public let page_size: Int
+    public let total: Int
+}
+
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/ToolServer/Service/Router.swift
+++ b/Sources/ToolServer/Service/Router.swift
@@ -1,0 +1,26 @@
+import Foundation
+import ServiceShared
+
+public struct Router {
+    public var handlers: Handlers
+
+    public init(handlers: Handlers = Handlers()) {
+        self.handlers = handlers
+    }
+
+    public func route(_ request: HTTPRequest) async throws -> HTTPResponse {
+        switch (request.method, request.path) {
+        case ("POST", let path) where path == "/tools/register" || path.hasPrefix("/tools/register?"):
+            return try await handlers.registerOpenapi(request)
+        case ("GET", let path) where path == "/tools" || path.hasPrefix("/tools?"):
+            return try await handlers.listTools(request)
+        case ("GET", "/metrics"):
+            let text = await PrometheusAdapter.shared.exposition()
+            return HTTPResponse(status: 200, headers: ["Content-Type": "text/plain"], body: Data(text.utf8))
+        default:
+            return HTTPResponse(status: 404)
+        }
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/ToolServer/main.swift
+++ b/Sources/ToolServer/main.swift
@@ -1,0 +1,104 @@
+import Foundation
+import Dispatch
+#if os(Linux)
+import Glibc
+#else
+import Darwin
+#endif
+
+import ToolsFactoryService
+
+final class SimpleHTTPRuntime: @unchecked Sendable {
+    enum RuntimeError: Error { case socket, bind, listen }
+    let kernel: HTTPKernel
+    let port: Int32
+    private var serverFD: Int32 = -1
+
+    init(kernel: HTTPKernel, port: Int32 = 8080) {
+        self.kernel = kernel
+        self.port = port
+    }
+
+    func start() throws {
+        #if os(Linux)
+        serverFD = socket(AF_INET, Int32(SOCK_STREAM.rawValue), 0)
+        #else
+        serverFD = socket(AF_INET, SOCK_STREAM, 0)
+        #endif
+        guard serverFD >= 0 else { throw RuntimeError.socket }
+        var opt: Int32 = 1
+        setsockopt(serverFD, SOL_SOCKET, SO_REUSEADDR, &opt, socklen_t(MemoryLayout.size(ofValue: opt)))
+        var addr = sockaddr_in()
+        addr.sin_family = sa_family_t(AF_INET)
+        addr.sin_port = in_port_t(UInt16(port).bigEndian)
+        addr.sin_addr = in_addr(s_addr: in_addr_t(0))
+        let bindResult = withUnsafePointer(to: &addr) {
+            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) { ptr in
+                bind(serverFD, ptr, socklen_t(MemoryLayout<sockaddr_in>.size))
+            }
+        }
+        guard bindResult >= 0 else { throw RuntimeError.bind }
+        guard listen(serverFD, 16) >= 0 else { throw RuntimeError.listen }
+        DispatchQueue.global().async { [weak self] in self?.acceptLoop() }
+    }
+
+    private func acceptLoop() {
+        while true {
+            var addr = sockaddr()
+            var len: socklen_t = socklen_t(MemoryLayout<sockaddr>.size)
+            let fd = accept(serverFD, &addr, &len)
+            if fd >= 0 {
+                DispatchQueue.global().async {
+                    self.handle(fd: fd)
+                }
+            }
+        }
+    }
+
+    private func handle(fd: Int32) {
+        var buffer = [UInt8](repeating: 0, count: 4096)
+        let n = read(fd, &buffer, buffer.count)
+        guard n > 0 else { close(fd); return }
+        let data = Data(buffer[0..<n])
+        guard let request = parseRequest(data) else { close(fd); return }
+        Task {
+            let resp = try await kernel.handle(request)
+            let respData = serialize(resp)
+            respData.withUnsafeBytes { _ = write(fd, $0.baseAddress!, respData.count) }
+            close(fd)
+        }
+    }
+
+    private func parseRequest(_ data: Data) -> HTTPRequest? {
+        guard let string = String(data: data, encoding: .utf8) else { return nil }
+        let parts = string.components(separatedBy: "\r\n\r\n")
+        let headerLines = parts[0].split(separator: "\r\n")
+        guard let requestLine = headerLines.first else { return nil }
+        let tokens = requestLine.split(separator: " ")
+        guard tokens.count >= 2 else { return nil }
+        let method = String(tokens[0])
+        let path = String(tokens[1])
+        return HTTPRequest(method: method, path: path)
+    }
+
+    private func serialize(_ resp: HTTPResponse) -> Data {
+        var text = "HTTP/1.1 \(resp.status) OK\r\n"
+        text += "Content-Length: \(resp.body.count)\r\n"
+        text += "\r\n"
+        var data = Data(text.utf8)
+        data.append(resp.body)
+        return data
+    }
+}
+
+let kernel = HTTPKernel()
+do {
+    let runtime = SimpleHTTPRuntime(kernel: kernel, port: 8080)
+    try runtime.start()
+    print("tools-factory server listening on port 8080")
+    dispatchMain()
+} catch {
+    print("Failed to start server: \(error)")
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- script to generate Toolsmith API client and server stubs from tools-factory OpenAPI spec
- checked in generated Toolsmith client and server code
- registered new targets and product in package manifest

## Testing
- `swift build --package-path FountainAIToolsmith`
- `swift build --product tools-factory-server` *(fails: build cancelled)*

------
https://chatgpt.com/codex/tasks/task_b_68a4834e27a08333a86b32c4ec3c1d45