### PR TITLE
Deprecate SPS service and skip related pipelines

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,6 +1,8 @@
 // swift-tools-version: 6.1
 import PackageDescription
 
+// SPS package is deprecated and intentionally omitted from workspace targets.
+
 var products: [Product] = [
     .library(name: "FountainCodex", targets: ["FountainCodex"]),
     .library(name: "MIDI2Models", targets: ["MIDI2Models"]),

--- a/Scripts/fix_and_verify.sh
+++ b/Scripts/fix_and_verify.sh
@@ -1,30 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-echo "[info] Creating clang module cache directory..."
-mkdir -p "$HOME/.cache/clang/ModuleCache"
+echo "[info] SPS is deprecated; skipping fix and verify."
+exit 0
 
-echo "[info] Showing current ownership (optional)..."
-ls -ld "$HOME/.cache" "$HOME/.cache/clang" "$HOME/.cache/clang/ModuleCache" 2>/dev/null || true
-
-echo "[info] Ensuring cache is owned by current user (may prompt for sudo)..."
-if [ "$(stat -f %Su "$HOME/.cache" 2>/dev/null || true)" != "$(whoami)" ]; then
-  sudo chown -R "$(whoami)" "$HOME/.cache"
-fi
-
-echo "[info] Setting user read/write/execute on clang cache..."
-chmod -R u+rwX "$HOME/.cache/clang" 2>/dev/null || true
-
-echo "[info] Verifying Swift and Xcode toolchain..."
-swift --version || { echo "[error] 'swift' not found in PATH"; exit 1; }
-xcode-select -p || echo "[warn] xcode-select path not found; run 'xcode-select --install' if needed"
-
-echo "[info] Building sps (release) -- this may take several minutes..."
-cd "$(dirname "$0")/.." || exit 1
-swift build -c release --package-path sps -v
-
-echo "[info] If build succeeded, running full verify pipeline..."
-FULL=1 bash Scripts/verify_pipeline.sh
-
-echo "[info] Done."
-
+# © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Scripts/verify_pipeline.sh
+++ b/Scripts/verify_pipeline.sh
@@ -1,62 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# One-shot verification script for the SPS -> MIDI model pipeline.
-# Usage:
-#   ./scripts/verify_pipeline.sh         # quick run (pages 1-3)
-#   FULL=1 ./scripts/verify_pipeline.sh  # full run over all pages (may be slow)
-#   PAGE_RANGE=1-5 ./scripts/verify_pipeline.sh  # custom page range
-#
-REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-SPS_BIN="$REPO_ROOT/sps/.build/release/sps"
-OUT_INDEX="$REPO_ROOT/midi/models/index.verify.json"
-MATRIX_OUT="$REPO_ROOT/midi/models/matrix.verify.json"
+# SPS pipeline is deprecated; verification skipped.
+echo "[verify] SPS pipeline deprecated; skipping."
 
-PAGE_RANGE="${PAGE_RANGE:-1-3}"
-FULL="${FULL:-0}"
-SPS_DEBUG="${SPS_DEBUG:-1}"
-
-export SPS_DEBUG
-
-echo "[verify] repo root: $REPO_ROOT"
-echo "[verify] SPS_DEBUG=$SPS_DEBUG PAGE_RANGE=$PAGE_RANGE FULL=$FULL"
-
-echo "[verify] Building sps (release)..."
-swift build -c release --package-path "$REPO_ROOT/sps"
-
-if [[ ! -x "$SPS_BIN" ]]; then
-  echo "[verify] ERROR: built binary not found at $SPS_BIN" >&2
-  exit 2
-fi
-
-PDFS=("$REPO_ROOT/midi/specs"/*.pdf)
-if (( ${#PDFS[@]} == 0 )); then
-  echo "[verify] No PDFs found in midi/specs/" >&2
-  exit 1
-fi
-
-echo "[verify] Scanning PDFs -> index: $OUT_INDEX"
-if [[ "$FULL" == "1" ]]; then
-  "$SPS_BIN" scan "${PDFS[@]}" --out "$OUT_INDEX" --include-text --sha256 --wait
-else
-  "$SPS_BIN" scan "${PDFS[@]}" --out "$OUT_INDEX" --include-text --sha256 --wait --page-range "$PAGE_RANGE"
-fi
-
-echo "[verify] Exporting matrix -> $MATRIX_OUT (with validation)"
-"$SPS_BIN" export-matrix "$OUT_INDEX" --out "$MATRIX_OUT" --validate || true
-
-echo "[verify] Building normalized models (midi/build-models.sh)"
-"$REPO_ROOT/midi/build-models.sh"
-
-echo "[verify] Matrix summary (counts):"
-if [[ -f "$MATRIX_OUT" ]]; then
-  jq '{messages: (.messages|length), enums: (.enums|length), bitfields: (.bitfields|length), ranges: (.ranges|length)}' "$MATRIX_OUT" || true
-else
-  echo "[verify] $MATRIX_OUT not found"
-fi
-
-echo "[verify] Running MIDI2 tests (swift test --filter MIDI2)"
-swift test --filter MIDI2 || true
-
-echo "[verify] Done. Index: $OUT_INDEX, Matrix: $MATRIX_OUT"
-
+# © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/sps/AGENT.md
+++ b/sps/AGENT.md
@@ -1,9 +1,7 @@
 # Semantic PDF Scanner (SPS) • AGENT.md
 
-## Mission
-Build a **Swift-only** command‑line tool that semantically scans PDF specifications and emits a normalized, queryable index for FountainAI’s tools‑factory. The SPS must cover our Midi2Swift needs (extract normative tables, terms, message layouts), while remaining **generally useful** for any PDF‑centric workflow.
-
-**Pipeline:** `PDFs → scan → semantic index → (optional) matrix export → contract verify → publish`
+## Deprecation Notice
+The Semantic PDF Scanner (SPS) service is deprecated and scheduled for removal on **2025-11-01**. Development has ceased and existing users should migrate to alternative tooling.
 
 ## Repository map (for `sps/`)
 - `Package.swift` — SwiftPM manifest (Swift 6)


### PR DESCRIPTION
## Summary
- deprecate SPS in its agent manifest
- document removal from workspace targets
- skip SPS jobs in verify and fix scripts

## Testing
- `Scripts/run-tests.sh` *(fails: terminated after extended build)*

------
https://chatgpt.com/codex/tasks/task_b_68a55a74ea148333afbf9354b7119b42