### PR TITLE
feat: add bubblewrap sandbox runner

### DIFF
--- a/FountainAIToolsmith/Package.swift
+++ b/FountainAIToolsmith/Package.swift
@@ -17,7 +17,8 @@ let package = Package(
         .target(name: "Toolsmith", dependencies: []),
         .target(name: "SandboxRunner", dependencies: []),
         .target(name: "ToolsmithAPI", dependencies: []),
-        .executableTarget(name: "toolsmith-cli", dependencies: ["Toolsmith"])
+        .executableTarget(name: "toolsmith-cli", dependencies: ["Toolsmith"]),
+        .testTarget(name: "SandboxRunnerTests", dependencies: ["SandboxRunner"])
     ]
 )
 

--- a/FountainAIToolsmith/Sources/SandboxRunner/BwrapRunner.swift
+++ b/FountainAIToolsmith/Sources/SandboxRunner/BwrapRunner.swift
@@ -1,0 +1,103 @@
+import Foundation
+
+public final class BwrapRunner: SandboxRunner {
+    private let bwrap: URL
+    private let cgroupRoot: URL
+
+    public init(bwrap: URL = URL(fileURLWithPath: "/usr/bin/bwrap"),
+                cgroupRoot: URL = URL(fileURLWithPath: "/sys/fs/cgroup")) {
+        self.bwrap = bwrap
+        self.cgroupRoot = cgroupRoot
+    }
+
+    @discardableResult
+    public func run(
+        executable: String,
+        arguments: [String] = [],
+        inputs: [URL] = [],
+        workDirectory: URL,
+        allowNetwork: Bool = false,
+        timeout: TimeInterval? = nil,
+        limits: CgroupLimits? = nil
+    ) throws -> SandboxResult {
+        var cgPath: URL?
+        if let limits = limits {
+            cgPath = try prepareCgroup(limits: limits)
+        }
+
+        var args: [String] = ["--die-with-parent", "--bind", workDirectory.path, "/work"]
+        if !allowNetwork {
+            args.append("--unshare-net")
+        }
+        for input in inputs {
+            let target = "/inputs/\(input.lastPathComponent)"
+            args.append(contentsOf: ["--ro-bind", input.path, target])
+        }
+        args.append(contentsOf: [executable])
+        args.append(contentsOf: arguments)
+
+        let process = Process()
+        process.executableURL = bwrap
+        process.arguments = args
+        let stdout = Pipe()
+        let stderr = Pipe()
+        process.standardOutput = stdout
+        process.standardError = stderr
+        try process.run()
+
+        if let cgPath = cgPath {
+            try add(pid: process.processIdentifier, toCgroup: cgPath)
+        }
+
+        var timedOut = false
+        if let timeout = timeout {
+            let group = DispatchGroup()
+            group.enter()
+            process.terminationHandler = { _ in group.leave() }
+            if group.wait(timeout: .now() + timeout) == .timedOut {
+                timedOut = true
+                process.terminate()
+                process.waitUntilExit()
+            }
+        } else {
+            process.waitUntilExit()
+        }
+
+        if let cgPath = cgPath {
+            try? FileManager.default.removeItem(at: cgPath)
+        }
+
+        if timedOut {
+            throw NSError(domain: "BwrapRunner", code: 1, userInfo: [NSLocalizedDescriptionKey: "Process timed out"])
+        }
+
+        let outData = stdout.fileHandleForReading.readDataToEndOfFile()
+        let errData = stderr.fileHandleForReading.readDataToEndOfFile()
+        return SandboxResult(
+            stdout: String(data: outData, encoding: .utf8) ?? "",
+            stderr: String(data: errData, encoding: .utf8) ?? "",
+            exitCode: process.terminationStatus
+        )
+    }
+
+    func prepareCgroup(limits: CgroupLimits) throws -> URL {
+        let path = cgroupRoot.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: path, withIntermediateDirectories: true)
+        if let m = limits.memoryMax {
+            try (m + "\n").write(to: path.appendingPathComponent("memory.max"), atomically: true, encoding: .utf8)
+        }
+        if let c = limits.cpuMax {
+            try (c + "\n").write(to: path.appendingPathComponent("cpu.max"), atomically: true, encoding: .utf8)
+        }
+        if let p = limits.pidsMax {
+            try (p + "\n").write(to: path.appendingPathComponent("pids.max"), atomically: true, encoding: .utf8)
+        }
+        return path
+    }
+
+    func add(pid: Int32, toCgroup path: URL) throws {
+        try "\(pid)\n".write(to: path.appendingPathComponent("cgroup.procs"), atomically: true, encoding: .utf8)
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/FountainAIToolsmith/Sources/SandboxRunner/SandboxRunner.swift
+++ b/FountainAIToolsmith/Sources/SandboxRunner/SandboxRunner.swift
@@ -1,5 +1,40 @@
-public struct SandboxRunner {
-    public init() {}
+import Foundation
+
+public struct SandboxResult {
+    public let stdout: String
+    public let stderr: String
+    public let exitCode: Int32
+
+    public init(stdout: String, stderr: String, exitCode: Int32) {
+        self.stdout = stdout
+        self.stderr = stderr
+        self.exitCode = exitCode
+    }
+}
+
+public struct CgroupLimits {
+    public var memoryMax: String?
+    public var cpuMax: String?
+    public var pidsMax: String?
+
+    public init(memoryMax: String? = nil, cpuMax: String? = nil, pidsMax: String? = nil) {
+        self.memoryMax = memoryMax
+        self.cpuMax = cpuMax
+        self.pidsMax = pidsMax
+    }
+}
+
+public protocol SandboxRunner {
+    @discardableResult
+    func run(
+        executable: String,
+        arguments: [String],
+        inputs: [URL],
+        workDirectory: URL,
+        allowNetwork: Bool,
+        timeout: TimeInterval?,
+        limits: CgroupLimits?
+    ) throws -> SandboxResult
 }
 
 // © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/FountainAIToolsmith/Tests/SandboxRunnerTests/BwrapRunnerTests.swift
+++ b/FountainAIToolsmith/Tests/SandboxRunnerTests/BwrapRunnerTests.swift
@@ -1,0 +1,61 @@
+import XCTest
+@testable import SandboxRunner
+
+final class BwrapRunnerTests: XCTestCase {
+    func testMountIsolation() throws {
+        try XCTSkipIf(!Self.canUseBubblewrap, "bubblewrap not functional")
+
+        let fm = FileManager.default
+        let tmp = fm.temporaryDirectory
+        let input = tmp.appendingPathComponent("input.txt")
+        try "hello".write(to: input, atomically: true, encoding: .utf8)
+        let work = tmp.appendingPathComponent(UUID().uuidString)
+        try fm.createDirectory(at: work, withIntermediateDirectories: true)
+
+        let runner = BwrapRunner()
+        _ = try runner.run(
+            executable: "/bin/sh",
+            arguments: ["-c", "echo hi > /work/out && echo fail >> /inputs/input.txt || true"],
+            inputs: [input],
+            workDirectory: work,
+            allowNetwork: false,
+            timeout: 5,
+            limits: nil
+        )
+
+        XCTAssertEqual(try String(contentsOf: input, encoding: .utf8), "hello")
+        let outPath = work.appendingPathComponent("out")
+        XCTAssertEqual(try String(contentsOf: outPath, encoding: .utf8).trimmingCharacters(in: .whitespacesAndNewlines), "hi")
+    }
+
+    func testCgroupEnforcement() throws {
+        let fm = FileManager.default
+        let cgRoot = fm.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try fm.createDirectory(at: cgRoot, withIntermediateDirectories: true)
+
+        let runner = BwrapRunner(cgroupRoot: cgRoot)
+        let limits = CgroupLimits(memoryMax: "1024", cpuMax: "50000 100000", pidsMax: "4")
+        let path = try runner.prepareCgroup(limits: limits)
+        try runner.add(pid: 1234, toCgroup: path)
+
+        XCTAssertEqual(try String(contentsOf: path.appendingPathComponent("memory.max"), encoding: .utf8), "1024\n")
+        XCTAssertEqual(try String(contentsOf: path.appendingPathComponent("cpu.max"), encoding: .utf8), "50000 100000\n")
+        XCTAssertEqual(try String(contentsOf: path.appendingPathComponent("pids.max"), encoding: .utf8), "4\n")
+        XCTAssertEqual(try String(contentsOf: path.appendingPathComponent("cgroup.procs"), encoding: .utf8), "1234\n")
+    }
+
+    private static let canUseBubblewrap: Bool = {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/bwrap")
+        process.arguments = ["--ro-bind", "/", "/", "/bin/true"]
+        do {
+            try process.run()
+            process.waitUntilExit()
+            return process.terminationStatus == 0
+        } catch {
+            return false
+        }
+    }()
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- add Bubblewrap-based sandbox runner with network toggle and cgroup limits
- expose sandbox runner protocol and result types
- cover mount isolation and cgroup setup in tests

## Testing
- `swift test --package-path FountainAIToolsmith`

------
https://chatgpt.com/codex/tasks/task_b_68a48fdbf4948333a7522ba49cc42bc9