### PR TITLE
docs: mark SPS as deprecated and add migration note

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 FountainAI assembles a family of Swift services that work together to run a secure, observable and extensible AI platform. Rather than centering on a single CLI, the repository balances gateways, operations tooling and code generation as equal pillars of the ecosystem.
 
+> ⚠️ **SPS Deprecated:** The Semantic PDF Scanner is frozen. Use the [Toolsmith-based PDF tooling](FountainAIToolsmith) instead.
+
 ## Architecture Pillars
 
 - **GatewayApp** – Plugin-driven HTTP and DNS gateway built on SwiftNIO. It composes `GatewayPlugin` implementations such as `LoggingPlugin` and `PublishingFrontendPlugin` to handle cross-cutting concerns.

--- a/agent.md
+++ b/agent.md
@@ -6,6 +6,11 @@
 
 ---
 
+## 🚚 SPS Folder Migration
+The `sps/` directory is frozen and scheduled for removal on **2025-11-01**. For migration assistance, contact **Benedikt Eickhoff** via the repository issue tracker.
+
+---
+
 ## 🎯 Mission
 
 This agent maintains an up-to-date view of outstanding development tasks across the entire repository. It exists to bridge declared intent (e.g., specs, interface plans) with verifiable implementation. Each task is described in a structured matrix to allow vertical slice execution and repeatable progress tracking.

--- a/docs/sps-usage-guide.md
+++ b/docs/sps-usage-guide.md
@@ -1,3 +1,5 @@
+> ⚠️ **Warning:** The Semantic PDF Scanner is frozen. Use the Toolsmith sandbox workflow instead (see [Toolsmith orchestration guide](toolsmith-orchestration.md)).
+
 # SPS Usage Guide
 
 This guide demonstrates end-to-end workflows with the Semantic PDF Scanner CLI, including page range queries and validation hooks.


### PR DESCRIPTION
## Summary
- signal SPS deprecation in README and point to Toolsmith PDF tooling
- warn that SPS usage guide is frozen and refer to sandbox workflow
- add repository migration note about upcoming SPS folder removal

## Testing
- `swift test` *(failed: terminated during long compilation)*


------
https://chatgpt.com/codex/tasks/task_b_68a55885209483338c2cc17fd61e306e