### PR TITLE
SSE reliability retransmit and metrics tracking

### DIFF
--- a/Tests/SSEOverMIDITests/MetricsTests.swift
+++ b/Tests/SSEOverMIDITests/MetricsTests.swift
@@ -1,0 +1,25 @@
+import XCTest
+import MIDI2
+import MIDI2Core
+@testable import SSEOverMIDI
+
+final class MetricsTests: XCTestCase {
+    func testCountersIncrement() {
+        let metrics = Metrics()
+        let rel = Reliability(metrics: metrics)
+        let pkt = Ump128(word0: 0xDEADBEEF, word1: 0, word2: 0, word3: 0)!
+        rel.record(seq: 1, frames: [pkt])
+        _ = rel.buildAck(h: 1)
+        _ = rel.buildNack([2])
+        let ctrl = SseEnvelope(ev: "ctrl", seq: 0, data: "{\"nack\":[1]}")
+        _ = rel.handleCtrl(ctrl)
+        metrics.incSeqGapsDetected()
+        let snap = metrics.snapshot()
+        XCTAssertEqual(snap.acksSent, 1)
+        XCTAssertEqual(snap.nacksSent, 1)
+        XCTAssertEqual(snap.retransmits, 1)
+        XCTAssertEqual(snap.seqGapsDetected, 1)
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- resend frames when sender receives control envelopes via attached receiver
- receiver records envelopes, builds acks/nacks, and forwards control frames
- add metrics test verifying ack, nack, retransmit, and gap counters

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_b_68a69a4155448333bfcee7f94853b194