### PR TITLE
Handle SysEx8 and reliability in DefaultSseReceiver

### DIFF
--- a/Sources/SSEOverMIDI/DefaultSseReceiver.swift
+++ b/Sources/SSEOverMIDI/DefaultSseReceiver.swift
@@ -5,34 +5,82 @@ import MIDI2Transports
 
 public final class DefaultSseReceiver: SseOverMidiReceiver {
     public var onEvent: ((SseEnvelope) -> Void)?
+    public var onCtrl: ((SseEnvelope) -> Void)?
     private let rtp: RTPMidiSession
     private let flex: FlexPacker
+    private let sysx: SysEx8Packer
+    private let rel: Reliability
     private let metrics: Metrics?
-    private var expectedSeq: UInt64?
+    private var expectedSeq: UInt64 = 0
+    private var pending: Set<UInt64> = []
 
-    public init(rtp: RTPMidiSession, flex: FlexPacker, metrics: Metrics? = nil) {
+    public init(rtp: RTPMidiSession, flex: FlexPacker, sysx: SysEx8Packer, rel: Reliability, metrics: Metrics? = nil) {
         self.rtp = rtp
         self.flex = flex
+        self.sysx = sysx
+        self.rel = rel
         self.metrics = metrics
         self.rtp.onReceiveUmps = { [weak self] packets in
             guard let self else { return }
-            var umps: [Ump128] = []
+            var flexUmps: [Ump128] = []
+            var sysxUmps: [Ump128] = []
             for words in packets {
-                if let pkt = Ump128(words: words) {
-                    umps.append(pkt)
+                guard let pkt = Ump128(words: words) else { continue }
+                let mt = (pkt.word0 >> 28) & 0xF
+                if mt == 0x5 {
+                    sysxUmps.append(pkt)
+                } else if mt == 0xD {
+                    flexUmps.append(pkt)
                 }
             }
-            for blob in self.flex.unpack(umps: umps) {
-                if let env = try? JSONDecoder().decode(SseEnvelope.self, from: blob) {
-                    self.metrics?.addRecv(bytes: blob.count)
-                    if let exp = self.expectedSeq, env.seq != exp {
-                        self.metrics?.incSeqGapsDetected()
-                    }
-                    self.expectedSeq = env.seq &+ 1
-                    self.onEvent?(env)
-                }
+            for (_, blob) in self.sysx.unpack(umps: sysxUmps) {
+                self.handleBlob(blob)
+            }
+            for blob in self.flex.unpack(umps: flexUmps) {
+                self.handleBlob(blob)
             }
         }
+    }
+
+    private func handleBlob(_ blob: Data) {
+        guard let env = try? JSONDecoder().decode(SseEnvelope.self, from: blob) else { return }
+        metrics?.addRecv(bytes: blob.count)
+        if env.ev == "ctrl" {
+            onCtrl?(env)
+        } else {
+            handleSeq(env.seq)
+            onEvent?(env)
+        }
+    }
+
+    private func handleSeq(_ seq: UInt64) {
+        if seq == expectedSeq {
+            expectedSeq &+= 1
+            while pending.remove(expectedSeq) != nil {
+                expectedSeq &+= 1
+            }
+            if expectedSeq > 0 {
+                let ackVal = expectedSeq &- 1
+                let ack = rel.buildAck(h: ackVal)
+                _ = rel.handleCtrl(ack)
+                sendCtrl(ack)
+            }
+        } else if seq > expectedSeq {
+            metrics?.incSeqGapsDetected()
+            let missing = Array(expectedSeq..<seq)
+            let nack = rel.buildNack(missing)
+            sendCtrl(nack)
+            pending.insert(seq)
+        } else {
+            pending.remove(seq)
+        }
+    }
+
+    private func sendCtrl(_ env: SseEnvelope) {
+        guard let data = try? JSONEncoder().encode(env) else { return }
+        let frames = flex.pack(json: data, group: 0x1, statusBank: 0x1, status: 0x1)
+        let umps = frames.map { $0.words }
+        try? rtp.send(umps: umps)
     }
 
     public func start() throws {

--- a/Sources/SSEOverMIDI/SseOverMidi.swift
+++ b/Sources/SSEOverMIDI/SseOverMidi.swift
@@ -9,6 +9,7 @@ public protocol SseOverMidiSender {
 
 public protocol SseOverMidiReceiver {
     var onEvent: ((SseEnvelope) -> Void)? { get set }
+    var onCtrl: ((SseEnvelope) -> Void)? { get set }
     func start() throws
     func stop()
 }


### PR DESCRIPTION
## Summary
- Decode SysEx8 packets alongside Flex and expose control envelope callback
- Track sequence gaps and send ACK/NACK using Reliability
- Document new receiver initializer and control handling

## Testing
- `swift test --filter SSEOverMIDITests` *(failed: build interrupted; repository too large for full test run)*

------
https://chatgpt.com/codex/tasks/task_b_68a696e05bac8333943911836ccf5ad6