### PR TITLE
fix: conditionally import FoundationNetworking

### DIFF
--- a/Sources/GatewayApp/TokenValidation.swift
+++ b/Sources/GatewayApp/TokenValidation.swift
@@ -1,5 +1,7 @@
 import Foundation
+#if canImport(FoundationNetworking)
 import FoundationNetworking
+#endif
 
 /// Claims extracted from a validated access token.
 public struct TokenClaims: Sendable {


### PR DESCRIPTION
## Summary
- avoid failing build on macOS by only importing FoundationNetworking when available

## Testing
- `swift test` *(fails: build aborted during dependency compilation)*
- `swift build --product gateway-server` *(fails: build aborted during dependency compilation)*

------
https://chatgpt.com/codex/tasks/task_b_68a549d7e6fc8333b571681b4edbef6a