### PR TITLE
Add ToolServer module with process adapters and logging

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -97,15 +97,17 @@ var targets: [Target] = [
         resources: [.process("Resources")]
     ),
     .target(
-        name: "ToolsFactoryService",
-        dependencies: ["ServiceShared", "Yams", "FountainCodex"],
-        path: "Sources/ToolServer/Service"
+        name: "ToolServer",
+        dependencies: [.product(name: "Crypto", package: "swift-crypto")],
+        path: "Sources/ToolServer",
+        exclude: ["main.swift", "Service", "Dockerfile"],
+        resources: [.process("openapi.yaml")]
     ),
     .executableTarget(
         name: "tools-factory-server",
-        dependencies: ["ToolsFactoryService"],
+        dependencies: ["ToolServer"],
         path: "Sources/ToolServer",
-        exclude: ["Dockerfile", "Service"],
+        exclude: ["Dockerfile", "Service", "Adapters", "Router.swift", "Validation.swift", "SandboxPolicy.swift", "HTTPTypes.swift", "openapi.yaml"],
         sources: ["main.swift"]
     ),
     .testTarget(name: "ClientGeneratorTests", dependencies: ["FountainCodex"], path: "Tests/ClientGeneratorTests"),

--- a/Sources/ToolServer/Adapters/ExifToolAdapter.swift
+++ b/Sources/ToolServer/Adapters/ExifToolAdapter.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+public struct ExifToolAdapter: ToolAdapter {
+    private let base = ProcessAdapter(tool: "exiftool", executable: "/usr/bin/exiftool")
+    public init() {}
+    public var tool: String { base.tool }
+    public func run(args: [String]) throws -> (Data, Int32) { try base.run(args: args) }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/ToolServer/Adapters/FFmpegAdapter.swift
+++ b/Sources/ToolServer/Adapters/FFmpegAdapter.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+public struct FFmpegAdapter: ToolAdapter {
+    private let base = ProcessAdapter(tool: "ffmpeg", executable: "/usr/bin/ffmpeg")
+    public init() {}
+    public var tool: String { base.tool }
+    public func run(args: [String]) throws -> (Data, Int32) { try base.run(args: args) }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/ToolServer/Adapters/ImageMagickAdapter.swift
+++ b/Sources/ToolServer/Adapters/ImageMagickAdapter.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+public struct ImageMagickAdapter: ToolAdapter {
+    private let base = ProcessAdapter(tool: "imagemagick", executable: "/usr/bin/convert")
+    public init() {}
+    public var tool: String { base.tool }
+    public func run(args: [String]) throws -> (Data, Int32) { try base.run(args: args) }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/ToolServer/Adapters/LibPlistAdapter.swift
+++ b/Sources/ToolServer/Adapters/LibPlistAdapter.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+public struct LibPlistAdapter: ToolAdapter {
+    private let base = ProcessAdapter(tool: "libplist", executable: "/usr/bin/plutil")
+    public init() {}
+    public var tool: String { base.tool }
+    public func run(args: [String]) throws -> (Data, Int32) { try base.run(args: args) }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/ToolServer/Adapters/PandocAdapter.swift
+++ b/Sources/ToolServer/Adapters/PandocAdapter.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+public struct PandocAdapter: ToolAdapter {
+    private let base = ProcessAdapter(tool: "pandoc", executable: "/usr/bin/pandoc")
+    public init() {}
+    public var tool: String { base.tool }
+    public func run(args: [String]) throws -> (Data, Int32) { try base.run(args: args) }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/ToolServer/Adapters/ProcessAdapter.swift
+++ b/Sources/ToolServer/Adapters/ProcessAdapter.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+public struct ProcessAdapter: ToolAdapter {
+    public let tool: String
+    let executable: String
+    public init(tool: String, executable: String) {
+        self.tool = tool
+        self.executable = executable
+    }
+    public func run(args: [String]) throws -> (Data, Int32) {
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: executable)
+        proc.arguments = args
+        let pipe = Pipe()
+        proc.standardOutput = pipe
+        proc.standardError = pipe
+        try proc.run()
+        proc.waitUntilExit()
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        return (data, proc.terminationStatus)
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/ToolServer/HTTPTypes.swift
+++ b/Sources/ToolServer/HTTPTypes.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+public struct HTTPRequest {
+    public let method: String
+    public let path: String
+    public var headers: [String: String]
+    public var body: Data
+    public init(method: String, path: String, headers: [String: String] = [:], body: Data = Data()) {
+        self.method = method
+        self.path = path
+        self.headers = headers
+        self.body = body
+    }
+}
+
+public struct HTTPResponse {
+    public var status: Int
+    public var headers: [String: String]
+    public var body: Data
+    public init(status: Int = 200, headers: [String: String] = [:], body: Data = Data()) {
+        self.status = status
+        self.headers = headers
+        self.body = body
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/ToolServer/Router.swift
+++ b/Sources/ToolServer/Router.swift
@@ -1,0 +1,53 @@
+import Foundation
+import Crypto
+
+public protocol ToolAdapter {
+    var tool: String { get }
+    func run(args: [String]) throws -> (Data, Int32)
+}
+
+public struct Router {
+    let adapters: [String: ToolAdapter]
+    let validator = Validation()
+
+    public init(adapters: [String: ToolAdapter]) {
+        self.adapters = adapters
+    }
+
+    public func route(_ request: HTTPRequest) async throws -> HTTPResponse {
+        if request.method == "GET" && request.path == "/openapi.yaml" {
+            let url = URL(fileURLWithPath: "Sources/ToolServer/openapi.yaml")
+            let data = try Data(contentsOf: url)
+            return HTTPResponse(status: 200, headers: ["Content-Type": "application/yaml"], body: data)
+        }
+
+        guard request.method == "POST" else { return HTTPResponse(status: 405) }
+        let parts = request.path.split(separator: "/").map(String.init)
+        guard parts.count == 2, let adapter = adapters[parts[1]] else { return HTTPResponse(status: 404) }
+
+        let payload = try JSONDecoder().decode(ToolRequest.self, from: request.body)
+        try validator.validate(args: payload.args)
+        let start = Date()
+        let (output, code) = try adapter.run(args: payload.args)
+        let duration = Int(Date().timeIntervalSince(start) * 1000)
+        let hash = SHA256.hash(data: Data(payload.args.joined(separator: " ").utf8)).compactMap { String(format: "%02x", $0) }.joined()
+        let log = LogEntry(request_id: payload.request_id ?? UUID().uuidString, tool: adapter.tool, args_hash: hash, duration_ms: duration, exit_code: code)
+        if let logData = try? JSONEncoder().encode(log) { print(String(data: logData, encoding: .utf8)!) }
+        return HTTPResponse(status: Int(code == 0 ? 200 : 500), body: output)
+    }
+}
+
+public struct ToolRequest: Codable {
+    public let args: [String]
+    public let request_id: String?
+}
+
+public struct LogEntry: Codable {
+    let request_id: String
+    let tool: String
+    let args_hash: String
+    let duration_ms: Int
+    let exit_code: Int32
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/ToolServer/SandboxPolicy.swift
+++ b/Sources/ToolServer/SandboxPolicy.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+public struct SandboxPolicy {
+    public static let allowedPaths: [String] = ["/tmp", "/var/tmp"]
+    public static func isPathAllowed(_ path: String) -> Bool {
+        return allowedPaths.contains { path.hasPrefix($0) }
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/ToolServer/Validation.swift
+++ b/Sources/ToolServer/Validation.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+public struct Validation {
+    public enum Error: Swift.Error { case forbiddenArg(String) }
+    public init() {}
+    public func validate(args: [String]) throws {
+        for arg in args {
+            if arg.contains("..") { throw Error.forbiddenArg(arg) }
+            if arg.starts(with: "/") && !SandboxPolicy.isPathAllowed(arg) {
+                throw Error.forbiddenArg(arg)
+            }
+        }
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/ToolServer/openapi.yaml
+++ b/Sources/ToolServer/openapi.yaml
@@ -1,0 +1,80 @@
+openapi: 3.0.0
+info:
+  title: Tool Server
+  version: 1.0.0
+paths:
+  /imagemagick:
+    post:
+      operationId: runImageMagick
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ToolRequest'
+      responses:
+        '200':
+          description: output
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+  /ffmpeg:
+    post:
+      operationId: runFFmpeg
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ToolRequest'
+      responses:
+        '200': { description: output }
+  /exiftool:
+    post:
+      operationId: runExifTool
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ToolRequest'
+      responses:
+        '200': { description: output }
+  /pandoc:
+    post:
+      operationId: runPandoc
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ToolRequest'
+      responses:
+        '200': { description: output }
+  /libplist:
+    post:
+      operationId: runLibPlist
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ToolRequest'
+      responses:
+        '200': { description: output }
+components:
+  schemas:
+    ToolRequest:
+      type: object
+      properties:
+        args:
+          type: array
+          items:
+            type: string
+        request_id:
+          type: string
+      required: [args]
+
+# © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- add `ToolServer` target with router, validation, and sandbox policy
- implement adapters for ImageMagick, ffmpeg, exiftool, pandoc, and libplist
- serve OpenAPI spec and structured logs for tool executions

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_b_68a4968918508333bf23e4da3f4fe5ec