### PR TITLE
feat: add RTP-MIDI discovery and MIDI-CI negotiation

### DIFF
--- a/Tests/MIDI2TransportsTests/RTPMidiSessionTests.swift
+++ b/Tests/MIDI2TransportsTests/RTPMidiSessionTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 final class RTPMidiSessionTests: XCTestCase {
     func testLoopbackSendReceive() throws {
-        let session = RTPMidiSession(localName: "test")
+        let session = RTPMidiSession(localName: "test", enableDiscovery: false, enableCINegotiation: false)
         let exp = expectation(description: "receive")
         var received: [UInt32] = []
         session.onReceiveUMP = { words in

--- a/Tests/SSEOverMIDITests/RTPMidiSessionTests.swift
+++ b/Tests/SSEOverMIDITests/RTPMidiSessionTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 final class RTPMidiSessionTests: XCTestCase {
     func testCoalescingAndReordering() throws {
-        let session = RTPMidiSession(localName: "test", mtu: 64)
+        let session = RTPMidiSession(localName: "test", mtu: 64, enableDiscovery: false, enableCINegotiation: false)
         let exp = expectation(description: "recv")
         var received: [[UInt32]] = []
         session.onReceiveUmps = { umps in


### PR DESCRIPTION
## Summary
- broadcast RTP-MIDI sessions over Bonjour/mDNS and track discovered peers
- perform a minimal MIDI-CI handshake before marking sessions ready
- allow tests to disable discovery and MIDI-CI negotiation

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_b_68a69ddbef788333a425660073906f83