### PR TITLE
ci: build sandbox image and run openapi tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,15 +37,37 @@ jobs:
         if: runner.os == 'macOS'
         working-directory: sps
         run: ./install-deps.sh
-      - name: Build
-        run: swift build
-      - name: Test
+      - name: Install sandbox deps
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y debootstrap qemu-utils jq
+      - name: Restore sandbox cache
+        if: runner.os == 'Linux'
+        id: cache-sandbox
+        uses: actions/cache@v4
+        with:
+          path: build
+          key: sandbox-${{ hashFiles('tools.json') }}
+      - name: Run tests (Linux)
+        if: runner.os == 'Linux'
         run: |
-          swift test --enable-code-coverage
+          BUILD_SANDBOX=${{ steps.cache-sandbox.outputs.cache-hit == 'true' && '0' || '1' }} Scripts/run-tests.sh
           echo "CODECOV_DIR=$(dirname $(swift test --show-codecov-path))" >> $GITHUB_ENV
-      - name: Test SPS
-        working-directory: sps
-        run: swift test --enable-code-coverage
+      - name: Run tests (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          Scripts/run-tests.sh
+          echo "CODECOV_DIR=$(dirname $(swift test --show-codecov-path))" >> $GITHUB_ENV
+      - name: Upload sandbox artifacts
+        if: runner.os == 'Linux' && steps.cache-sandbox.outputs.cache-hit != 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: sandbox
+          path: build
+      - name: Release sandbox
+        if: runner.os == 'Linux' && github.ref_type == 'tag'
+        uses: softprops/action-gh-release@v2
+        with:
+          files: build/*
       - name: Verify licenses
         run: Scripts/verify-licenses.sh
       - name: Generate Coverage

--- a/Scripts/run-tests.sh
+++ b/Scripts/run-tests.sh
@@ -3,14 +3,59 @@ set -euo pipefail
 
 # Timestamp used to differentiate successive log files.
 TS=$(date +"%Y%m%d%H%M%S")
+LOG_DIR="logs"
+mkdir -p "$LOG_DIR" build
 
-# Build the package in release mode while treating warnings as errors.
-# Output is tee'd into a log under the `logs` directory for later inspection.
+###############################################################################
+# 1. Generate OpenAPI sources
+###############################################################################
+swift Scripts/generate-toolsmith-client.swift \
+  2>&1 | tee "$LOG_DIR/openapi-$TS.log"
+
+if ! git diff --quiet -- FountainAIToolsmith/Sources/ToolsmithAPI Sources/ToolServer; then
+  git config --global user.email "ci@example.com"
+  git config --global user.name "CI"
+  git add FountainAIToolsmith/Sources/ToolsmithAPI Sources/ToolServer
+  git commit -m "chore: regenerate OpenAPI client" || true
+fi
+
+###############################################################################
+# 2. Build sandbox image and verify checksums
+###############################################################################
+BUILD_SANDBOX=${BUILD_SANDBOX:-1}
+if [[ "$(uname)" == "Linux" ]]; then
+  if [[ "$BUILD_SANDBOX" == "1" ]]; then
+    OUTPUT_DIR=build Scripts/build-sandbox-image.sh \
+      2>&1 | tee "$LOG_DIR/sandbox-$TS.log"
+  fi
+
+  if [[ -f build/tools.json ]]; then
+    expected=$(jq -r '.image.sha256' tools.json)
+    actual=$(jq -r '.image.sha256' build/tools.json)
+    if [[ "$expected" != "$actual" ]]; then
+      echo "Checksum mismatch: $expected != $actual" >&2
+      exit 1
+    fi
+  else
+    echo "Sandbox manifest build/tools.json missing" >&2
+    exit 1
+  fi
+fi
+
+###############################################################################
+# 3. Build package and run tests
+###############################################################################
 swift build -c release -Xswiftc -O -Xswiftc -warnings-as-errors \
-  2>&1 | tee "logs/build-$TS.log"
+  2>&1 | tee "$LOG_DIR/build-$TS.log"
 
-# Execute the test suite with code coverage enabled and capture the results.
 swift test -c release --enable-code-coverage \
-  2>&1 | tee "logs/test-$TS.log"
+  2>&1 | tee "$LOG_DIR/test-$TS.log"
+
+if [[ -d sps ]]; then
+  pushd sps >/dev/null
+  swift test --enable-code-coverage \
+    2>&1 | tee "../$LOG_DIR/sps-test-$TS.log"
+  popd >/dev/null
+fi
 
 # © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- generate OpenAPI sources during test runs and commit any diffs
- build sandbox image, verify checksums against tools.json, and run tests via script
- cache sandbox artifacts in CI and upload them for reuse/release

## Testing
- `BUILD_SANDBOX=0 Scripts/run-tests.sh` *(fails: Illegal instruction)*

------
https://chatgpt.com/codex/tasks/task_b_68a4af992c3c8333a04d0af5efb23687