### PR TITLE
Add Toolsmith adapter and sandbox tests

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -126,7 +126,15 @@ var targets: [Target] = [
     .testTarget(name: "FlexctlTests", dependencies: ["flexctl", "ResourceLoader"], path: "Tests/FlexctlTests"),
     .testTarget(name: "GatewayAppTests", dependencies: ["gateway-server", "LLMGatewayClient"], path: "Tests/GatewayAppTests"),
     .testTarget(name: "FountainOpsTests", dependencies: ["LLMGatewayService"], path: "Tests/FountainOpsTests"),
-    .testTarget(name: "ToolServerTests", dependencies: ["ToolServer"], path: "Tests/ToolServerTests")
+    .testTarget(name: "ToolServerTests", dependencies: ["ToolServer"], path: "Tests/ToolServerTests"),
+    .testTarget(
+        name: "FountainAIToolsmithTests",
+        dependencies: [
+            "ToolServer",
+            .product(name: "SandboxRunner", package: "FountainAIToolsmith")
+        ],
+        path: "Tests/FountainAIToolsmithTests"
+    )
 ]
 
 #if os(Linux)

--- a/Tests/FountainAIToolsmithTests/AdapterTests.swift
+++ b/Tests/FountainAIToolsmithTests/AdapterTests.swift
@@ -1,0 +1,58 @@
+import XCTest
+@testable import ToolServer
+
+final class AdapterTests: XCTestCase {
+    func testProcessAdapterPassesArgumentsAndCapturesOutput() throws {
+        let fm = FileManager.default
+        let script = fm.temporaryDirectory.appendingPathComponent("echo_args.sh")
+        let scriptContent = "#!/bin/sh\necho $@"
+        try scriptContent.write(to: script, atomically: true, encoding: .utf8)
+        try fm.setAttributes([.posixPermissions: 0o755], ofItemAtPath: script.path)
+        let adapter = ProcessAdapter(tool: "test", executable: script.path)
+        let (data, code) = try adapter.run(args: ["hello", "world"])
+        XCTAssertEqual(code, 0)
+        XCTAssertEqual(String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines), "hello world")
+    }
+
+    func testImageMagickAdapterVersion() throws {
+        try XCTSkipIf(!FileManager.default.isExecutableFile(atPath: "/usr/bin/convert"), "imagemagick missing")
+        let adapter = ImageMagickAdapter()
+        let (data, code) = try adapter.run(args: ["-version"])
+        XCTAssertEqual(code, 0)
+        XCTAssertTrue(String(data: data, encoding: .utf8)?.contains("ImageMagick") ?? false)
+    }
+
+    func testFFmpegAdapterVersion() throws {
+        try XCTSkipIf(!FileManager.default.isExecutableFile(atPath: "/usr/bin/ffmpeg"), "ffmpeg missing")
+        let adapter = FFmpegAdapter()
+        let (data, code) = try adapter.run(args: ["-version"])
+        XCTAssertEqual(code, 0)
+        XCTAssertTrue(String(data: data, encoding: .utf8)?.contains("ffmpeg") ?? false)
+    }
+
+    func testExifToolAdapterVersion() throws {
+        try XCTSkipIf(!FileManager.default.isExecutableFile(atPath: "/usr/bin/exiftool"), "exiftool missing")
+        let adapter = ExifToolAdapter()
+        let (data, code) = try adapter.run(args: ["-ver"])
+        XCTAssertEqual(code, 0)
+        XCTAssertFalse(String(data: data, encoding: .utf8)?.isEmpty ?? true)
+    }
+
+    func testPandocAdapterVersion() throws {
+        try XCTSkipIf(!FileManager.default.isExecutableFile(atPath: "/usr/bin/pandoc"), "pandoc missing")
+        let adapter = PandocAdapter()
+        let (data, code) = try adapter.run(args: ["--version"])
+        XCTAssertEqual(code, 0)
+        XCTAssertTrue(String(data: data, encoding: .utf8)?.contains("pandoc") ?? false)
+    }
+
+    func testLibPlistAdapterHelp() throws {
+        try XCTSkipIf(!FileManager.default.isExecutableFile(atPath: "/usr/bin/plutil"), "plutil missing")
+        let adapter = LibPlistAdapter()
+        let (data, code) = try adapter.run(args: ["-help"])
+        XCTAssertEqual(code, 1) // plutil -help exits 1
+        XCTAssertTrue(String(data: data, encoding: .utf8)?.contains("plutil") ?? false)
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Tests/FountainAIToolsmithTests/IntegrationTests.swift
+++ b/Tests/FountainAIToolsmithTests/IntegrationTests.swift
@@ -1,0 +1,25 @@
+import XCTest
+@testable import ToolServer
+
+final class IntegrationTests: XCTestCase {
+    func testRouterEndpointsAndOperations() async throws {
+        let manifest = ToolManifest(
+            image: .init(name: "img", tarball: "t.tar", sha256: "a", qcow2: "q.qcow2", qcow2_sha256: "b"),
+            tools: ["imagemagick": "1"],
+            operations: ["convert"]
+        )
+        try XCTSkipIf(!FileManager.default.isExecutableFile(atPath: "/usr/bin/convert"), "imagemagick missing")
+        let router = Router(adapters: ["imagemagick": ImageMagickAdapter()], manifest: manifest)
+        let health = try await router.route(HTTPRequest(method: "GET", path: "/_health"))
+        XCTAssertEqual(health.status, 200)
+        let manifestResp = try await router.route(HTTPRequest(method: "GET", path: "/manifest"))
+        XCTAssertEqual(manifestResp.status, 200)
+        let request = ToolRequest(args: ["-version"], request_id: nil)
+        let body = try JSONEncoder().encode(request)
+        let opResp = try await router.route(HTTPRequest(method: "POST", path: "/tool/imagemagick", headers: ["Content-Type": "application/json"], body: body))
+        XCTAssertEqual(opResp.status, 200)
+        XCTAssertTrue(String(data: opResp.body, encoding: .utf8)?.contains("ImageMagick") ?? false)
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Tests/FountainAIToolsmithTests/PerformanceTests.swift
+++ b/Tests/FountainAIToolsmithTests/PerformanceTests.swift
@@ -1,0 +1,85 @@
+import XCTest
+import SandboxRunner
+@testable import ToolServer
+
+final class PerformanceTests: XCTestCase {
+    func testColdBwrapPerformance() throws {
+        try XCTSkipIf(!Self.canUseBubblewrap, "bubblewrap not functional")
+        let fm = FileManager.default
+        let work = fm.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try fm.createDirectory(at: work, withIntermediateDirectories: true)
+        let runner = BwrapRunner()
+        let start = Date()
+        _ = try runner.run(
+            executable: "/bin/true",
+            arguments: [],
+            inputs: [],
+            workDirectory: work,
+            allowNetwork: false,
+            timeout: 5,
+            limits: nil
+        )
+        let duration = Date().timeIntervalSince(start) * 1000
+        XCTAssertLessThanOrEqual(duration, 150)
+    }
+
+    func testVMSnapshotPerformance() throws {
+        let qemuPath = "/usr/bin/qemu-system-x86_64"
+        let qemuImgPath = "/usr/bin/qemu-img"
+        try XCTSkipIf(!FileManager.default.isExecutableFile(atPath: qemuPath) || !FileManager.default.isExecutableFile(atPath: qemuImgPath), "qemu missing")
+        let fm = FileManager.default
+        let tmp = fm.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try fm.createDirectory(at: tmp, withIntermediateDirectories: true)
+        let image = tmp.appendingPathComponent("disk.qcow2")
+        let img = Process()
+        img.executableURL = URL(fileURLWithPath: qemuImgPath)
+        img.arguments = ["create", "-f", "qcow2", image.path, "64M"]
+        try img.run()
+        img.waitUntilExit()
+        let runner = QemuRunner(image: image)
+        let start = Date()
+        try? runner.run(executable: "/bin/true", workDirectory: tmp, allowNetwork: false, timeout: 2)
+        let duration = Date().timeIntervalSince(start) * 1000
+        XCTAssertLessThanOrEqual(duration, 2000)
+    }
+
+    func testImageConversionPerformance() throws {
+        try XCTSkipIf(!FileManager.default.isExecutableFile(atPath: "/usr/bin/convert"), "imagemagick missing")
+        let fm = FileManager.default
+        let tmp = fm.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try fm.createDirectory(at: tmp, withIntermediateDirectories: true)
+        let input = tmp.appendingPathComponent("input.jpg")
+        let create = Process()
+        create.executableURL = URL(fileURLWithPath: "/usr/bin/convert")
+        create.arguments = ["-size", "4000x4000", "xc:white", "-quality", "85", input.path]
+        try create.run()
+        create.waitUntilExit()
+        let attrs = try fm.attributesOfItem(atPath: input.path)
+        let size = attrs[.size] as? NSNumber
+        XCTAssertGreaterThanOrEqual(size?.intValue ?? 0, 1_000_000)
+        let adapter = ImageMagickAdapter()
+        let start = Date()
+        let (data, code) = try adapter.run(args: [input.path, "-resize", "1024", "png:-"])
+        let duration = Date().timeIntervalSince(start) * 1000
+        XCTAssertEqual(code, 0)
+        XCTAssertLessThanOrEqual(duration, 500)
+        XCTAssertEqual(data.prefix(8), Data([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]))
+    }
+}
+
+extension PerformanceTests {
+    private static let canUseBubblewrap: Bool = {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/bwrap")
+        process.arguments = ["--ro-bind", "/", "/", "/bin/true"]
+        do {
+            try process.run()
+            process.waitUntilExit()
+            return process.terminationStatus == 0
+        } catch {
+            return false
+        }
+    }()
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Tests/FountainAIToolsmithTests/SecurityTests.swift
+++ b/Tests/FountainAIToolsmithTests/SecurityTests.swift
@@ -1,0 +1,60 @@
+import XCTest
+import SandboxRunner
+
+final class SecurityTests: XCTestCase {
+    func testNetworkDenied() throws {
+        try XCTSkipIf(!Self.canUseBubblewrap, "bubblewrap not functional")
+        let fm = FileManager.default
+        let work = fm.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try fm.createDirectory(at: work, withIntermediateDirectories: true)
+        let runner = BwrapRunner()
+        let result = try runner.run(
+            executable: "/bin/sh",
+            arguments: ["-c", "curl -sSf http://example.com >/dev/null && echo ok || echo fail"],
+            inputs: [],
+            workDirectory: work,
+            allowNetwork: false,
+            timeout: 5,
+            limits: nil
+        )
+        XCTAssertEqual(result.stdout.trimmingCharacters(in: .whitespacesAndNewlines), "fail")
+    }
+
+    func testFilesystemIsolation() throws {
+        try XCTSkipIf(!Self.canUseBubblewrap, "bubblewrap not functional")
+        let fm = FileManager.default
+        let tmp = fm.temporaryDirectory
+        let input = tmp.appendingPathComponent("input.txt")
+        try "hello".write(to: input, atomically: true, encoding: .utf8)
+        let work = tmp.appendingPathComponent(UUID().uuidString)
+        try fm.createDirectory(at: work, withIntermediateDirectories: true)
+        let runner = BwrapRunner()
+        _ = try runner.run(
+            executable: "/bin/sh",
+            arguments: ["-c", "echo hi > /work/out && echo nope >> /inputs/input.txt || true"],
+            inputs: [input],
+            workDirectory: work,
+            allowNetwork: false,
+            timeout: 5,
+            limits: nil
+        )
+        XCTAssertEqual(try String(contentsOf: input, encoding: .utf8), "hello")
+        let outPath = work.appendingPathComponent("out")
+        XCTAssertEqual(try String(contentsOf: outPath, encoding: .utf8).trimmingCharacters(in: .whitespacesAndNewlines), "hi")
+    }
+
+    private static let canUseBubblewrap: Bool = {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/bwrap")
+        process.arguments = ["--ro-bind", "/", "/", "/bin/true"]
+        do {
+            try process.run()
+            process.waitUntilExit()
+            return process.terminationStatus == 0
+        } catch {
+            return false
+        }
+    }()
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- Add FountainAIToolsmithTests target
- Cover tool adapters, router integration, security isolation, and performance benchmarks

## Testing
- `swift test`
- `swift test --filter FountainAIToolsmithTests`


------
https://chatgpt.com/codex/tasks/task_b_68a4ab695d008333bc049ff470219efb