### PR TITLE
Embed JR timestamp in SSE envelopes

### DIFF
--- a/Sources/SSEOverMIDI/DefaultSseReceiver.swift
+++ b/Sources/SSEOverMIDI/DefaultSseReceiver.swift
@@ -50,7 +50,22 @@ public final class DefaultSseReceiver: SseOverMidiReceiver {
             onCtrl?(env)
         } else {
             handleSeq(env.seq)
-            onEvent?(env)
+            if let ts = env.ts {
+                let hostTs = Timing.hostTime(fromJR: ts)
+                let translated = SseEnvelope(
+                    v: env.v,
+                    ev: env.ev,
+                    id: env.id,
+                    ct: env.ct,
+                    seq: env.seq,
+                    frag: env.frag,
+                    ts: hostTs,
+                    data: env.data
+                )
+                onEvent?(translated)
+            } else {
+                onEvent?(env)
+            }
         }
     }
 

--- a/Sources/SSEOverMIDI/DefaultSseSender.swift
+++ b/Sources/SSEOverMIDI/DefaultSseSender.swift
@@ -37,7 +37,7 @@ public final class DefaultSseSender: SseOverMidiSender, @unchecked Sendable {
         }
 
         let seq = allocateSeq()
-        let ts = Date().timeIntervalSince1970
+        let ts = Timing.jrNow()
         let env = SseEnvelope(
             v: event.v,
             ev: event.ev,

--- a/Sources/SSEOverMIDI/Timing.swift
+++ b/Sources/SSEOverMIDI/Timing.swift
@@ -1,0 +1,18 @@
+import Foundation
+import Dispatch
+
+enum Timing {
+    private static let startUptime = DispatchTime.now().uptimeNanoseconds
+    private static let startHost = Date().timeIntervalSince1970
+
+    static func jrNow() -> Double {
+        let us = (DispatchTime.now().uptimeNanoseconds &- startUptime) / 1_000
+        return Double(us)
+    }
+
+    static func hostTime(fromJR ts: Double) -> Double {
+        return startHost + ts / 1_000_000
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Tests/SSEOverMIDITests/TimestampTests.swift
+++ b/Tests/SSEOverMIDITests/TimestampTests.swift
@@ -1,0 +1,12 @@
+import XCTest
+@testable import SSEOverMIDI
+
+final class TimestampTests: XCTestCase {
+    func testTimestampPropagation() {
+        let start = Timing.hostTime(fromJR: 0)
+        let later = Timing.hostTime(fromJR: 500_000) // +0.5s
+        XCTAssertEqual(later - start, 0.5, accuracy: 0.01)
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- record JR microsecond timestamp when sending SSE envelopes
- translate JR timestamps to host time on reception
- add timing utilities and propagation test

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_b_68a6a088d90883338330c6ec45f2de81