### PR TITLE
Add two-session SSE over MIDI example

### DIFF
--- a/Examples/SSEOverMIDI/TwoSessions.swift
+++ b/Examples/SSEOverMIDI/TwoSessions.swift
@@ -1,0 +1,47 @@
+import MIDI2
+import MIDI2Core
+import MIDI2Transports
+import SSEOverMIDI
+
+let senderSession = RTPMidiSession(localName: "sender")
+let receiverSession = RTPMidiSession(localName: "receiver")
+
+let flex = FlexPacker()
+let sysx = SysEx8Packer()
+let senderRel = Reliability()
+let receiverRel = Reliability()
+
+let sender = DefaultSseSender(rtp: senderSession, flex: flex, sysx: sysx, rel: senderRel)
+let receiver = DefaultSseReceiver(rtp: receiverSession, flex: flex, sysx: sysx, rel: receiverRel)
+
+sender.listen(to: receiver)
+
+senderSession.onReceiveUmps = { packets in
+    receiverSession.onReceiveUmps?(packets)
+}
+
+receiver.onEvent = { env in
+    print("Received #\(env.seq): \(env.data ?? "")")
+}
+receiver.onCtrl = { env in
+    if let resend = receiverRel.handleCtrl(env) {
+        for frames in resend.values {
+            for f in frames { try? senderSession.send(umps: [f.words]) }
+        }
+    }
+}
+
+try senderSession.open()
+try receiver.start()
+
+let tokens = ["Hello", "from", "two", "sessions"]
+for (i, t) in tokens.enumerated() {
+    let env = SseEnvelope(ev: "message", seq: UInt64(i), data: t)
+    try sender.send(event: env)
+    sender.flush()
+}
+
+sender.close()
+receiver.stop()
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,16 @@ FountainAI assembles a family of Swift services that work together to run a secu
 
 > ⚠️ **SPS Deprecated:** The Semantic PDF Scanner is frozen. Use the [Toolsmith-based PDF tooling](FountainAIToolsmith) instead.
 
+## Quick start
+
+Try streaming Server-Sent Events over a local MIDI 2.0 loopback:
+
+```bash
+swift Examples/SSEOverMIDI/TwoSessions.swift
+```
+
+See [docs/sse-over-midi-guide.md](docs/sse-over-midi-guide.md) for setup details and expected output.
+
 ## Architecture Pillars
 
 - **GatewayApp** – Plugin-driven HTTP and DNS gateway built on SwiftNIO. It composes `GatewayPlugin` implementations such as `LoggingPlugin` and `PublishingFrontendPlugin` to handle cross-cutting concerns.

--- a/docs/sse-over-midi-guide.md
+++ b/docs/sse-over-midi-guide.md
@@ -2,42 +2,37 @@
 
 This short guide shows how to stream Server-Sent Events over a local MIDI 2.0 loopback using the `SSEOverMIDI` package.
 
+## Example
+
+`Examples/SSEOverMIDI/TwoSessions.swift` opens separate sender and receiver `RTPMidiSession`s on localhost and forwards packets between them.
+
 ```swift
 import MIDI2
 import MIDI2Core
 import MIDI2Transports
 import SSEOverMIDI
 
-let session = RTPMidiSession(localName: "loopback")
-let rel = Reliability()
-let sender = DefaultSseSender(
-    rtp: session,
-    flex: FlexPacker(),
-    sysx: SysEx8Packer(),
-    rel: rel
-)
-
-let receiver = DefaultSseReceiver(
-    rtp: session,
-    flex: FlexPacker(),
-    sysx: SysEx8Packer(),
-    rel: rel
-)
-receiver.onEvent = { env in
-    print("Received: \(env.data ?? "")")
-}
-receiver.onCtrl = { env in
-    if let resend = rel.handleCtrl(env) {
-        for frames in resend.values {
-            for f in frames { try? session.send(umps: [f.words]) }
-        }
-    }
-}
-
-try receiver.start()
-try sender.send(event: SseEnvelope(ev: "message", seq: 0, data: "hello"))
+let senderSession = RTPMidiSession(localName: "sender")
+let receiverSession = RTPMidiSession(localName: "receiver")
 ```
 
-The snippet creates an `RTPMidiSession`, `DefaultSseSender`, and `DefaultSseReceiver` to pass SSE tokens across a loopback transport.
+Run the example from the repository root:
+
+```bash
+swift Examples/SSEOverMIDI/TwoSessions.swift
+```
+
+## Expected Output
+
+The receiver prints each token as it arrives:
+
+```
+Received #0: Hello
+Received #1: from
+Received #2: two
+Received #3: sessions
+```
+
+These tokens demonstrate SSE envelopes delivered over a local MIDI 2.0 link.
 
 © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/logs/sse-over-midi-demo.log
+++ b/logs/sse-over-midi-demo.log
@@ -3,7 +3,14 @@ changes:
   - added SSE over MIDI demo under Examples/SSEOverMIDI
   - documented RTPMidiSession, DefaultSseSender, and DefaultSseReceiver in docs/sse-over-midi-guide.md
   - ensured Package.swift exposes SSEOverMIDI target and tests
-  
+
+tests: swift test
+
+date: 2025-08-21
+changes:
+  - added two-session SSE example under Examples/SSEOverMIDI
+  - expanded sse-over-midi-guide with setup and expected output
+  - linked guide in README quick start
 tests: swift test
 
 © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- add TwoSessions.swift demo streaming SSE tokens between sender and receiver sessions
- document setup and expected output in sse-over-midi-guide
- link guide from new Quick start section in README

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_b_68a6ac1f50288333867ca5126cd74bf4