### PR TITLE
Add SSE envelope model and over-MIDI protocols

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,6 +6,7 @@ var products: [Product] = [
     .library(name: "MIDI2Models", targets: ["MIDI2Models"]),
     .library(name: "MIDI2Core", targets: ["MIDI2Core"]),
     .library(name: "FlexBridge", targets: ["FlexBridge"]),
+    .library(name: "SSEOverMIDI", targets: ["SSEOverMIDI"]),
     .executable(name: "clientgen-service", targets: ["clientgen-service"]),
     .executable(name: "gateway-server", targets: ["gateway-server"]),
     .executable(name: "publishing-frontend", targets: ["publishing-frontend"]),
@@ -82,6 +83,7 @@ var targets: [Target] = [
     ),
     .target(name: "MIDI2Core", dependencies: [.product(name: "MIDI2", package: "midi2")], path: "Sources/MIDI2Core"),
     .target(name: "MIDI2Transports", path: "Sources/MIDI2Transports"),
+    .target(name: "SSEOverMIDI", dependencies: ["MIDI2Core"], path: "Sources/SSEOverMIDI"),
     .target(
         name: "FlexBridge",
         dependencies: [

--- a/Sources/MIDI2Core/SseEnvelope.swift
+++ b/Sources/MIDI2Core/SseEnvelope.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+public struct SseEnvelope: Codable, Equatable, Sendable {
+    public struct Fragment: Codable, Equatable, Sendable {
+        public let i: Int
+        public let n: Int
+
+        public init(i: Int, n: Int) {
+            self.i = i
+            self.n = n
+        }
+    }
+
+    public let v: Int
+    public let ev: String
+    public let id: String?
+    public let ct: String?
+    public let seq: UInt64
+    public let frag: Fragment?
+    public let ts: Double?
+    public let data: String?
+
+    public init(
+        v: Int = 1,
+        ev: String,
+        id: String? = nil,
+        ct: String? = nil,
+        seq: UInt64,
+        frag: Fragment? = nil,
+        ts: Double? = nil,
+        data: String? = nil
+    ) {
+        self.v = v
+        self.ev = ev
+        self.id = id
+        self.ct = ct
+        self.seq = seq
+        self.frag = frag
+        self.ts = ts
+        self.data = data
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/SSEOverMIDI/SseOverMidi.swift
+++ b/Sources/SSEOverMIDI/SseOverMidi.swift
@@ -1,0 +1,16 @@
+import MIDI2Core
+
+public protocol SseOverMidiSender {
+    func send(event: SseEnvelope) throws
+    func flush()
+    func setWindow(_ n: Int)
+    func close()
+}
+
+public protocol SseOverMidiReceiver {
+    var onEvent: ((SseEnvelope) -> Void)? { get set }
+    func start() throws
+    func stop()
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- Add `SseEnvelope` model to MIDI2Core
- Introduce `SSEOverMIDI` module with sender/receiver protocols
- Expose new module in Swift package manifest

## Testing
- `swift test` *(fails: GatewayServerTests.testBudgetBreakerPluginLimitsAndShedsLoad)*

------
https://chatgpt.com/codex/tasks/task_b_68a5f8df50fc8333afcf1c8a9156d789